### PR TITLE
Fix ControllerButton ordering, which broke isDown

### DIFF
--- a/src/headset/headset.h
+++ b/src/headset/headset.h
@@ -37,7 +37,6 @@ typedef enum {
 } ControllerAxis;
 
 typedef enum {
-  CONTROLLER_BUTTON_UNKNOWN,
   CONTROLLER_BUTTON_SYSTEM,
   CONTROLLER_BUTTON_MENU,
   CONTROLLER_BUTTON_TRIGGER,
@@ -47,7 +46,8 @@ typedef enum {
   CONTROLLER_BUTTON_A,
   CONTROLLER_BUTTON_B,
   CONTROLLER_BUTTON_X,
-  CONTROLLER_BUTTON_Y
+  CONTROLLER_BUTTON_Y,
+  CONTROLLER_BUTTON_UNKNOWN // Must be last item
 } ControllerButton;
 
 typedef enum {


### PR DESCRIPTION
In current lovr master, the first item in the ControllerButtons array (CONTROLLER_BUTTON_UNKNOWN) is NULL, which means luaL_checkoption interprets ControllerButtons as a 0-length array and controller:isDown always fails with an error message like "bad argument #1 to 'isDown' (invalid option 'trigger')"

There are two possible solutions to this

1. Reorder the ControllerButton enum so CONTROLLER_BUTTON_UNKNOWN is last instead of first
2. Add "unknown" to ControllerButtons, which would mean the "unknown" button could be queried (?)

This patch implements solution 1