### PR TITLE
Mirror eyes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ build
 /data
 /*.lua
 src/obj
-src/**/Tupfile
+**/Tupfile
+Tuprules.tup
 /watch.sh
 *.glsl
 .DS_Store

--- a/src/api/graphics.c
+++ b/src/api/graphics.c
@@ -796,7 +796,11 @@ static int l_lovrGraphicsStencil(lua_State* L) {
 
 static int l_lovrGraphicsFill(lua_State* L) {
   Texture* texture = lua_isnoneornil(L, 1) ? NULL : luax_checktexture(L, 1);
-  lovrGraphicsFill(texture);
+  float u = luaL_optnumber(L, 2, 0.);
+  float v = luaL_optnumber(L, 3, 0.);
+  float w = luaL_optnumber(L, 4, 1. - u);
+  float h = luaL_optnumber(L, 5, 1. - v);
+  lovrGraphicsFill(texture, u, v, w, h);
   return 0;
 }
 

--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -873,7 +873,7 @@ void lovrGraphicsPrint(const char* str, mat4 transform, float wrap, HorizontalAl
   lovrGraphicsPop();
 }
 
-void lovrGraphicsFill(Texture* texture) {
+void lovrGraphicsFill(Texture* texture, float u, float v, float w, float h) {
   lovrGraphicsPushPipeline();
   lovrGraphicsSetDepthTest(COMPARE_NONE, false);
   lovrGraphicsDraw(&(DrawCommand) {
@@ -883,10 +883,10 @@ void lovrGraphicsFill(Texture* texture) {
     .mode = MESH_TRIANGLE_STRIP,
     .vertex.count = 4,
     .vertex.data = (float[]) {
-      -1, 1, 0,  0, 0, 0, 0, 1,
-      -1, -1, 0, 0, 0, 0, 0, 0,
-      1, 1, 0,   0, 0, 0, 1, 1,
-      1, -1, 0,  0, 0, 0, 1, 0
+      -1, 1, 0,  0, 0, 0, u, v + h,
+      -1, -1, 0, 0, 0, 0, u, v,
+      1, 1, 0,   0, 0, 0, u + w, v + h,
+      1, -1, 0,  0, 0, 0, u + w, v
     }
   });
   lovrGraphicsPopPipeline();

--- a/src/graphics/graphics.h
+++ b/src/graphics/graphics.h
@@ -222,7 +222,7 @@ void lovrGraphicsCylinder(Material* material, float x1, float y1, float z1, floa
 void lovrGraphicsSphere(Material* material, mat4 transform, int segments);
 void lovrGraphicsSkybox(Texture* texture, float angle, float ax, float ay, float az);
 void lovrGraphicsPrint(const char* str, mat4 transform, float wrap, HorizontalAlign halign, VerticalAlign valign);
-void lovrGraphicsFill(Texture* texture);
+void lovrGraphicsFill(Texture* texture, float u, float v, float w, float h);
 #define lovrGraphicsStencil lovrGpuStencil
 #define lovrGraphicsCompute lovrGpuCompute
 

--- a/src/headset/fake.c
+++ b/src/headset/fake.c
@@ -13,6 +13,7 @@
 static struct {
   HeadsetType type;
   bool mirrored;
+  HeadsetEye mirrorEye;
   float offset;
 
   vec_controller_t controllers;
@@ -102,12 +103,14 @@ static bool fakeIsMounted() {
   return true;
 }
 
-static bool fakeIsMirrored() {
-  return state.mirrored;
+static void fakeIsMirrored(bool* mirrored, HeadsetEye* eye) {
+  *mirrored = state.mirrored;
+  *eye = state.mirrorEye;
 }
 
-static void fakeSetMirrored(bool mirror) {
+static void fakeSetMirrored(bool mirror, HeadsetEye eye) {
   state.mirrored = mirror;
+  state.mirrorEye = eye;
 }
 
 static void fakeGetDisplayDimensions(int* width, int* height) {
@@ -209,8 +212,9 @@ static void fakeRenderTo(void (*callback)(void*), void* userdata) {
 
   int width, height;
   fakeGetDisplayDimensions(&width, &height);
-  Camera camera = { .canvas = NULL, .stereo = true };
-  mat4_perspective(camera.projection[0], state.clipNear, state.clipFar, 67 * M_PI / 180., (float) width / 2 / height);
+  bool stereo = state.mirrorEye == EYE_BOTH;
+  Camera camera = { .canvas = NULL, .stereo = stereo };
+  mat4_perspective(camera.projection[0], state.clipNear, state.clipFar, 67 * M_PI / 180., (float) width / (1 + stereo) / height);
   mat4_identity(camera.viewMatrix[0]);
   mat4_translate(camera.viewMatrix[0], 0, state.offset, 0);
   mat4_multiply(camera.viewMatrix[0], state.transform);

--- a/src/headset/headset.h
+++ b/src/headset/headset.h
@@ -6,6 +6,7 @@
 #pragma once
 
 typedef enum {
+  EYE_BOTH = -1,
   EYE_LEFT,
   EYE_RIGHT
 } HeadsetEye;
@@ -70,8 +71,8 @@ typedef struct {
   HeadsetType (*getType)();
   HeadsetOrigin (*getOriginType)();
   bool (*isMounted)();
-  bool (*isMirrored)();
-  void (*setMirrored)(bool mirror);
+  void (*isMirrored)(bool* mirrored, HeadsetEye* eye);
+  void (*setMirrored)(bool mirror, HeadsetEye eye);
   void (*getDisplayDimensions)(int* width, int* height);
   void (*getClipDistance)(float* clipNear, float* clipFar);
   void (*setClipDistance)(float clipNear, float clipFar);

--- a/src/headset/oculus.c
+++ b/src/headset/oculus.c
@@ -12,6 +12,7 @@
 
 typedef struct {
   bool isMirrored;
+  HeadsetEye mirrorEye;
   bool hmdPresent;
   bool needRefreshTracking;
   bool needRefreshButtons;
@@ -99,6 +100,7 @@ static bool oculusInit(float offset, int msaa) {
   state.needRefreshButtons = true;
   state.lastButtonState = 0;
   state.isMirrored = true;
+  state.mirrorEye = EYE_BOTH;
   state.clipNear = 0.1f;
   state.clipFar = 30.f;
 
@@ -159,12 +161,14 @@ static bool oculusIsMounted() {
   return true;
 }
 
-static bool oculusIsMirrored() {
-  return state.isMirrored;
+static void oculusIsMirrored(bool* mirrored, bool* eye) {
+  *mirrored = state.isMirrored;
+  *eye = state.mirrorEye;
 }
 
-static void oculusSetMirrored(bool mirror) {
+static void oculusSetMirrored(bool mirror, HeadsetEye eye) {
   state.isMirrored = mirror;
+  state.mirrorEye = eye;
 }
 
 static void oculusGetDisplayDimensions(int* width, int* height) {
@@ -422,7 +426,11 @@ static void oculusRenderTo(void (*callback)(void*), void* userdata) {
     lovrGraphicsPushPipeline();
     lovrGraphicsSetColor((Color) { 1, 1, 1, 1 });
     lovrGraphicsSetShader(NULL);
-    lovrGraphicsFill(texture);
+    if (state.mirrorEye == EYE_BOTH) {
+      lovrGraphicsFill(texture, 0, 0, 1, 1);
+    } else {
+      lovrGraphicsFill(texture, .5 * state.mirrorEye, 0, .5, 1);
+    }
     lovrGraphicsPopPipeline();
   }
 }

--- a/src/headset/openvr.c
+++ b/src/headset/openvr.c
@@ -28,6 +28,7 @@ static ControllerHand openvrControllerGetHand(Controller* controller);
 typedef struct {
   bool isRendering;
   bool isMirrored;
+  HeadsetEye mirrorEye;
   float offset;
   int msaa;
 
@@ -294,6 +295,7 @@ static bool openvrInit(float offset, int msaa) {
   state.vsyncToPhotons = state.system->GetFloatTrackedDeviceProperty(state.headsetIndex, ETrackedDeviceProperty_Prop_SecondsFromVsyncToPhotons_Float, NULL);
   state.isRendering = false;
   state.isMirrored = true;
+  state.mirrorEye = EYE_BOTH;
   state.offset = state.compositor->GetTrackingSpace() == ETrackingUniverseOrigin_TrackingUniverseStanding ? 0. : offset;
   state.msaa = msaa;
   state.canvas = NULL;
@@ -358,12 +360,14 @@ static bool openvrIsMounted() {
   return (input.ulButtonPressed >> EVRButtonId_k_EButton_ProximitySensor) & 1;
 }
 
-static bool openvrIsMirrored() {
-  return state.isMirrored;
+static void openvrIsMirrored(bool* mirrored, HeadsetEye* eye) {
+  *mirrored = state.isMirrored;
+  *eye = state.mirrorEye;
 }
 
-static void openvrSetMirrored(bool mirror) {
+static void openvrSetMirrored(bool mirror, HeadsetEye eye) {
   state.isMirrored = mirror;
+  state.mirrorEye = eye;
 }
 
 static void openvrGetDisplayDimensions(int* width, int* height) {

--- a/src/headset/openvr.c
+++ b/src/headset/openvr.c
@@ -695,7 +695,11 @@ static void openvrRenderTo(void (*callback)(void*), void* userdata) {
     lovrGraphicsPushPipeline();
     lovrGraphicsSetColor((Color) { 1, 1, 1, 1 });
     lovrGraphicsSetShader(NULL);
-    lovrGraphicsFill(attachments[0].texture);
+    if (state.mirrorEye == EYE_BOTH) {
+      lovrGraphicsFill(attachments[0].texture, 0, 0, 1, 1);
+    } else {
+      lovrGraphicsFill(attachments[0].texture, .5 * state.mirrorEye, 0, .5, 1);
+    }
     lovrGraphicsPopPipeline();
   }
 }

--- a/src/resources/lovr.js
+++ b/src/resources/lovr.js
@@ -20,6 +20,7 @@ var LibraryLOVR = {
       webvr.gamepads = [];
       webvr.lastGamepadState = [];
       webvr.mirrored = true;
+      webvr.mirrorEye = true;
       webvr.offset = offset;
       webvr.controlleradded = added;
       webvr.controllerremoved = removed;
@@ -140,12 +141,14 @@ var LibraryLOVR = {
     return webvr.display.isPresenting;
   },
 
-  webvrIsMirrored: function() {
-    return webvr.mirrored;
+  webvrIsMirrored: function(mirror, eye) {
+    HEAP32[mirror >> 2] = webvr.mirrored;
+    HEAP32[eye >> 2] = webvr.mirrorEye;
   },
 
-  webvrSetMirrored: function(mirror) {
+  webvrSetMirrored: function(mirror, eye) {
     webvr.mirrored = mirror;
+    webvr.mirrorEye = eye;
   },
 
   webvrGetDisplayDimensions: function(width, height) {


### PR DESCRIPTION
Adds the ability to mirror specific eyes.  Convenient for certain situations.  Implementation seems kinda messy, I wish it didn't use 2 variables.

To make it work with OpenVR/Oculus, plan is to add uv offset parameters to `lovrGraphicsFill` and use that to blit half of the Canvas when mirroring (also those parameters will be exposed to Lua).