### PR TITLE
Restart-without-quit support: lovr.event.quit("restart")

### DIFF
--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -3,10 +3,16 @@
 #include "math/quat.h"
 #include "util.h"
 #include <stdlib.h>
+#include "lovr.h"
 
 static AudioState state;
+static bool audioAlreadyInit = false;
 
 void lovrAudioInit() {
+  if (audioAlreadyInit) { // During a reload, bring down the audio device then recreate it
+    lovrAudioDestroy();
+  }
+
   ALCdevice* device = alcOpenDevice(NULL);
   lovrAssert(device, "Unable to open default audio device");
 
@@ -31,7 +37,10 @@ void lovrAudioInit() {
   vec3_set(state.position, 0, 0, 0);
   vec3_set(state.velocity, 0, 0, 0);
 
-  atexit(lovrAudioDestroy);
+  if (!audioAlreadyInit) {
+    atexit(lovrAudioDestroy);
+    audioAlreadyInit = true;
+  }
 }
 
 void lovrAudioDestroy() {

--- a/src/event/event.c
+++ b/src/event/event.c
@@ -3,12 +3,18 @@
 #include <stdlib.h>
 
 static EventState state;
+bool eventAlreadyInit = false;
 
 void lovrEventInit() {
+  if (eventAlreadyInit)
+    lovrEventDestroy();
   vec_init(&state.pumps);
   vec_init(&state.events);
   lovrEventAddPump(glfwPollEvents);
-  atexit(lovrEventDestroy);
+  if (!eventAlreadyInit) {
+    atexit(lovrEventDestroy);
+    eventAlreadyInit = true;
+  }
 }
 
 void lovrEventDestroy() {

--- a/src/event/event.h
+++ b/src/event/event.h
@@ -14,6 +14,7 @@ typedef enum {
 } EventType;
 
 typedef struct {
+  bool restart;
   int exitCode;
 } QuitEvent;
 

--- a/src/filesystem/filesystem.c
+++ b/src/filesystem/filesystem.c
@@ -4,6 +4,7 @@
 #include <physfs.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "lovr.h"
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
@@ -20,7 +21,13 @@
 
 static FilesystemState state;
 
+bool filesystemAlreadyInit = false;
+
 void lovrFilesystemInit(const char* arg0, const char* arg1) {
+  if (filesystemAlreadyInit) // Do not change settings during a reload, and don't try to initialize PhysFS twice
+    return;
+  filesystemAlreadyInit = true;
+
   if (!PHYSFS_init(arg0)) {
     lovrThrow("Could not initialize filesystem: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
   }

--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
+#include "lovr.h"
 
 static GraphicsState state;
 
@@ -164,8 +165,16 @@ void lovrGraphicsPrepare(Material* material, float* pose) {
   lovrShaderBind(shader);
 }
 
+static bool graphicsAlreadyInit = false;
+
 void lovrGraphicsCreateWindow(int w, int h, bool fullscreen, int msaa, const char* title, const char* icon) {
-  lovrAssert(!state.window, "Window is already created");
+  if (graphicsAlreadyInit) {
+    lovrGraphicsReset();
+    return;
+  } else {
+    lovrAssert(!state.window, "Window is already created");
+    graphicsAlreadyInit = true;
+  }
 
 #ifdef EMSCRIPTEN
   glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);

--- a/src/headset/headset.c
+++ b/src/headset/headset.c
@@ -7,6 +7,7 @@ void lovrControllerDestroy(const Ref* ref) {
 }
 
 static HeadsetInterface* headset = NULL;
+static bool headsetAlreadyInit = false;
 
 void lovrHeadsetInit(HeadsetDriver* drivers, int count) {
   for (int i = 0; i < count; i++) {
@@ -28,9 +29,10 @@ void lovrHeadsetInit(HeadsetDriver* drivers, int count) {
     }
   }
 
-  if (headset) {
+  if (!headsetAlreadyInit && headset) {
     headset->init();
     atexit(lovrHeadsetDestroy);
+    headsetAlreadyInit = true;
   }
 }
 

--- a/src/lib/lua-enet/enet.c
+++ b/src/lib/lua-enet/enet.c
@@ -31,6 +31,7 @@
 #include "lualib.h"
 #include "lauxlib.h"
 #include <enet/enet.h>
+#include <stdbool.h>
 
 #define check_host(l, idx)\
 	*(ENetHost**)luaL_checkudata(l, idx, "enet_host")
@@ -768,9 +769,14 @@ static const struct luaL_Reg enet_peer_funcs [] = {
 	{NULL, NULL}
 };
 
+static bool enitAlreadyInit = false;
+
 int luaopen_enet(lua_State *l) {
 	enet_initialize();
-	atexit(enet_deinitialize);
+	if (!enitAlreadyInit) {
+		atexit(enet_deinitialize);
+		enitAlreadyInit = true;
+	}
 
 	// create metatables
 	luaL_newmetatable(l, "enet_host");

--- a/src/lovr.h
+++ b/src/lovr.h
@@ -1,4 +1,5 @@
 #include "luax.h"
+#include <stdbool.h>
 
 #define LOVR_VERSION_MAJOR 0
 #define LOVR_VERSION_MINOR 9
@@ -7,4 +8,4 @@
 
 void lovrInit(lua_State* L, int argc, char** argv);
 void lovrDestroy(int exitCode);
-void lovrRun(lua_State* L);
+bool lovrRun(lua_State* L); // Returns true to request continue

--- a/src/main.c
+++ b/src/main.c
@@ -1,11 +1,14 @@
 #include "lovr.h"
 
 int main(int argc, char** argv) {
-  lua_State* L = luaL_newstate();
-  luaL_openlibs(L);
+  bool reloading;
+  do {
+	lua_State* L = luaL_newstate();
+	luaL_openlibs(L);
 
-  lovrInit(L, argc, argv);
-  lovrRun(L);
+    lovrInit(L, argc, argv);
+    reloading = lovrRun(L);
+  } while (reloading);
 
   return 0;
 }

--- a/src/math/math.c
+++ b/src/math/math.c
@@ -3,14 +3,19 @@
 #include <math.h>
 #include <stdlib.h>
 #include <time.h>
+#include <stdbool.h>
 
 static RandomGenerator* generator;
+bool mathAlreadyInit = false;
 
 void lovrMathInit() {
   generator = lovrRandomGeneratorCreate();
   Seed seed = { .b64 = (uint64_t) time(0) };
 	lovrRandomGeneratorSetSeed(generator, seed);
-  atexit(lovrMathDestroy);
+  if (!mathAlreadyInit) {
+    atexit(lovrMathDestroy);
+    mathAlreadyInit = true;
+  }
 }
 
 void lovrMathDestroy() {

--- a/src/physics/physics.c
+++ b/src/physics/physics.c
@@ -28,9 +28,15 @@ static void raycastCallback(void* data, dGeomID a, dGeomID b) {
   }
 }
 
+static bool odeAlreadyInit = false;
+
 void lovrPhysicsInit() {
+  if (odeAlreadyInit)
+    return;
+
   dInitODE();
   atexit(lovrPhysicsDestroy);
+  odeAlreadyInit = true;
 }
 
 void lovrPhysicsDestroy() {


### PR DESCRIPTION
This is an alternative to #29. lovr.event.quit and return-from-run() both support the string "restart" in place of an exit code. When this happens, the program reruns itself in a new, isolated environment. In Emscripten, no reboot occurs and the program only quits. If either receive an unexpected value (something other than a number, nil or a string other than "restart") there is an error.

I am making this change with the intent of enabling a feature where lovr auto-restarts on file changes (either in a future PR or in a personal fork I use).

Here is a test program I use to verify it is working.

```
local total = 0

print("BOOT")

function lovr.update(dt)
	total = total + dt
	if total > 5 then
		print("QUIT")
		lovr.event.quit("restart")
	end
end

function lovr.draw()
  lovr.graphics.print('oh wow', 0, 2, -3, .5)
end
```

Concerns I have about the current code:

- There is a mix of init functions handling the reboot by simply tolerating multiple calls and discarding repeat calls; and special-checking the `lovrReloadPending` variable. I am uncertain the `lovrReloadPending` variable should exist (it is an artifact of how #29 did things) and maybe it should be removed.
- Some code duplication between lovrRun and l_lovrEventQuit
- I think there should be some way for a lovr builder/invoker to disable restarts (in case it is some sort of security risk for example?)
- In my recent tests on Windows, when I quit I get an "openAL not shut down!" error. I do not know if this is because of this patch or not and I do not have access to my Windows machine today.