### PR TITLE
Use alpha to coverage and alpha test for text;

### DIFF
--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -859,15 +859,14 @@ void lovrGraphicsPrint(const char* str, mat4 transform, float wrap, HorizontalAl
   lovrGraphicsMatrixTransform(transform);
   lovrGraphicsScale(scale, scale, scale);
   lovrGraphicsTranslate(0, offsety, 0);
-  lovrGraphicsPushPipeline();
-  state.pipelines[state.pipeline].depthWrite = false;
+  state.pipelines[state.pipeline].alphaCoverage = true;
   lovrGraphicsDraw(&(DrawCommand) {
     .shader = SHADER_FONT,
     .textures[TEXTURE_DIFFUSE] = font->texture,
     .mode = MESH_TRIANGLES,
     .range = { 0, vertexCount }
   });
-  lovrGraphicsPopPipeline();
+  state.pipelines[state.pipeline].alphaCoverage = false;
   lovrGraphicsPop();
 }
 

--- a/src/graphics/graphics.h
+++ b/src/graphics/graphics.h
@@ -93,6 +93,7 @@ typedef struct {
 } Camera;
 
 typedef struct {
+  bool alphaCoverage;
   Color backgroundColor;
   BlendMode blendMode;
   BlendAlphaMode blendAlphaMode;

--- a/src/graphics/opengl.c
+++ b/src/graphics/opengl.c
@@ -47,6 +47,7 @@ typedef enum {
 
 static struct {
   Texture* defaultTexture;
+  bool alphaCoverage;
   BlendMode blendMode;
   BlendAlphaMode blendAlphaMode;
   bool culling;
@@ -628,6 +629,9 @@ void lovrGpuInit(bool srgb, gpuProc (*getProcAddress)(const char*)) {
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
   state.srgb = srgb;
 
+  state.alphaCoverage = false;
+  glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+
   state.blendMode = BLEND_ALPHA;
   state.blendAlphaMode = BLEND_ALPHA_MULTIPLY;
   glBlendEquation(GL_FUNC_ADD);
@@ -680,6 +684,16 @@ void lovrGpuDestroy() {
 }
 
 void lovrGpuBindPipeline(Pipeline* pipeline) {
+
+  // Alpha Coverage
+  if (state.alphaCoverage != pipeline->alphaCoverage) {
+    state.alphaCoverage = pipeline->alphaCoverage;
+    if (state.alphaCoverage) {
+      glEnable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+    } else {
+      glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+    }
+  }
 
   // Blend mode
   if (state.blendMode != pipeline->blendMode || state.blendAlphaMode != pipeline->blendAlphaMode) {

--- a/src/resources/shaders.c
+++ b/src/resources/shaders.c
@@ -137,6 +137,7 @@ const char* lovrFontFragmentShader = ""
 "  float sdf = median(col.r, col.g, col.b); \n"
 "  float w = fwidth(sdf); \n"
 "  float alpha = smoothstep(.5 - w, .5 + w, sdf); \n"
+"  if (alpha <= 0.0) discard; \n"
 "  return vec4(graphicsColor.rgb, graphicsColor.a * alpha); \n"
 "}";
 


### PR DESCRIPTION
This solves problems with transparency and depth testing when rendering fonts, but subtly changes the appearance of rendered text.  I would say that text seems to be a little more "shimmery" when viewed from far away now.  My guess is that the font shader is not antialiasing properly.