### PR TITLE
remove webvrGetBoundsGeometry reference from webvr.c

### DIFF
--- a/src/headset/webvr.c
+++ b/src/headset/webvr.c
@@ -269,7 +269,6 @@ HeadsetInterface lovrHeadsetWebVRDriver = {
   webvrSetClipDistance,
   webvrGetBoundsWidth,
   webvrGetBoundsDepth,
-  webvrGetBoundsGeometry,
   webvrGetPose,
   webvrGetEyePose,
   webvrGetVelocity,


### PR DESCRIPTION
getBoundsGeometry implementation was dropped with 11586e8
but not in HeadsetInterface.