### PR TITLE
Fix controller button detection for linux and mac

### DIFF
--- a/src/headset/headset.h
+++ b/src/headset/headset.h
@@ -5,6 +5,10 @@
 
 #pragma once
 
+#ifndef WIN32
+#pragma pack(push, 4)
+#endif
+
 typedef enum {
   EYE_LEFT,
   EYE_RIGHT

--- a/src/headset/headset.h
+++ b/src/headset/headset.h
@@ -5,10 +5,6 @@
 
 #pragma once
 
-#ifndef WIN32
-#pragma pack(push, 4)
-#endif
-
 typedef enum {
   EYE_LEFT,
   EYE_RIGHT

--- a/src/headset/openvr.c
+++ b/src/headset/openvr.c
@@ -9,7 +9,13 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#ifndef WIN32
+#pragma pack(push, 4)
+#endif
 #include <openvr_capi.h>
+#ifndef WIN32
+#pragma pack(pop)
+#endif
 
 // From openvr_capi.h
 extern intptr_t VR_InitInternal(EVRInitError *peError, EVRApplicationType eType);


### PR DESCRIPTION
There seems to be a memory alignment issue on linux and mac that causes every button press to be reported as 'system'.
Please see this SteamVR issue for reference:
https://github.com/ValveSoftware/SteamVR-for-Linux/issues/35