### PR TITLE
Fix linux build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ elseif(WIN32)
 else()
   pkg_search_module(ODE REQUIRED ode)
   include_directories(${ODE_INCLUDE_DIRS})
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lstdc++")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lstdc++ -lpthread")
   set(LOVR_ODE ode)
 endif()
 


### PR DESCRIPTION
On (arch) linux, compilation would not complete due to the following error:
```/usr/bin/ld: CMakeFiles/lovr.dir/src/lib/tinycthread/tinycthread.c.o: undefined reference to symbol 'pthread_mutexattr_settype@@GLIBC_2.2.5'
/usr/lib/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status```

Adding `-lpthread` to the linker flags fixes this