### PR TITLE
Set glfw time to 0 during init.

### DIFF
--- a/src/timer/timer.c
+++ b/src/timer/timer.c
@@ -5,6 +5,7 @@
 static TimerState timerState;
 
 void lovrTimerInit() {
+  glfwSetTime(0);
   timerState.tickIndex = 0;
   for (int i = 0; i < TICK_SAMPLES; i++) {
     timerState.tickBuffer[i] = 0.;


### PR DESCRIPTION
This was something I did in my live-reload branch (where prevents a large erroneous negative dt on first update). However, it also helps if lovr is launched in a debugger such as lldb which pauses at boot (it prevents a large erroneous positive dt on first update).