### PR TITLE
Update README to require OpenVR v1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Next, build using CMake:
 ```sh
 mkdir build
 cd build
-cmake .. -DOPENVR_DIR=../openvr
+cmake .. -DOPENVR_DIR=../../openvr
 cmake --build .
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,9 +104,14 @@ create and run a game from this point is:
 
 #### Unix (CMake)
 
-First, clone [OpenVR](https://github.com/ValveSoftware/openvr).  For this example, we'll clone
-`openvr` into the same directory that `lovr` was cloned into.  Next, install the other dependencies
-above using your package manager of choice:
+First, clone [OpenVR](https://github.com/ValveSoftware/openvr) (v1.0.3).  For this example, we'll clone
+`openvr` into the same directory that `lovr` was cloned into.
+
+```sh
+git clone --branch v1.0.3 https://github.com/ValveSoftware/openvr.git
+```
+
+Next, install the other dependencies above using your package manager of choice:
 
 ```sh
 brew install assimp glfw3 luajit physfs


### PR DESCRIPTION
If you clone the OpenVR repo as it currently stands, you are unable to compile LÖVR from source. It appears LÖVR is targeting v1.0.3 (and I have confirmed the build works as expected when compiling against this release).

I also included a small typo in the README regarding the `-DOPENVR_DIR` argument.

Fixes #4.

Note: This has been tested only on Mac OSX.