### PR TITLE
Fix controller:isDown() for 'grip' and 'trigger' on Oculus

### DIFF
--- a/src/headset/oculus.c
+++ b/src/headset/oculus.c
@@ -279,9 +279,9 @@ static int oculusControllerIsDown(Controller* controller, ControllerButton butto
     case CONTROLLER_BUTTON_X: return (relevant & ovrButton_X) > 0;
     case CONTROLLER_BUTTON_Y: return (relevant & ovrButton_Y) > 0;
     case CONTROLLER_BUTTON_MENU: return (relevant & ovrButton_Enter) > 0;
-    case CONTROLLER_BUTTON_TRIGGER: return (relevant & (ovrButton_LShoulder | ovrButton_RShoulder)) > 0;
+    case CONTROLLER_BUTTON_TRIGGER: return is->IndexTriggerNoDeadzone[controller->id] > 0.5f;
     case CONTROLLER_BUTTON_TOUCHPAD: return (relevant & (ovrButton_LThumb | ovrButton_RThumb)) > 0;
-    case CONTROLLER_BUTTON_GRIP: return is->HandTrigger[controller->id] > 0.0f;
+    case CONTROLLER_BUTTON_GRIP: return is->HandTrigger[controller->id] > 0.9f;
     default: return 0;
   }
 }


### PR DESCRIPTION
Consider this test program

```
local function drawText()
  local s = string.format("%d controllers", lovr.headset.getControllerCount()) 
  for i,controller in ipairs(lovr.headset.getControllers()) do
    s = string.format("%s\n%d: TRIG %s GRIP %s PAD %s", s, i,
      controller:isDown("trigger") and "Y" or "N", controller:isDown("grip") and "Y" or "N",
      controller:isDown("touchpad") and "Y" or "N")
    if i == 1 then s = s .. " X " .. (controller:isDown("x") and "Y" or "N") end
    if i == 2 then s = s .. " A " .. (controller:isDown("a") and "Y" or "N") end
  end

  lovr.graphics.print(s, 0, 2, -3, .5)
end
function lovr.draw(eye)
  drawText()
end
```

With current master and this test program, controller:isDown('grip') returns always true, and for 'trigger' false is always returned. This PR adjusts oculusControllerIsDown() to use an axis threshold rather than the Shoulder bit for 'trigger', and to use a more demanding threshold for 'grip' (it was using 0, and oculus was always returning 0.0000001 or something). I don't know if 0.5 is the best threshold for trigger, I picked it arbitrarily