### PR TITLE
Reference Counting

### DIFF
--- a/src/graphics/buffer.c
+++ b/src/graphics/buffer.c
@@ -217,5 +217,13 @@ Texture* lovrBufferGetTexture(Buffer* buffer) {
 }
 
 void lovrBufferSetTexture(Buffer* buffer, Texture* texture) {
+  if (buffer->texture) {
+    lovrRelease(&buffer->texture->ref);
+  }
+
   buffer->texture = texture;
+
+  if (buffer->texture) {
+    lovrRetain(&buffer->texture->ref);
+  }
 }

--- a/src/graphics/buffer.c
+++ b/src/graphics/buffer.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 
 Buffer* lovrBufferCreate(int size, BufferFormat* format, BufferDrawMode drawMode, BufferUsage usage) {
-  Buffer* buffer = malloc(sizeof(Buffer));
+  Buffer* buffer = lovrAlloc(sizeof(Buffer), lovrBufferDestroy);
   if (!buffer) return NULL;
 
   vec_init(&buffer->map);
@@ -51,7 +51,8 @@ Buffer* lovrBufferCreate(int size, BufferFormat* format, BufferDrawMode drawMode
   return buffer;
 }
 
-void lovrBufferDestroy(Buffer* buffer) {
+void lovrBufferDestroy(const Ref* ref) {
+  Buffer* buffer = containerof(ref, Buffer);
   glDeleteBuffers(1, &buffer->vbo);
   glDeleteVertexArrays(1, &buffer->vao);
   vec_deinit(&buffer->map);

--- a/src/graphics/buffer.c
+++ b/src/graphics/buffer.c
@@ -53,6 +53,9 @@ Buffer* lovrBufferCreate(int size, BufferFormat* format, BufferDrawMode drawMode
 
 void lovrBufferDestroy(const Ref* ref) {
   Buffer* buffer = containerof(ref, Buffer);
+  if (buffer->texture) {
+    lovrRelease(&buffer->texture->ref);
+  }
   glDeleteBuffers(1, &buffer->vbo);
   glDeleteVertexArrays(1, &buffer->vao);
   vec_deinit(&buffer->map);
@@ -101,6 +104,8 @@ void lovrBufferDraw(Buffer* buffer) {
   // Set texture
   if (buffer->texture) {
     lovrTextureBind(buffer->texture);
+  } else {
+    glBindTexture(GL_TEXTURE_2D, 0);
   }
 
   // Determine range of vertices to be rendered and whether we're using an IBO or not

--- a/src/graphics/buffer.h
+++ b/src/graphics/buffer.h
@@ -32,6 +32,7 @@ typedef struct {
 typedef vec_t(BufferAttribute) BufferFormat;
 
 typedef struct Buffer {
+  Ref ref;
   int size;
   int stride;
   void* data;
@@ -51,7 +52,7 @@ typedef struct Buffer {
 #endif
 
 Buffer* lovrBufferCreate(int size, BufferFormat* format, BufferDrawMode drawMode, BufferUsage usage);
-void lovrBufferDestroy(Buffer* buffer);
+void lovrBufferDestroy(const Ref* ref);
 void lovrBufferDraw(Buffer* buffer);
 BufferFormat lovrBufferGetVertexFormat(Buffer* buffer);
 BufferDrawMode lovrBufferGetDrawMode(Buffer* buffer);

--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -485,6 +485,7 @@ void lovrGraphicsSkybox(Skybox* skybox, float angle, float ax, float ay, float a
   }
 
   Shader* lastShader = lovrGraphicsGetShader();
+  lovrRetain(&lastShader->ref);
   lovrGraphicsSetShader(state.skyboxShader);
 
   float cos2 = cos(angle / 2);
@@ -552,5 +553,6 @@ void lovrGraphicsSkybox(Skybox* skybox, float angle, float ax, float ay, float a
   glDepthMask(GL_TRUE);
 
   lovrGraphicsSetShader(lastShader);
+  lovrRelease(&lastShader->ref);
   lovrGraphicsPop();
 }

--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -24,10 +24,13 @@ void lovrGraphicsInit() {
 }
 
 void lovrGraphicsDestroy() {
+  lovrGraphicsSetShader(NULL);
+  glUseProgram(0);
+  lovrRelease(&state.defaultShader->ref);
   vec_deinit(&state.transforms);
   mat4_deinit(state.projection);
-  lovrShaderDestroy(&state.defaultShader->ref);
-  lovrShaderDestroy(&state.skyboxShader->ref);
+  lovrRelease(&state.defaultShader->ref);
+  lovrRelease(&state.skyboxShader->ref);
   glDeleteBuffers(1, &state.shapeBuffer);
   glDeleteBuffers(1, &state.shapeIndexBuffer);
   glDeleteVertexArrays(1, &state.shapeArray);
@@ -157,7 +160,15 @@ void lovrGraphicsSetShader(Shader* shader) {
     shader = state.defaultShader;
   }
 
-  state.activeShader = shader;
+  if (shader != state.activeShader) {
+    if (state.activeShader) {
+      lovrRelease(&state.activeShader->ref);
+    }
+
+    state.activeShader = shader;
+
+    lovrRetain(&state.activeShader->ref);
+  }
 }
 
 void lovrGraphicsSetProjection(float near, float far, float fov) {

--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -26,8 +26,8 @@ void lovrGraphicsInit() {
 void lovrGraphicsDestroy() {
   vec_deinit(&state.transforms);
   mat4_deinit(state.projection);
-  lovrShaderDestroy(state.defaultShader);
-  lovrShaderDestroy(state.skyboxShader);
+  lovrShaderDestroy(&state.defaultShader->ref);
+  lovrShaderDestroy(&state.skyboxShader->ref);
   glDeleteBuffers(1, &state.shapeBuffer);
   glDeleteBuffers(1, &state.shapeIndexBuffer);
   glDeleteVertexArrays(1, &state.shapeArray);

--- a/src/graphics/model.c
+++ b/src/graphics/model.c
@@ -59,7 +59,7 @@ static void visitNode(ModelData* modelData, ModelNode* node, mat4 transform, vec
 }
 
 Model* lovrModelCreate(void* data, int size) {
-  Model* model = malloc(sizeof(Model));
+  Model* model = lovrAlloc(sizeof(Model), lovrModelDestroy);
   if (!model) return NULL;
 
   model->modelData = lovrModelDataCreate(data, size);
@@ -98,9 +98,10 @@ Model* lovrModelCreate(void* data, int size) {
   return model;
 }
 
-void lovrModelDestroy(Model* model) {
-  lovrModelDataDestroy(model->modelData);
-  lovrBufferDestroy(model->buffer);
+void lovrModelDestroy(const Ref* ref) {
+  Model* model = containerof(ref, Model);
+  lovrRelease(&model->modelData->ref);
+  lovrRelease(&model->buffer->ref);
   free(model);
 }
 

--- a/src/graphics/model.h
+++ b/src/graphics/model.h
@@ -2,10 +2,12 @@
 #include "graphics/texture.h"
 #include "model/modelData.h"
 #include "glfw.h"
+#include "util.h"
 
 #ifndef LOVR_MODEL_TYPES
 #define LOVR_MODEL_TYPES
 typedef struct {
+  Ref ref;
   ModelData* modelData;
   Buffer* buffer;
   Texture* texture;
@@ -13,7 +15,7 @@ typedef struct {
 #endif
 
 Model* lovrModelCreate(void* data, int size);
-void lovrModelDestroy(Model* model);
+void lovrModelDestroy(const Ref* ref);
 void lovrModelDraw(Model* model, float x, float y, float z, float scale, float angle, float ax, float ay, float az);
 Texture* lovrModelGetTexture(Model* model);
 void lovrModelSetTexture(Model* model, Texture* texture);

--- a/src/graphics/shader.c
+++ b/src/graphics/shader.c
@@ -99,7 +99,7 @@ GLuint linkShaders(GLuint vertexShader, GLuint fragmentShader) {
 }
 
 Shader* lovrShaderCreate(const char* vertexSource, const char* fragmentSource) {
-  Shader* shader = (Shader*) malloc(sizeof(Shader));
+  Shader* shader = lovrAlloc(sizeof(Shader), lovrShaderDestroy);
   if (!shader) return NULL;
 
   // Vertex
@@ -142,7 +142,8 @@ Shader* lovrShaderCreate(const char* vertexSource, const char* fragmentSource) {
   return shader;
 }
 
-void lovrShaderDestroy(Shader* shader) {
+void lovrShaderDestroy(const Ref* ref) {
+  Shader* shader = containerof(ref, Shader);
   glDeleteProgram(shader->id);
   mat4_deinit(shader->transform);
   mat4_deinit(shader->projection);

--- a/src/graphics/shader.h
+++ b/src/graphics/shader.h
@@ -1,6 +1,7 @@
 #include "glfw.h"
 #include "matrix.h"
 #include "vendor/map/map.h"
+#include "util.h"
 
 #ifndef LOVR_SHADER_TYPES
 #define LOVR_SHADER_TYPES
@@ -21,6 +22,7 @@ typedef struct {
 typedef map_t(Uniform) map_uniform_t;
 
 typedef struct {
+  Ref ref;
   int id;
   map_uniform_t uniforms;
   mat4 transform;
@@ -40,7 +42,7 @@ GLuint compileShader(GLuint type, const char* filename);
 GLuint linkShaders(GLuint vertexShader, GLuint fragmentShader);
 
 Shader* lovrShaderCreate(const char* vertexSource, const char* fragmentSource);
-void lovrShaderDestroy(Shader* shader);
+void lovrShaderDestroy(const Ref* ref);
 void lovrShaderBind(Shader* shader, mat4 transform, mat4 projection, unsigned int color, int force);
 int lovrShaderGetAttributeId(Shader* shader, const char* name);
 int lovrShaderGetUniformId(Shader* shader, const char* name);

--- a/src/graphics/skybox.c
+++ b/src/graphics/skybox.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 Skybox* lovrSkyboxCreate(void** data, int* size) {
-  Skybox* skybox = malloc(sizeof(Skybox));
+  Skybox* skybox = lovrAlloc(sizeof(Skybox), lovrSkyboxDestroy);
   if (!skybox) return NULL;
 
   glGenTextures(1, &skybox->texture);
@@ -30,7 +30,8 @@ Skybox* lovrSkyboxCreate(void** data, int* size) {
   return skybox;
 }
 
-void lovrSkyboxDestroy(Skybox* skybox) {
+void lovrSkyboxDestroy(const Ref* ref) {
+  Skybox* skybox = containerof(ref, Skybox);
   glDeleteTextures(1, &skybox->texture);
   free(skybox);
 }

--- a/src/graphics/skybox.h
+++ b/src/graphics/skybox.h
@@ -1,11 +1,13 @@
 #include "glfw.h"
+#include "util.h"
 
 #ifndef LOVR_SKYBOX_TYPES
 #define LOVR_SKYBOX_TYPES
 typedef struct {
+  Ref ref;
   GLuint texture;
 } Skybox;
 #endif
 
 Skybox* lovrSkyboxCreate(void** data, int* size);
-void lovrSkyboxDestroy(Skybox* skybox);
+void lovrSkyboxDestroy(const Ref* ref);

--- a/src/graphics/texture.c
+++ b/src/graphics/texture.c
@@ -33,19 +33,23 @@ Texture* lovrTextureCreateFromBuffer(Buffer* buffer) {
     return NULL;
   }
 
-  Texture* texture = malloc(sizeof(Texture));
+  Texture* texture = lovrAlloc(sizeof(Texture), lovrTextureDestroy);
   if (!texture) return NULL;
 
   glGenTextures(1, &texture->id);
-  texture->buffer = buffer->vbo;
+  texture->buffer = buffer;
   lovrTextureBind(texture);
   glTexBuffer(GL_TEXTURE_BUFFER, GL_RGB32F, buffer->vbo);
+  lovrRetain(&buffer->ref);
 
   return texture;
 }
 
 void lovrTextureDestroy(const Ref* ref) {
   Texture* texture = containerof(ref, Texture);
+  if (texture->buffer) {
+    lovrRelease(&texture->buffer->ref);
+  }
   glDeleteTextures(1, &texture->id);
   free(texture);
 }
@@ -60,7 +64,7 @@ void lovrTextureRefresh(Texture* texture) {
   }
 
   lovrTextureBind(texture);
-  glTexBuffer(GL_TEXTURE_BUFFER, GL_RGB32F, texture->buffer);
+  glTexBuffer(GL_TEXTURE_BUFFER, GL_RGB32F, texture->buffer->vbo);
 }
 
 int lovrTextureGetHeight(Texture* texture) {

--- a/src/graphics/texture.c
+++ b/src/graphics/texture.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 
 Texture* lovrTextureCreate(void* data, int size) {
-  Texture* texture = malloc(sizeof(Texture));
+  Texture* texture = lovrAlloc(sizeof(Texture), lovrTextureDestroy);
   if (!texture) return NULL;
 
   texture->buffer = 0;
@@ -14,7 +14,7 @@ Texture* lovrTextureCreate(void* data, int size) {
     int channels;
     unsigned char* image = loadImage(data, size, &texture->width, &texture->height, &channels, 3);
     if (!image) {
-      lovrTextureDestroy(texture);
+      lovrTextureDestroy(&texture->ref);
       return NULL;
     }
 
@@ -44,7 +44,8 @@ Texture* lovrTextureCreateFromBuffer(Buffer* buffer) {
   return texture;
 }
 
-void lovrTextureDestroy(Texture* texture) {
+void lovrTextureDestroy(const Ref* ref) {
+  Texture* texture = containerof(ref, Texture);
   glDeleteTextures(1, &texture->id);
   free(texture);
 }

--- a/src/graphics/texture.h
+++ b/src/graphics/texture.h
@@ -21,7 +21,7 @@ typedef enum {
 typedef struct {
   Ref ref;
   GLuint id;
-  GLuint buffer;
+  struct Buffer* buffer;
   int width;
   int height;
   FilterMode filterMin;

--- a/src/graphics/texture.h
+++ b/src/graphics/texture.h
@@ -1,4 +1,5 @@
 #include "glfw.h"
+#include "util.h"
 
 struct Buffer;
 
@@ -18,6 +19,7 @@ typedef enum {
 } WrapMode;
 
 typedef struct {
+  Ref ref;
   GLuint id;
   GLuint buffer;
   int width;
@@ -32,7 +34,7 @@ typedef struct {
 
 Texture* lovrTextureCreate(void* data, int size);
 Texture* lovrTextureCreateFromBuffer(struct Buffer* buffer);
-void lovrTextureDestroy(Texture* texture);
+void lovrTextureDestroy(const Ref* ref);
 void lovrTextureBind(Texture* texture);
 void lovrTextureRefresh(Texture* texture);
 int lovrTextureGetHeight(Texture* texture);

--- a/src/headset/vive.c
+++ b/src/headset/vive.c
@@ -99,7 +99,7 @@ Headset* viveInit() {
   state->clipFar = 30.f;
   state->vrSystem->GetRecommendedRenderTargetSize(&state->renderWidth, &state->renderHeight);
 
-  Controller* leftController = malloc(sizeof(Controller));
+  Controller* leftController = lovrAlloc(sizeof(Controller), NULL);
   if (!leftController) {
     viveDestroy(this);
     return NULL;
@@ -108,7 +108,7 @@ Headset* viveInit() {
   state->controllers[CONTROLLER_HAND_LEFT] = leftController;
   state->controllerIndex[CONTROLLER_HAND_LEFT] = state->vrSystem->GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole_TrackedControllerRole_LeftHand);
 
-  Controller* rightController = malloc(sizeof(Controller));
+  Controller* rightController = lovrAlloc(sizeof(Controller), NULL);
   if (!rightController) {
     viveDestroy(this);
     return NULL;

--- a/src/lovr.c
+++ b/src/lovr.c
@@ -30,11 +30,11 @@ void lovrInit(lua_State* L, int argc, char** argv) {
   lua_setglobal(L, "lovr");
 
   // Preload modules
-  luaPreloadModule(L, "lovr.event", l_lovrEventInit);
-  luaPreloadModule(L, "lovr.filesystem", l_lovrFilesystemInit);
-  luaPreloadModule(L, "lovr.graphics", l_lovrGraphicsInit);
-  luaPreloadModule(L, "lovr.headset", l_lovrHeadsetInit);
-  luaPreloadModule(L, "lovr.timer", l_lovrTimerInit);
+  luax_preloadmodule(L, "lovr.event", l_lovrEventInit);
+  luax_preloadmodule(L, "lovr.filesystem", l_lovrFilesystemInit);
+  luax_preloadmodule(L, "lovr.graphics", l_lovrGraphicsInit);
+  luax_preloadmodule(L, "lovr.headset", l_lovrHeadsetInit);
+  luax_preloadmodule(L, "lovr.timer", l_lovrTimerInit);
 
   // Bootstrap
   char buffer[2048];

--- a/src/lovr/graphics.c
+++ b/src/lovr/graphics.c
@@ -86,11 +86,11 @@ const luaL_Reg lovrGraphics[] = {
 int l_lovrGraphicsInit(lua_State* L) {
   lua_newtable(L);
   luaL_register(L, NULL, lovrGraphics);
-  luaRegisterType(L, "Buffer", lovrBuffer);
-  luaRegisterType(L, "Model", lovrModel);
-  luaRegisterType(L, "Shader", lovrShader);
-  luaRegisterType(L, "Skybox", lovrSkybox);
-  luaRegisterType(L, "Texture", lovrTexture);
+  luax_registertype(L, "Buffer", lovrBuffer);
+  luax_registertype(L, "Model", lovrModel);
+  luax_registertype(L, "Shader", lovrShader);
+  luax_registertype(L, "Skybox", lovrSkybox);
+  luax_registertype(L, "Texture", lovrTexture);
 
   map_init(&BufferAttributeTypes);
   map_set(&BufferAttributeTypes, "float", BUFFER_FLOAT);
@@ -530,7 +530,7 @@ int l_lovrGraphicsNewBuffer(lua_State* L) {
   }
 
   vec_deinit(&format);
-  luax_pushlovrtype(L, Buffer, buffer);
+  luax_pushtype(L, Buffer, buffer);
   return 1;
 }
 
@@ -617,7 +617,7 @@ int l_lovrGraphicsNewTexture(lua_State* L) {
     texture = lovrTextureCreate(data, size);
     free(data);
   } else {
-    Buffer* buffer = luax_checklovrtype(L, 1, Buffer); // TODO don't error if it's not a buffer
+    Buffer* buffer = luax_checktype(L, 1, Buffer); // TODO don't error if it's not a buffer
     texture = lovrTextureCreateFromBuffer(buffer);
   }
 

--- a/src/lovr/graphics.c
+++ b/src/lovr/graphics.c
@@ -248,12 +248,12 @@ int l_lovrGraphicsSetScissor(lua_State* L) {
 }
 
 int l_lovrGraphicsGetShader(lua_State* L) {
-  luax_pushshader(L, lovrGraphicsGetShader());
+  luax_pushtype(L, Shader, lovrGraphicsGetShader());
   return 1;
 }
 
 int l_lovrGraphicsSetShader(lua_State* L) {
-  Shader* shader = lua_isnoneornil(L, 1) ? NULL : luax_checkshader(L, 1);
+  Shader* shader = lua_isnoneornil(L, 1) ? NULL : luax_checktype(L, 1, Shader);
   lovrGraphicsSetShader(shader);
   return 0;
 }
@@ -542,7 +542,7 @@ int l_lovrGraphicsNewModel(lua_State* L) {
     return luaL_error(L, "Could not load model file '%s'", path);
   }
 
-  luax_pushmodel(L, lovrModelCreate(data, size));
+  luax_pushtype(L, Model, lovrModelCreate(data, size));
   free(data);
   return 1;
 }
@@ -564,7 +564,7 @@ int l_lovrGraphicsNewShader(lua_State* L) {
 
   const char* vertexSource = lua_tostring(L, 1);
   const char* fragmentSource = lua_tostring(L, 2);
-  luax_pushshader(L, lovrShaderCreate(vertexSource, fragmentSource));
+  luax_pushtype(L, Shader, lovrShaderCreate(vertexSource, fragmentSource));
   return 1;
 }
 
@@ -595,7 +595,7 @@ int l_lovrGraphicsNewSkybox(lua_State* L) {
     }
   }
 
-  luax_pushskybox(L, lovrSkyboxCreate(data, size));
+  luax_pushtype(L, Skybox, lovrSkyboxCreate(data, size));
 
   for (int i = 0; i < 6; i++) {
     free(data[i]);
@@ -621,7 +621,7 @@ int l_lovrGraphicsNewTexture(lua_State* L) {
     texture = lovrTextureCreateFromBuffer(buffer);
   }
 
-  luax_pushtexture(L, texture);
+  luax_pushtype(L, Texture, texture);
   return 1;
 }
 

--- a/src/lovr/graphics.c
+++ b/src/lovr/graphics.c
@@ -86,11 +86,11 @@ const luaL_Reg lovrGraphics[] = {
 int l_lovrGraphicsInit(lua_State* L) {
   lua_newtable(L);
   luaL_register(L, NULL, lovrGraphics);
-  luaRegisterType(L, "Buffer", lovrBuffer, luax_destroybuffer);
-  luaRegisterType(L, "Model", lovrModel, luax_destroymodel);
-  luaRegisterType(L, "Shader", lovrShader, luax_destroyshader);
-  luaRegisterType(L, "Skybox", lovrSkybox, luax_destroyskybox);
-  luaRegisterType(L, "Texture", lovrTexture, luax_destroytexture);
+  luaRegisterType(L, "Buffer", lovrBuffer);
+  luaRegisterType(L, "Model", lovrModel);
+  luaRegisterType(L, "Shader", lovrShader);
+  luaRegisterType(L, "Skybox", lovrSkybox);
+  luaRegisterType(L, "Texture", lovrTexture);
 
   map_init(&BufferAttributeTypes);
   map_set(&BufferAttributeTypes, "float", BUFFER_FLOAT);
@@ -530,7 +530,7 @@ int l_lovrGraphicsNewBuffer(lua_State* L) {
   }
 
   vec_deinit(&format);
-  luax_pushbuffer(L, buffer);
+  luax_pushlovrtype(L, Buffer, buffer);
   return 1;
 }
 
@@ -617,7 +617,7 @@ int l_lovrGraphicsNewTexture(lua_State* L) {
     texture = lovrTextureCreate(data, size);
     free(data);
   } else {
-    Buffer* buffer = luax_checkbuffer(L, 1); // TODO don't error if it's not a buffer
+    Buffer* buffer = luax_checklovrtype(L, 1, Buffer); // TODO don't error if it's not a buffer
     texture = lovrTextureCreateFromBuffer(buffer);
   }
 

--- a/src/lovr/headset.c
+++ b/src/lovr/headset.c
@@ -161,7 +161,7 @@ int l_lovrHeadsetGetAngularVelocity(lua_State* L) {
 
 int l_lovrHeadsetGetController(lua_State* L) {
   ControllerHand* hand = (ControllerHand*) luax_checkenum(L, 1, &ControllerHands, "controller hand");
-  luax_pushcontroller(L, lovrHeadsetGetController(*hand));
+  luax_pushtype(L, Controller, lovrHeadsetGetController(*hand));
   return 1;
 }
 

--- a/src/lovr/headset.c
+++ b/src/lovr/headset.c
@@ -34,7 +34,7 @@ const luaL_Reg lovrHeadset[] = {
 int l_lovrHeadsetInit(lua_State* L) {
   lua_newtable(L);
   luaL_register(L, NULL, lovrHeadset);
-  luaRegisterType(L, "Controller", lovrController, NULL);
+  luaRegisterType(L, "Controller", lovrController);
 
   map_init(&ControllerHands);
   map_set(&ControllerHands, "left", CONTROLLER_HAND_LEFT);

--- a/src/lovr/headset.c
+++ b/src/lovr/headset.c
@@ -34,7 +34,7 @@ const luaL_Reg lovrHeadset[] = {
 int l_lovrHeadsetInit(lua_State* L) {
   lua_newtable(L);
   luaL_register(L, NULL, lovrHeadset);
-  luaRegisterType(L, "Controller", lovrController);
+  luax_registertype(L, "Controller", lovrController);
 
   map_init(&ControllerHands);
   map_set(&ControllerHands, "left", CONTROLLER_HAND_LEFT);

--- a/src/lovr/types/buffer.c
+++ b/src/lovr/types/buffer.c
@@ -2,7 +2,7 @@
 #include "lovr/types/texture.h"
 #include "lovr/graphics.h"
 
-int luax_pushbuffervertex(lua_State* L, void* vertex, BufferFormat format) {
+static int luax_pushbuffervertex(lua_State* L, void* vertex, BufferFormat format) {
   int count = 0;
   int i;
   BufferAttribute attribute;
@@ -322,13 +322,13 @@ int l_lovrBufferSetDrawRange(lua_State* L) {
 
 int l_lovrBufferGetTexture(lua_State* L) {
   Buffer* buffer = luax_checktype(L, 1, Buffer);
-  luax_pushtexture(L, lovrBufferGetTexture(buffer));
+  luax_pushtype(L, Texture, lovrBufferGetTexture(buffer));
   return 1;
 }
 
 int l_lovrBufferSetTexture(lua_State* L) {
   Buffer* buffer = luax_checktype(L, 1, Buffer);
-  Texture* texture = luax_checktexture(L, 2);
+  Texture* texture = luax_checktype(L, 2, Texture);
   lovrBufferSetTexture(buffer, texture);
   return 0;
 }

--- a/src/lovr/types/buffer.c
+++ b/src/lovr/types/buffer.c
@@ -2,18 +2,6 @@
 #include "lovr/types/texture.h"
 #include "lovr/graphics.h"
 
-void luax_pushbuffer(lua_State* L, Buffer* buffer) {
-  if (buffer == NULL) {
-    lua_pushnil(L);
-    return;
-  }
-
-  Buffer** userdata = (Buffer**) lua_newuserdata(L, sizeof(Buffer*));
-  luaL_getmetatable(L, "Buffer");
-  lua_setmetatable(L, -2);
-  *userdata = buffer;
-}
-
 int luax_pushbuffervertex(lua_State* L, void* vertex, BufferFormat format) {
   int count = 0;
   int i;
@@ -63,16 +51,6 @@ void luax_checkbufferformat(lua_State* L, int index, BufferFormat* format) {
   }
 }
 
-Buffer* luax_checkbuffer(lua_State* L, int index) {
-  return *(Buffer**) luaL_checkudata(L, index, "Buffer");
-}
-
-int luax_destroybuffer(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
-  lovrBufferDestroy(buffer);
-  return 0;
-}
-
 const luaL_Reg lovrBuffer[] = {
   { "draw", l_lovrBufferDraw },
   { "getVertexCount", l_lovrBufferGetVertexCount },
@@ -91,32 +69,32 @@ const luaL_Reg lovrBuffer[] = {
 };
 
 int l_lovrBufferDraw(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   lovrBufferDraw(buffer);
   return 0;
 }
 
 int l_lovrBufferGetDrawMode(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   lua_pushstring(L, map_int_find(&BufferDrawModes, lovrBufferGetDrawMode(buffer)));
   return 1;
 }
 
 int l_lovrBufferSetDrawMode(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   BufferDrawMode* drawMode = (BufferDrawMode*) luax_checkenum(L, 2, &BufferDrawModes, "buffer draw mode");
   lovrBufferSetDrawMode(buffer, *drawMode);
   return 0;
 }
 
 int l_lovrBufferGetVertexCount(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   lua_pushnumber(L, lovrBufferGetVertexCount(buffer));
   return 1;
 }
 
 int l_lovrBufferGetVertex(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   int index = luaL_checkint(L, 2) - 1;
   void* vertex = lovrBufferGetScratchVertex(buffer);
   lovrBufferGetVertex(buffer, index, vertex);
@@ -125,7 +103,7 @@ int l_lovrBufferGetVertex(lua_State* L) {
 }
 
 int l_lovrBufferSetVertex(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   int index = luaL_checkint(L, 2) - 1;
   BufferFormat format = lovrBufferGetVertexFormat(buffer);
   void* vertex = lovrBufferGetScratchVertex(buffer);
@@ -204,7 +182,7 @@ int l_lovrBufferSetVertex(lua_State* L) {
 }
 
 int l_lovrBufferSetVertices(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   BufferFormat format = lovrBufferGetVertexFormat(buffer);
   luaL_checktype(L, 2, LUA_TTABLE);
   int vertexCount = lua_objlen(L, 2);
@@ -261,7 +239,7 @@ int l_lovrBufferSetVertices(lua_State* L) {
 }
 
 int l_lovrBufferGetVertexMap(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   int count;
   unsigned int* indices = lovrBufferGetVertexMap(buffer, &count);
 
@@ -280,7 +258,7 @@ int l_lovrBufferGetVertexMap(lua_State* L) {
 }
 
 int l_lovrBufferSetVertexMap(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
 
   if (lua_isnoneornil(L, 2)) {
     lovrBufferSetVertexMap(buffer, NULL, 0);
@@ -312,7 +290,7 @@ int l_lovrBufferSetVertexMap(lua_State* L) {
 }
 
 int l_lovrBufferGetDrawRange(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   if (!lovrBufferIsRangeEnabled(buffer)) {
     lua_pushnil(L);
     return 1;
@@ -326,7 +304,7 @@ int l_lovrBufferGetDrawRange(lua_State* L) {
 }
 
 int l_lovrBufferSetDrawRange(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   if (lua_isnoneornil(L, 2)) {
     lovrBufferSetRangeEnabled(buffer, 0);
     return 0;
@@ -343,13 +321,13 @@ int l_lovrBufferSetDrawRange(lua_State* L) {
 }
 
 int l_lovrBufferGetTexture(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   luax_pushtexture(L, lovrBufferGetTexture(buffer));
   return 1;
 }
 
 int l_lovrBufferSetTexture(lua_State* L) {
-  Buffer* buffer = luax_checkbuffer(L, 1);
+  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
   Texture* texture = luax_checktexture(L, 2);
   lovrBufferSetTexture(buffer, texture);
   return 0;

--- a/src/lovr/types/buffer.c
+++ b/src/lovr/types/buffer.c
@@ -322,13 +322,20 @@ int l_lovrBufferSetDrawRange(lua_State* L) {
 
 int l_lovrBufferGetTexture(lua_State* L) {
   Buffer* buffer = luax_checktype(L, 1, Buffer);
-  luax_pushtype(L, Texture, lovrBufferGetTexture(buffer));
+  Texture* texture = lovrBufferGetTexture(buffer);
+
+  if (texture) {
+    luax_pushtype(L, Texture, texture);
+  } else {
+    lua_pushnil(L);
+  }
+
   return 1;
 }
 
 int l_lovrBufferSetTexture(lua_State* L) {
   Buffer* buffer = luax_checktype(L, 1, Buffer);
-  Texture* texture = luax_checktype(L, 2, Texture);
+  Texture* texture = lua_isnoneornil(L, 2) ? NULL : luax_checktype(L, 2, Texture);
   lovrBufferSetTexture(buffer, texture);
   return 0;
 }

--- a/src/lovr/types/buffer.c
+++ b/src/lovr/types/buffer.c
@@ -69,32 +69,32 @@ const luaL_Reg lovrBuffer[] = {
 };
 
 int l_lovrBufferDraw(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   lovrBufferDraw(buffer);
   return 0;
 }
 
 int l_lovrBufferGetDrawMode(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   lua_pushstring(L, map_int_find(&BufferDrawModes, lovrBufferGetDrawMode(buffer)));
   return 1;
 }
 
 int l_lovrBufferSetDrawMode(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   BufferDrawMode* drawMode = (BufferDrawMode*) luax_checkenum(L, 2, &BufferDrawModes, "buffer draw mode");
   lovrBufferSetDrawMode(buffer, *drawMode);
   return 0;
 }
 
 int l_lovrBufferGetVertexCount(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   lua_pushnumber(L, lovrBufferGetVertexCount(buffer));
   return 1;
 }
 
 int l_lovrBufferGetVertex(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   int index = luaL_checkint(L, 2) - 1;
   void* vertex = lovrBufferGetScratchVertex(buffer);
   lovrBufferGetVertex(buffer, index, vertex);
@@ -103,7 +103,7 @@ int l_lovrBufferGetVertex(lua_State* L) {
 }
 
 int l_lovrBufferSetVertex(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   int index = luaL_checkint(L, 2) - 1;
   BufferFormat format = lovrBufferGetVertexFormat(buffer);
   void* vertex = lovrBufferGetScratchVertex(buffer);
@@ -182,7 +182,7 @@ int l_lovrBufferSetVertex(lua_State* L) {
 }
 
 int l_lovrBufferSetVertices(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   BufferFormat format = lovrBufferGetVertexFormat(buffer);
   luaL_checktype(L, 2, LUA_TTABLE);
   int vertexCount = lua_objlen(L, 2);
@@ -239,7 +239,7 @@ int l_lovrBufferSetVertices(lua_State* L) {
 }
 
 int l_lovrBufferGetVertexMap(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   int count;
   unsigned int* indices = lovrBufferGetVertexMap(buffer, &count);
 
@@ -258,7 +258,7 @@ int l_lovrBufferGetVertexMap(lua_State* L) {
 }
 
 int l_lovrBufferSetVertexMap(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
 
   if (lua_isnoneornil(L, 2)) {
     lovrBufferSetVertexMap(buffer, NULL, 0);
@@ -290,7 +290,7 @@ int l_lovrBufferSetVertexMap(lua_State* L) {
 }
 
 int l_lovrBufferGetDrawRange(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   if (!lovrBufferIsRangeEnabled(buffer)) {
     lua_pushnil(L);
     return 1;
@@ -304,7 +304,7 @@ int l_lovrBufferGetDrawRange(lua_State* L) {
 }
 
 int l_lovrBufferSetDrawRange(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   if (lua_isnoneornil(L, 2)) {
     lovrBufferSetRangeEnabled(buffer, 0);
     return 0;
@@ -321,13 +321,13 @@ int l_lovrBufferSetDrawRange(lua_State* L) {
 }
 
 int l_lovrBufferGetTexture(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   luax_pushtexture(L, lovrBufferGetTexture(buffer));
   return 1;
 }
 
 int l_lovrBufferSetTexture(lua_State* L) {
-  Buffer* buffer = luax_checklovrtype(L, 1, Buffer);
+  Buffer* buffer = luax_checktype(L, 1, Buffer);
   Texture* texture = luax_checktexture(L, 2);
   lovrBufferSetTexture(buffer, texture);
   return 0;

--- a/src/lovr/types/buffer.h
+++ b/src/lovr/types/buffer.h
@@ -3,11 +3,8 @@
 #include <lauxlib.h>
 #include <lualib.h>
 
-void luax_pushbuffer(lua_State* L, Buffer* buffer);
 int luax_pushvertex(lua_State* L, void* vertex, BufferFormat format);
 void luax_checkbufferformat(lua_State* L, int index, BufferFormat* format);
-Buffer* luax_checkbuffer(lua_State* L, int index);
-int luax_destroybuffer(lua_State* L);
 extern const luaL_Reg lovrBuffer[];
 
 int l_lovrBufferDraw(lua_State* L);

--- a/src/lovr/types/buffer.h
+++ b/src/lovr/types/buffer.h
@@ -3,10 +3,9 @@
 #include <lauxlib.h>
 #include <lualib.h>
 
-int luax_pushvertex(lua_State* L, void* vertex, BufferFormat format);
 void luax_checkbufferformat(lua_State* L, int index, BufferFormat* format);
-extern const luaL_Reg lovrBuffer[];
 
+extern const luaL_Reg lovrBuffer[];
 int l_lovrBufferDraw(lua_State* L);
 int l_lovrBufferGetVertexCount(lua_State* L);
 int l_lovrBufferGetVertex(lua_State* L);

--- a/src/lovr/types/controller.c
+++ b/src/lovr/types/controller.c
@@ -2,22 +2,6 @@
 #include "lovr/headset.h"
 #include "util.h"
 
-void luax_pushcontroller(lua_State* L, Controller* controller) {
-  if (controller == NULL) {
-    lua_pushnil(L);
-    return;
-  }
-
-  Controller** userdata = (Controller**) lua_newuserdata(L, sizeof(Controller*));
-  luaL_getmetatable(L, "Controller");
-  lua_setmetatable(L, -2);
-  *userdata = controller;
-}
-
-Controller* luax_checkcontroller(lua_State* L, int index) {
-  return *(Controller**) luaL_checkudata(L, index, "Controller");
-}
-
 const luaL_Reg lovrController[] = {
   { "isPresent", l_lovrControllerIsPresent },
   { "getPosition", l_lovrControllerGetPosition },
@@ -30,13 +14,13 @@ const luaL_Reg lovrController[] = {
 };
 
 int l_lovrControllerIsPresent(lua_State* L) {
-  Controller* controller = luax_checkcontroller(L, 1);
+  Controller* controller = luax_checktype(L, 1, Controller);
   lua_pushboolean(L, lovrHeadsetControllerIsPresent(controller));
   return 1;
 }
 
 int l_lovrControllerGetPosition(lua_State* L) {
-  Controller* controller = luax_checkcontroller(L, 1);
+  Controller* controller = luax_checktype(L, 1, Controller);
   float x, y, z;
   lovrHeadsetControllerGetPosition(controller, &x, &y, &z);
   lua_pushnumber(L, x);
@@ -46,7 +30,7 @@ int l_lovrControllerGetPosition(lua_State* L) {
 }
 
 int l_lovrControllerGetOrientation(lua_State* L) {
-  Controller* controller = luax_checkcontroller(L, 1);
+  Controller* controller = luax_checktype(L, 1, Controller);
   float w, x, y, z;
   lovrHeadsetControllerGetOrientation(controller, &w, &x, &y, &z);
   lua_pushnumber(L, w);
@@ -57,27 +41,27 @@ int l_lovrControllerGetOrientation(lua_State* L) {
 }
 
 int l_lovrControllerGetAxis(lua_State* L) {
-  Controller* controller = luax_checkcontroller(L, 1);
+  Controller* controller = luax_checktype(L, 1, Controller);
   ControllerAxis* axis = (ControllerAxis*) luax_checkenum(L, 2, &ControllerAxes, "controller axis");
   lua_pushnumber(L, lovrHeadsetControllerGetAxis(controller, *axis));
   return 1;
 }
 
 int l_lovrControllerIsDown(lua_State* L) {
-  Controller* controller = luax_checkcontroller(L, 1);
+  Controller* controller = luax_checktype(L, 1, Controller);
   ControllerButton* button = (ControllerButton*) luax_checkenum(L, 2, &ControllerButtons, "controller button");
   lua_pushboolean(L, lovrHeadsetControllerIsDown(controller, *button));
   return 1;
 }
 
 int l_lovrControllerGetHand(lua_State* L) {
-  Controller* controller = luax_checkcontroller(L, 1);
+  Controller* controller = luax_checktype(L, 1, Controller);
   lua_pushstring(L, map_int_find(&ControllerHands, lovrHeadsetControllerGetHand(controller)));
   return 1;
 }
 
 int l_lovrControllerVibrate(lua_State* L) {
-  Controller* controller = luax_checkcontroller(L, 1);
+  Controller* controller = luax_checktype(L, 1, Controller);
   float duration = luaL_optnumber(L, 2, .5);
   lovrHeadsetControllerVibrate(controller, duration);
   return 0;

--- a/src/lovr/types/controller.h
+++ b/src/lovr/types/controller.h
@@ -3,9 +3,6 @@
 #include <lauxlib.h>
 #include <lualib.h>
 
-void luax_pushcontroller(lua_State* L, Controller* controller);
-extern const luaL_Reg lovrController[];
-
 extern const luaL_Reg lovrController[];
 int l_lovrControllerIsPresent(lua_State* L);
 int l_lovrControllerGetPosition(lua_State* L);

--- a/src/lovr/types/controller.h
+++ b/src/lovr/types/controller.h
@@ -4,8 +4,6 @@
 #include <lualib.h>
 
 void luax_pushcontroller(lua_State* L, Controller* controller);
-Controller* luax_checkcontroller(lua_State* L, int index);
-int luax_destroycontroller(lua_State* L);
 extern const luaL_Reg lovrController[];
 
 extern const luaL_Reg lovrController[];

--- a/src/lovr/types/model.c
+++ b/src/lovr/types/model.c
@@ -17,12 +17,6 @@ Model* luax_checkmodel(lua_State* L, int index) {
   return *(Model**) luaL_checkudata(L, index, "Model");
 }
 
-int luax_destroymodel(lua_State* L) {
-  Model* model = luax_checkmodel(L, 1);
-  lovrModelDestroy(model);
-  return 0;
-}
-
 const luaL_Reg lovrModel[] = {
   { "draw", l_lovrModelDraw },
   { "getTexture", l_lovrModelGetTexture },

--- a/src/lovr/types/model.c
+++ b/src/lovr/types/model.c
@@ -1,22 +1,6 @@
 #include "lovr/types/model.h"
 #include "lovr/types/texture.h"
 
-void luax_pushmodel(lua_State* L, Model* model) {
-  if (model == NULL) {
-    lua_pushnil(L);
-    return;
-  }
-
-  Model** userdata = (Model**) lua_newuserdata(L, sizeof(Model*));
-  luaL_getmetatable(L, "Model");
-  lua_setmetatable(L, -2);
-  *userdata = model;
-}
-
-Model* luax_checkmodel(lua_State* L, int index) {
-  return *(Model**) luaL_checkudata(L, index, "Model");
-}
-
 const luaL_Reg lovrModel[] = {
   { "draw", l_lovrModelDraw },
   { "getTexture", l_lovrModelGetTexture },
@@ -25,7 +9,7 @@ const luaL_Reg lovrModel[] = {
 };
 
 int l_lovrModelDraw(lua_State* L) {
-  Model* model = luax_checkmodel(L, 1);
+  Model* model = luax_checktype(L, 1, Model);
   float x = luaL_optnumber(L, 2, 0.f);
   float y = luaL_optnumber(L, 3, 0.f);
   float z = luaL_optnumber(L, 4, 0.f);
@@ -39,14 +23,14 @@ int l_lovrModelDraw(lua_State* L) {
 }
 
 int l_lovrModelGetTexture(lua_State* L) {
-  Model* model = luax_checkmodel(L, 1);
-  luax_pushtexture(L, lovrModelGetTexture(model));
+  Model* model = luax_checktype(L, 1, Model);
+  luax_pushtype(L, Texture, lovrModelGetTexture(model));
   return 1;
 }
 
 int l_lovrModelSetTexture(lua_State* L) {
-  Model* model = luax_checkmodel(L, 1);
-  Texture* texture = luax_checktexture(L, 2);
+  Model* model = luax_checktype(L, 1, Model);
+  Texture* texture = luax_checktype(L, 2, Texture);
   lovrModelSetTexture(model, texture);
   return 0;
 }

--- a/src/lovr/types/model.h
+++ b/src/lovr/types/model.h
@@ -3,10 +3,7 @@
 #include <lauxlib.h>
 #include <lualib.h>
 
-void luax_pushmodel(lua_State* L, Model* model);
-Model* luax_checkmodel(lua_State* L, int index);
 extern const luaL_Reg lovrModel[];
-
 int l_lovrModelDraw(lua_State* L);
 int l_lovrModelGetTexture(lua_State* L);
 int l_lovrModelSetTexture(lua_State* L);

--- a/src/lovr/types/model.h
+++ b/src/lovr/types/model.h
@@ -5,7 +5,6 @@
 
 void luax_pushmodel(lua_State* L, Model* model);
 Model* luax_checkmodel(lua_State* L, int index);
-int luax_destroymodel(lua_State* L);
 extern const luaL_Reg lovrModel[];
 
 int l_lovrModelDraw(lua_State* L);

--- a/src/lovr/types/shader.c
+++ b/src/lovr/types/shader.c
@@ -1,28 +1,12 @@
 #include "lovr/types/shader.h"
 
-void luax_pushshader(lua_State* L, Shader* shader) {
-  if (shader == NULL) {
-    lua_pushnil(L);
-    return;
-  }
-
-  Shader** userdata = (Shader**) lua_newuserdata(L, sizeof(Shader*));
-  luaL_getmetatable(L, "Shader");
-  lua_setmetatable(L, -2);
-  *userdata = shader;
-}
-
-Shader* luax_checkshader(lua_State* L, int index) {
-  return *(Shader**) luaL_checkudata(L, index, "Shader");
-}
-
 const luaL_Reg lovrShader[] = {
   { "send", l_lovrShaderSend },
   { NULL, NULL }
 };
 
 int l_lovrShaderSend(lua_State* L) {
-  Shader* shader = luax_checkshader(L, 1);
+  Shader* shader = luax_checktype(L, 1, Shader);
   const char* name = luaL_checkstring(L, 2);
 
   int id = lovrShaderGetUniformId(shader, name);

--- a/src/lovr/types/shader.c
+++ b/src/lovr/types/shader.c
@@ -16,12 +16,6 @@ Shader* luax_checkshader(lua_State* L, int index) {
   return *(Shader**) luaL_checkudata(L, index, "Shader");
 }
 
-int luax_destroyshader(lua_State* L) {
-  Shader* shader = luax_checkshader(L, 1);
-  lovrShaderDestroy(shader);
-  return 0;
-}
-
 const luaL_Reg lovrShader[] = {
   { "send", l_lovrShaderSend },
   { NULL, NULL }

--- a/src/lovr/types/shader.h
+++ b/src/lovr/types/shader.h
@@ -3,8 +3,5 @@
 #include <lauxlib.h>
 #include <lualib.h>
 
-void luax_pushshader(lua_State* L, Shader* shader);
-Shader* luax_checkshader(lua_State* L, int index);
 extern const luaL_Reg lovrShader[];
-
 int l_lovrShaderSend(lua_State* L);

--- a/src/lovr/types/shader.h
+++ b/src/lovr/types/shader.h
@@ -5,7 +5,6 @@
 
 void luax_pushshader(lua_State* L, Shader* shader);
 Shader* luax_checkshader(lua_State* L, int index);
-int luax_destroyshader(lua_State* L);
 extern const luaL_Reg lovrShader[];
 
 int l_lovrShaderSend(lua_State* L);

--- a/src/lovr/types/skybox.c
+++ b/src/lovr/types/skybox.c
@@ -1,20 +1,5 @@
 #include "lovr/types/skybox.h"
-
-void luax_pushskybox(lua_State* L, Skybox* skybox) {
-  if (skybox == NULL) {
-    lua_pushnil(L);
-    return;
-  }
-
-  Skybox** userdata = (Skybox**) lua_newuserdata(L, sizeof(Skybox*));
-  luaL_getmetatable(L, "Skybox");
-  lua_setmetatable(L, -2);
-  *userdata = skybox;
-}
-
-Skybox* luax_checkskybox(lua_State* L, int index) {
-  return *(Skybox**) luaL_checkudata(L, index, "Skybox");
-}
+#include "graphics/graphics.h"
 
 const luaL_Reg lovrSkybox[] = {
   { "draw", l_lovrSkyboxDraw },
@@ -22,7 +7,7 @@ const luaL_Reg lovrSkybox[] = {
 };
 
 int l_lovrSkyboxDraw(lua_State* L) {
-  Skybox* skybox = luax_checkskybox(L, 1);
+  Skybox* skybox = luax_checktype(L, 1, Skybox);
   float angle = luaL_optnumber(L, 2, 0.f);
   float ax = luaL_optnumber(L, 3, 0.f);
   float ay = luaL_optnumber(L, 4, 0.f);

--- a/src/lovr/types/skybox.c
+++ b/src/lovr/types/skybox.c
@@ -16,12 +16,6 @@ Skybox* luax_checkskybox(lua_State* L, int index) {
   return *(Skybox**) luaL_checkudata(L, index, "Skybox");
 }
 
-int luax_destroyskybox(lua_State* L) {
-  Skybox* skybox = luax_checkskybox(L, 1);
-  lovrSkyboxDestroy(skybox);
-  return 0;
-}
-
 const luaL_Reg lovrSkybox[] = {
   { "draw", l_lovrSkyboxDraw },
   { NULL, NULL }

--- a/src/lovr/types/skybox.h
+++ b/src/lovr/types/skybox.h
@@ -6,7 +6,6 @@
 
 void luax_pushskybox(lua_State* L, Skybox* skybox);
 Skybox* luax_checkskybox(lua_State* L, int index);
-int luax_destroyskybox(lua_State* L);
 extern const luaL_Reg lovrSkybox[];
 
 int l_lovrSkyboxDraw(lua_State* L);

--- a/src/lovr/types/skybox.h
+++ b/src/lovr/types/skybox.h
@@ -4,8 +4,5 @@
 #include <lauxlib.h>
 #include <lualib.h>
 
-void luax_pushskybox(lua_State* L, Skybox* skybox);
-Skybox* luax_checkskybox(lua_State* L, int index);
 extern const luaL_Reg lovrSkybox[];
-
 int l_lovrSkyboxDraw(lua_State* L);

--- a/src/lovr/types/texture.c
+++ b/src/lovr/types/texture.c
@@ -2,22 +2,6 @@
 #include "lovr/graphics.h"
 #include "util.h"
 
-void luax_pushtexture(lua_State* L, Texture* texture) {
-  if (texture == NULL) {
-    lua_pushnil(L);
-    return;
-  }
-
-  Texture** userdata = (Texture**) lua_newuserdata(L, sizeof(Texture*));
-  luaL_getmetatable(L, "Texture");
-  lua_setmetatable(L, -2);
-  *userdata = texture;
-}
-
-Texture* luax_checktexture(lua_State* L, int index) {
-  return *(Texture**) luaL_checkudata(L, index, "Texture");
-}
-
 const luaL_Reg lovrTexture[] = {
   { "bind", l_lovrTextureBind },
   { "refresh", l_lovrTextureRefresh },
@@ -32,26 +16,26 @@ const luaL_Reg lovrTexture[] = {
 };
 
 int l_lovrTextureBind(lua_State* L) {
-  Texture* texture = luax_checktexture(L, 1);
+  Texture* texture = luax_checktype(L, 1, Texture);
   lovrTextureBind(texture);
   return 0;
 }
 
 int l_lovrTextureRefresh(lua_State* L) {
-  Texture* texture = luax_checktexture(L, 1);
+  Texture* texture = luax_checktype(L, 1, Texture);
   lovrTextureRefresh(texture);
   return 0;
 }
 
 int l_lovrTextureGetDimensions(lua_State* L) {
-  Texture* texture = luax_checktexture(L, 1);
+  Texture* texture = luax_checktype(L, 1, Texture);
   lua_pushnumber(L, lovrTextureGetWidth(texture));
   lua_pushnumber(L, lovrTextureGetHeight(texture));
   return 2;
 }
 
 int l_lovrTextureGetFilter(lua_State* L) {
-  Texture* texture = luax_checktexture(L, 1);
+  Texture* texture = luax_checktype(L, 1, Texture);
   FilterMode min, mag;
   lovrTextureGetFilter(texture, &min, &mag);
   lua_pushstring(L, map_int_find(&FilterModes, min));
@@ -60,19 +44,19 @@ int l_lovrTextureGetFilter(lua_State* L) {
 }
 
 int l_lovrTextureGetHeight(lua_State* L) {
-  Texture* texture = luax_checktexture(L, 1);
+  Texture* texture = luax_checktype(L, 1, Texture);
   lua_pushnumber(L, lovrTextureGetHeight(texture));
   return 1;
 }
 
 int l_lovrTextureGetWidth(lua_State* L) {
-  Texture* texture = luax_checktexture(L, 1);
+  Texture* texture = luax_checktype(L, 1, Texture);
   lua_pushnumber(L, lovrTextureGetWidth(texture));
   return 1;
 }
 
 int l_lovrTextureGetWrap(lua_State* L) {
-  Texture* texture = luax_checktexture(L, 1);
+  Texture* texture = luax_checktype(L, 1, Texture);
   WrapMode horizontal, vertical;
   lovrTextureGetWrap(texture, &horizontal, &vertical);
   lua_pushstring(L, map_int_find(&WrapModes, horizontal));
@@ -81,7 +65,7 @@ int l_lovrTextureGetWrap(lua_State* L) {
 }
 
 int l_lovrTextureSetFilter(lua_State* L) {
-  Texture* texture = luax_checktexture(L, 1);
+  Texture* texture = luax_checktype(L, 1, Texture);
   FilterMode* min = (FilterMode*) luax_checkenum(L, 2, &FilterModes, "filter mode");
   FilterMode* mag = (FilterMode*) luax_optenum(L, 3, luaL_checkstring(L, 2), &FilterModes, "filter mode");
   lovrTextureSetFilter(texture, *min, *mag);
@@ -89,7 +73,7 @@ int l_lovrTextureSetFilter(lua_State* L) {
 }
 
 int l_lovrTextureSetWrap(lua_State* L) {
-  Texture* texture = luax_checktexture(L, 1);
+  Texture* texture = luax_checktype(L, 1, Texture);
   WrapMode* horizontal = (WrapMode*) luax_checkenum(L, 2, &WrapModes, "wrap mode");
   WrapMode* vertical = (WrapMode*) luax_optenum(L, 3, luaL_checkstring(L, 2), &WrapModes, "wrap mode");
   lovrTextureSetWrap(texture, *horizontal, *vertical);

--- a/src/lovr/types/texture.c
+++ b/src/lovr/types/texture.c
@@ -18,12 +18,6 @@ Texture* luax_checktexture(lua_State* L, int index) {
   return *(Texture**) luaL_checkudata(L, index, "Texture");
 }
 
-int luax_destroytexture(lua_State* L) {
-  Texture* texture = luax_checktexture(L, 1);
-  lovrTextureDestroy(texture);
-  return 0;
-}
-
 const luaL_Reg lovrTexture[] = {
   { "bind", l_lovrTextureBind },
   { "refresh", l_lovrTextureRefresh },

--- a/src/lovr/types/texture.h
+++ b/src/lovr/types/texture.h
@@ -3,10 +3,7 @@
 #include <lauxlib.h>
 #include <lualib.h>
 
-void luax_pushtexture(lua_State* L, Texture* texture);
-Texture* luax_checktexture(lua_State* L, int index);
 extern const luaL_Reg lovrTexture[];
-
 int l_lovrTextureBind(lua_State* L);
 int l_lovrTextureRefresh(lua_State* L);
 int l_lovrTextureGetDimensions(lua_State* L);

--- a/src/lovr/types/texture.h
+++ b/src/lovr/types/texture.h
@@ -5,7 +5,6 @@
 
 void luax_pushtexture(lua_State* L, Texture* texture);
 Texture* luax_checktexture(lua_State* L, int index);
-int luax_destroytexture(lua_State* L);
 extern const luaL_Reg lovrTexture[];
 
 int l_lovrTextureBind(lua_State* L);

--- a/src/model/modelData.c
+++ b/src/model/modelData.c
@@ -92,7 +92,9 @@ ModelData* lovrModelDataCreate(void* data, int size) {
   return modelData;
 }
 
-void lovrModelDataDestroy(ModelData* modelData) {
+void lovrModelDataDestroy(const Ref* ref) {
+  ModelData* modelData = containerof(ref, ModelData);
+
   for (int i = 0; i < modelData->meshes.length; i++) {
     ModelMesh* mesh = modelData->meshes.data[i];
 

--- a/src/model/modelData.h
+++ b/src/model/modelData.h
@@ -34,6 +34,7 @@ typedef struct ModelNode {
 } ModelNode;
 
 typedef struct {
+  Ref ref;
   ModelNode* root;
   vec_model_mesh_t meshes;
   int hasNormals;
@@ -42,4 +43,4 @@ typedef struct {
 #endif
 
 ModelData* lovrModelDataCreate(void* data, int size);
-void lovrModelDataDestroy(ModelData* modelData);
+void lovrModelDataDestroy(const Ref* ref);

--- a/src/util.c
+++ b/src/util.c
@@ -18,7 +18,34 @@ unsigned char* loadImage(void* data, size_t size, int* w, int* h, int* n, int ch
   return stbi_load_from_memory(data, size, w, h, n, channels);
 }
 
-int luaPreloadModule(lua_State* L, const char* key, lua_CFunction f) {
+// Returns a key that maps to value or NULL if the value is not in the map
+const char* map_int_find(map_int_t* map, int value) {
+  const char* key;
+  map_iter_t iter = map_iter(map);
+  while ((key = map_next(map, &iter))) {
+    if (*map_get(map, key) == value) {
+      return key;
+    }
+  }
+  return NULL;
+}
+
+void* lovrAlloc(size_t size, void (*destructor)(const Ref* ref)) {
+  void* object = malloc(size);
+  if (!object) return NULL;
+  *((Ref*) object) = (Ref) { destructor, 1 };
+  return object;
+}
+
+void lovrRetain(const Ref* ref) {
+  ((Ref*) ref)->count++;
+}
+
+void lovrRelease(const Ref* ref) {
+  if (--((Ref*) ref)->count == 0 && ref->free) ref->free(ref);
+}
+
+int luax_preloadmodule(lua_State* L, const char* key, lua_CFunction f) {
   lua_getglobal(L, "package");
   lua_getfield(L, -1, "preload");
   lua_pushcfunction(L, f);
@@ -27,23 +54,7 @@ int luaPreloadModule(lua_State* L, const char* key, lua_CFunction f) {
   return 0;
 }
 
-void luaRegisterModule(lua_State* L, const char* name, const luaL_Reg* module) {
-
-  // Get reference to lovr
-  lua_getglobal(L, "lovr");
-
-  // Create a table and fill it with the module functions
-  lua_newtable(L);
-  luaL_register(L, NULL, module);
-
-  // lovr[name] = module
-  lua_setfield(L, -2, name);
-
-  // Pop lovr
-  lua_pop(L, 1);
-}
-
-void luaRegisterType(lua_State* L, const char* name, const luaL_Reg* functions) {
+void luax_registertype(lua_State* L, const char* name, const luaL_Reg* functions) {
 
   // Push metatable
   luaL_newmetatable(L, name);
@@ -54,7 +65,7 @@ void luaRegisterType(lua_State* L, const char* name, const luaL_Reg* functions) 
   lua_setfield(L, -1, "__index");
 
   // m.__gc = gc
-  lua_pushcfunction(L, luax_destroylovrtype);
+  lua_pushcfunction(L, luax_releasetype);
   lua_setfield(L, -2, "__gc");
 
   // m.name = name
@@ -70,16 +81,9 @@ void luaRegisterType(lua_State* L, const char* name, const luaL_Reg* functions) 
   lua_pop(L, 1);
 }
 
-// Returns a key that maps to value or NULL if the value is not in the map
-const char* map_int_find(map_int_t* map, int value) {
-  const char* key;
-  map_iter_t iter = map_iter(map);
-  while ((key = map_next(map, &iter))) {
-    if (*map_get(map, key) == value) {
-      return key;
-    }
-  }
-  return NULL;
+int luax_releasetype(lua_State* L) {
+  lovrRelease(*(Ref**) lua_touserdata(L, 1));
+  return 0;
 }
 
 void* luax_checkenum(lua_State* L, int index, map_int_t* map, const char* typeName) {
@@ -102,24 +106,4 @@ void* luax_optenum(lua_State* L, int index, const char* fallback, map_int_t* map
   }
 
   return value;
-}
-
-void* lovrAlloc(size_t size, void (*destructor)(const Ref* ref)) {
-  void* object = malloc(size);
-  if (!object) return NULL;
-  *((Ref*) object) = (Ref) { destructor, 1 };
-  return object;
-}
-
-void lovrRetain(const Ref* ref) {
-  ((Ref*) ref)->count++;
-}
-
-void lovrRelease(const Ref* ref) {
-  if (--((Ref*) ref)->count == 0 && ref->free) ref->free(ref);
-}
-
-int luax_destroylovrtype(lua_State* L) {
-  lovrRelease(*(Ref**) lua_touserdata(L, 1));
-  return 0;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -15,14 +15,33 @@
 #define LOVR_COLOR_B(c) (c >> 8  & 0xff)
 #define LOVR_COLOR_A(c) (c >> 0  & 0xff)
 
+#define luax_checklovrtype(L, i, T) *(T**) luaL_checkudata(L, i, #T);
+
+#define luax_pushlovrtype(L, T, x) \
+  T** u = (T**) lua_newuserdata(L, sizeof(T**)); \
+  luaL_getmetatable(L, #T); \
+  lua_setmetatable(L, -2); \
+  *u = x;
+
+typedef struct ref {
+  void (*free)(const struct ref* ref);
+  int count;
+} Ref;
+
+#define containerof(ptr, type) ((type*)((char*)(ptr) - offsetof(type, ref)))
+
 typedef vec_t(unsigned int) vec_uint_t;
 #endif
 
 void error(const char* format, ...);
 unsigned char* loadImage(void* data, size_t size, int* w, int* h, int* n, int channels);
 void luaRegisterModule(lua_State* L, const char* name, const luaL_Reg* module);
-void luaRegisterType(lua_State* L, const char* name, const luaL_Reg* functions, lua_CFunction gc);
+void luaRegisterType(lua_State* L, const char* name, const luaL_Reg* functions);
 int luaPreloadModule(lua_State* L, const char* key, lua_CFunction f);
 const char* map_int_find(map_int_t *map, int value);
 void* luax_checkenum(lua_State* L, int index, map_int_t* map, const char* typeName);
 void* luax_optenum(lua_State* L, int index, const char* fallback, map_int_t* map, const char* typeName);
+void* lovrAlloc(size_t size, void (*destructor)(const Ref* ref));
+void lovrRetain(const Ref* ref);
+void lovrRelease(const Ref* ref);
+int luax_destroylovrtype(lua_State* L);

--- a/src/util.h
+++ b/src/util.h
@@ -6,6 +6,8 @@
 
 #ifndef UTIL_TYPES
 #define UTIL_TYPES
+#define containerof(ptr, type) ((type*)((char*)(ptr) - offsetof(type, ref)))
+
 #define MAX(a, b) a > b ? a : b
 #define MIN(a, b) a < b ? a : b
 
@@ -15,9 +17,9 @@
 #define LOVR_COLOR_B(c) (c >> 8  & 0xff)
 #define LOVR_COLOR_A(c) (c >> 0  & 0xff)
 
-#define luax_checklovrtype(L, i, T) *(T**) luaL_checkudata(L, i, #T);
+#define luax_checktype(L, i, T) *(T**) luaL_checkudata(L, i, #T);
 
-#define luax_pushlovrtype(L, T, x) \
+#define luax_pushtype(L, T, x) \
   T** u = (T**) lua_newuserdata(L, sizeof(T**)); \
   luaL_getmetatable(L, #T); \
   lua_setmetatable(L, -2); \
@@ -28,20 +30,19 @@ typedef struct ref {
   int count;
 } Ref;
 
-#define containerof(ptr, type) ((type*)((char*)(ptr) - offsetof(type, ref)))
-
 typedef vec_t(unsigned int) vec_uint_t;
 #endif
 
 void error(const char* format, ...);
 unsigned char* loadImage(void* data, size_t size, int* w, int* h, int* n, int channels);
-void luaRegisterModule(lua_State* L, const char* name, const luaL_Reg* module);
-void luaRegisterType(lua_State* L, const char* name, const luaL_Reg* functions);
-int luaPreloadModule(lua_State* L, const char* key, lua_CFunction f);
 const char* map_int_find(map_int_t *map, int value);
-void* luax_checkenum(lua_State* L, int index, map_int_t* map, const char* typeName);
-void* luax_optenum(lua_State* L, int index, const char* fallback, map_int_t* map, const char* typeName);
+
 void* lovrAlloc(size_t size, void (*destructor)(const Ref* ref));
 void lovrRetain(const Ref* ref);
 void lovrRelease(const Ref* ref);
-int luax_destroylovrtype(lua_State* L);
+
+int luax_preloadmodule(lua_State* L, const char* key, lua_CFunction f);
+void luax_registertype(lua_State* L, const char* name, const luaL_Reg* functions);
+int luax_releasetype(lua_State* L);
+void* luax_checkenum(lua_State* L, int index, map_int_t* map, const char* typeName);
+void* luax_optenum(lua_State* L, int index, const char* fallback, map_int_t* map, const char* typeName);


### PR DESCRIPTION
- Reference counting so C can better enforce ownership of objects.  This also alleviates the need to be careful about object lifetimes and relationships on the Lua side.
- Some macros for commonly repeated Lua API functionality.