### PR TITLE
Optional heap

### DIFF
--- a/src/api/thread.c
+++ b/src/api/thread.c
@@ -69,8 +69,8 @@ int luaopen_lovr_thread(lua_State* L) {
   luaL_register(L, NULL, lovrThreadModule);
   luax_registertype(L, "Thread", lovrThread);
   luax_registertype(L, "Channel", lovrChannel);
-  if (lovrThreadInit()) {
-    luax_atexit(L, lovrThreadDeinit);
+  if (lovrThreadModuleInit()) {
+    luax_atexit(L, lovrThreadModuleDestroy);
   }
   return 1;
 }

--- a/src/audio/microphone.c
+++ b/src/audio/microphone.c
@@ -1,23 +1,14 @@
 #include "audio/microphone.h"
 #include "audio/audio.h"
 
-Microphone* lovrMicrophoneCreate(const char* name, int samples, int sampleRate, int bitDepth, int channelCount) {
-  Microphone* microphone = lovrAlloc(Microphone, lovrMicrophoneDestroy);
-  if (!microphone) return NULL;
-
+Microphone* lovrMicrophoneInit(Microphone* microphone, const char* name, int samples, int sampleRate, int bitDepth, int channelCount) {
   ALCdevice* device = alcCaptureOpenDevice(name, sampleRate, lovrAudioConvertFormat(bitDepth, channelCount), samples);
-
-  if (!device) {
-    free(microphone);
-    return NULL;
-  }
-
+  lovrAssert(device, "Error opening capture device for microphone '%s'", name);
   microphone->device = device;
   microphone->name = name ? name : alcGetString(device, ALC_CAPTURE_DEVICE_SPECIFIER);
   microphone->sampleRate = sampleRate;
   microphone->bitDepth = bitDepth;
   microphone->channelCount = channelCount;
-
   return microphone;
 }
 

--- a/src/audio/microphone.h
+++ b/src/audio/microphone.h
@@ -16,7 +16,8 @@ typedef struct {
   int channelCount;
 } Microphone;
 
-Microphone* lovrMicrophoneCreate(const char* name, int samples, int sampleRate, int bitDepth, int channelCount);
+Microphone* lovrMicrophoneInit(Microphone* microphone, const char* name, int samples, int sampleRate, int bitDepth, int channelCount);
+#define lovrMicrophoneCreate(...) lovrMicrophoneInit(lovrAlloc(Microphone, lovrMicrophoneDestroy), __VA_ARGS__)
 void lovrMicrophoneDestroy(void* ref);
 int lovrMicrophoneGetBitDepth(Microphone* microphone);
 int lovrMicrophoneGetChannelCount(Microphone* microphone);

--- a/src/audio/microphone.h
+++ b/src/audio/microphone.h
@@ -17,7 +17,7 @@ typedef struct {
 } Microphone;
 
 Microphone* lovrMicrophoneInit(Microphone* microphone, const char* name, int samples, int sampleRate, int bitDepth, int channelCount);
-#define lovrMicrophoneCreate(...) lovrMicrophoneInit(lovrAlloc(Microphone, lovrMicrophoneDestroy), __VA_ARGS__)
+#define lovrMicrophoneCreate(...) lovrMicrophoneInit(lovrAlloc(Microphone), __VA_ARGS__)
 void lovrMicrophoneDestroy(void* ref);
 int lovrMicrophoneGetBitDepth(Microphone* microphone);
 int lovrMicrophoneGetChannelCount(Microphone* microphone);

--- a/src/audio/source.c
+++ b/src/audio/source.c
@@ -11,10 +11,7 @@ static ALenum lovrSourceGetState(Source* source) {
   return state;
 }
 
-Source* lovrSourceCreateStatic(SoundData* soundData) {
-  Source* source = lovrAlloc(Source, lovrSourceDestroy);
-  if (!source) return NULL;
-
+Source* lovrSourceInitStatic(Source* source, SoundData* soundData) {
   ALenum format = lovrAudioConvertFormat(soundData->bitDepth, soundData->channelCount);
   source->type = SOURCE_STATIC;
   source->soundData = soundData;
@@ -23,20 +20,15 @@ Source* lovrSourceCreateStatic(SoundData* soundData) {
   alBufferData(source->buffers[0], format, soundData->blob.data, soundData->blob.size, soundData->sampleRate);
   alSourcei(source->id, AL_BUFFER, source->buffers[0]);
   lovrRetain(soundData);
-
   return source;
 }
 
-Source* lovrSourceCreateStream(AudioStream* stream) {
-  Source* source = lovrAlloc(Source, lovrSourceDestroy);
-  if (!source) return NULL;
-
+Source* lovrSourceInitStream(Source* source, AudioStream* stream) {
   source->type = SOURCE_STREAM;
   source->stream = stream;
   alGenSources(1, &source->id);
   alGenBuffers(SOURCE_BUFFERS, source->buffers);
   lovrRetain(stream);
-
   return source;
 }
 

--- a/src/audio/source.h
+++ b/src/audio/source.h
@@ -31,8 +31,8 @@ typedef struct {
 
 Source* lovrSourceInitStatic(Source* source, SoundData* soundData);
 Source* lovrSourceInitStream(Source* source, AudioStream* stream);
-#define lovrSourceCreateStatic(...) lovrSourceInitStatic(lovrAlloc(Source, lovrSourceDestroy), __VA_ARGS__)
-#define lovrSourceCreateStream(...) lovrSourceInitStream(lovrAlloc(Source, lovrSourceDestroy), __VA_ARGS__)
+#define lovrSourceCreateStatic(...) lovrSourceInitStatic(lovrAlloc(Source), __VA_ARGS__)
+#define lovrSourceCreateStream(...) lovrSourceInitStream(lovrAlloc(Source), __VA_ARGS__)
 void lovrSourceDestroy(void* ref);
 SourceType lovrSourceGetType(Source* source);
 int lovrSourceGetBitDepth(Source* source);

--- a/src/audio/source.h
+++ b/src/audio/source.h
@@ -29,8 +29,10 @@ typedef struct {
   bool isLooping;
 } Source;
 
-Source* lovrSourceCreateStatic(SoundData* soundData);
-Source* lovrSourceCreateStream(AudioStream* stream);
+Source* lovrSourceInitStatic(Source* source, SoundData* soundData);
+Source* lovrSourceInitStream(Source* source, AudioStream* stream);
+#define lovrSourceCreateStatic(...) lovrSourceInitStatic(lovrAlloc(Source, lovrSourceDestroy), __VA_ARGS__)
+#define lovrSourceCreateStream(...) lovrSourceInitStream(lovrAlloc(Source, lovrSourceDestroy), __VA_ARGS__)
 void lovrSourceDestroy(void* ref);
 SourceType lovrSourceGetType(Source* source);
 int lovrSourceGetBitDepth(Source* source);

--- a/src/data/audioStream.c
+++ b/src/data/audioStream.c
@@ -3,16 +3,9 @@
 #include "util.h"
 #include <stdlib.h>
 
-AudioStream* lovrAudioStreamCreate(Blob* blob, size_t bufferSize) {
-  AudioStream* stream = lovrAlloc(AudioStream, lovrAudioStreamDestroy);
-  if (!stream) return NULL;
-
+AudioStream* lovrAudioStreamInit(AudioStream* stream, Blob* blob, size_t bufferSize) {
   stb_vorbis* decoder = stb_vorbis_open_memory(blob->data, blob->size, NULL, NULL);
-
-  if (!decoder) {
-    free(stream);
-    return NULL;
-  }
+  lovrAssert(decoder, "Could not create audio stream for '%s'", blob->name);
 
   stb_vorbis_info info = stb_vorbis_get_info(decoder);
 

--- a/src/data/audioStream.h
+++ b/src/data/audioStream.h
@@ -15,7 +15,8 @@ typedef struct {
   Blob* blob;
 } AudioStream;
 
-AudioStream* lovrAudioStreamCreate(Blob* blob, size_t bufferSize);
+AudioStream* lovrAudioStreamInit(AudioStream* stream, Blob* blob, size_t bufferSize);
+#define lovrAudioStreamCreate(...) lovrAudioStreamInit(lovrAlloc(AudioStream, lovrAudioStreamDestroy), __VA_ARGS__)
 void lovrAudioStreamDestroy(void* ref);
 int lovrAudioStreamDecode(AudioStream* stream, short* destination, size_t size);
 void lovrAudioStreamRewind(AudioStream* stream);

--- a/src/data/audioStream.h
+++ b/src/data/audioStream.h
@@ -16,7 +16,7 @@ typedef struct {
 } AudioStream;
 
 AudioStream* lovrAudioStreamInit(AudioStream* stream, Blob* blob, size_t bufferSize);
-#define lovrAudioStreamCreate(...) lovrAudioStreamInit(lovrAlloc(AudioStream, lovrAudioStreamDestroy), __VA_ARGS__)
+#define lovrAudioStreamCreate(...) lovrAudioStreamInit(lovrAlloc(AudioStream), __VA_ARGS__)
 void lovrAudioStreamDestroy(void* ref);
 int lovrAudioStreamDecode(AudioStream* stream, short* destination, size_t size);
 void lovrAudioStreamRewind(AudioStream* stream);

--- a/src/data/blob.c
+++ b/src/data/blob.c
@@ -1,13 +1,9 @@
 #include "data/blob.h"
 
-Blob* lovrBlobCreate(void* data, size_t size, const char* name) {
-  Blob* blob = lovrAlloc(Blob, lovrBlobDestroy);
-  if (!blob) return NULL;
-
+Blob* lovrBlobInit(Blob* blob, void* data, size_t size, const char* name) {
   blob->data = data;
   blob->size = size;
   blob->name = name;
-
   return blob;
 }
 

--- a/src/data/blob.h
+++ b/src/data/blob.h
@@ -12,5 +12,5 @@ typedef struct {
 } Blob;
 
 Blob* lovrBlobInit(Blob* blob, void* data, size_t size, const char* name);
-#define lovrBlobCreate(...) lovrBlobInit(lovrAlloc(Blob, lovrBlobDestroy), __VA_ARGS__)
+#define lovrBlobCreate(...) lovrBlobInit(lovrAlloc(Blob), __VA_ARGS__)
 void lovrBlobDestroy(void* ref);

--- a/src/data/blob.h
+++ b/src/data/blob.h
@@ -11,5 +11,6 @@ typedef struct {
   size_t seek;
 } Blob;
 
-Blob* lovrBlobCreate(void* data, size_t size, const char* name);
+Blob* lovrBlobInit(Blob* blob, void* data, size_t size, const char* name);
+#define lovrBlobCreate(...) lovrBlobInit(lovrAlloc(Blob, lovrBlobDestroy), __VA_ARGS__)
 void lovrBlobDestroy(void* ref);

--- a/src/data/modelData.c
+++ b/src/data/modelData.c
@@ -273,10 +273,7 @@ static void assimpFileClose(struct aiFileIO* io, struct aiFile* assimpFile) {
   free(assimpFile);
 }
 
-ModelData* lovrModelDataCreate(Blob* blob) {
-  ModelData* modelData = lovrAlloc(ModelData, lovrModelDataDestroy);
-  if (!modelData) return NULL;
-
+ModelData* lovrModelDataInit(ModelData* modelData, Blob* blob) {
   struct aiFileIO assimpIO;
   assimpIO.OpenProc = assimpFileOpen;
   assimpIO.CloseProc = assimpFileClose;
@@ -288,10 +285,7 @@ ModelData* lovrModelDataCreate(Blob* blob) {
   unsigned int flags = aiProcessPreset_TargetRealtime_MaxQuality | aiProcess_OptimizeGraph | aiProcess_SplitByBoneCount;
   const struct aiScene* scene = aiImportFileExWithProperties(blob->name, flags, &assimpIO, propertyStore);
   aiReleasePropertyStore(propertyStore);
-
-  if (!scene) {
-    lovrThrow("Unable to load model from '%s': %s\n", blob->name, aiGetErrorString());
-  }
+  lovrAssert(scene, "Unable to load model from '%s': %s", blob->name, aiGetErrorString());
 
   uint32_t vertexCount = 0;
   bool hasNormals = false;
@@ -543,14 +537,10 @@ ModelData* lovrModelDataCreate(Blob* blob) {
 }
 #else
 static void aabbIterator(ModelData* modelData, ModelNode* node, float aabb[6]) {}
-ModelData* lovrModelDataCreate(Blob* blob) {
+ModelData* lovrModelDataInit(ModelData* modelData, Blob* blob) {
   return NULL;
 }
 #endif
-
-ModelData* lovrModelDataCreateEmpty() {
-  return lovrAlloc(ModelData, lovrModelDataDestroy);
-}
 
 void lovrModelDataDestroy(void* ref) {
   ModelData* modelData = ref;

--- a/src/data/modelData.h
+++ b/src/data/modelData.h
@@ -90,6 +90,6 @@ typedef struct {
 } ModelData;
 
 ModelData* lovrModelDataInit(ModelData* modelData, Blob* blob);
-#define lovrModelDataCreate(...) lovrModelDataInit(lovrAlloc(ModelData, lovrModelDataDestroy), __VA_ARGS__)
+#define lovrModelDataCreate(...) lovrModelDataInit(lovrAlloc(ModelData), __VA_ARGS__)
 void lovrModelDataDestroy(void* ref);
 void lovrModelDataGetAABB(ModelData* modelData, float aabb[6]);

--- a/src/data/modelData.h
+++ b/src/data/modelData.h
@@ -89,7 +89,7 @@ typedef struct {
   int materialCount;
 } ModelData;
 
-ModelData* lovrModelDataCreate(Blob* blob);
-ModelData* lovrModelDataCreateEmpty();
+ModelData* lovrModelDataInit(ModelData* modelData, Blob* blob);
+#define lovrModelDataCreate(...) lovrModelDataInit(lovrAlloc(ModelData, lovrModelDataDestroy), __VA_ARGS__)
 void lovrModelDataDestroy(void* ref);
 void lovrModelDataGetAABB(ModelData* modelData, float aabb[6]);

--- a/src/data/rasterizer.c
+++ b/src/data/rasterizer.c
@@ -5,10 +5,7 @@
 #include "msdfgen-c.h"
 #include <math.h>
 
-Rasterizer* lovrRasterizerCreate(Blob* blob, int size) {
-  Rasterizer* rasterizer = lovrAlloc(Rasterizer, lovrRasterizerDestroy);
-  if (!rasterizer) return NULL;
-
+Rasterizer* lovrRasterizerInit(Rasterizer* rasterizer, Blob* blob, int size) {
   stbtt_fontinfo* font = &rasterizer->font;
   unsigned char* data = blob ? blob->data : VarelaRound_ttf;
   if (!stbtt_InitFont(font, data, stbtt_GetFontOffsetForIndex(data, 0))) {

--- a/src/data/rasterizer.h
+++ b/src/data/rasterizer.h
@@ -39,7 +39,7 @@ typedef struct {
 typedef map_t(Glyph) map_glyph_t;
 
 Rasterizer* lovrRasterizerInit(Rasterizer* rasterizer, Blob* blob, int size);
-#define lovrRasterizerCreate(...) lovrRasterizerInit(lovrAlloc(Rasterizer, lovrRasterizerDestroy), __VA_ARGS__)
+#define lovrRasterizerCreate(...) lovrRasterizerInit(lovrAlloc(Rasterizer), __VA_ARGS__)
 void lovrRasterizerDestroy(void* ref);
 bool lovrRasterizerHasGlyph(Rasterizer* fontData, uint32_t character);
 bool lovrRasterizerHasGlyphs(Rasterizer* fontData, const char* str);

--- a/src/data/rasterizer.h
+++ b/src/data/rasterizer.h
@@ -38,7 +38,8 @@ typedef struct {
 
 typedef map_t(Glyph) map_glyph_t;
 
-Rasterizer* lovrRasterizerCreate(Blob* blob, int size);
+Rasterizer* lovrRasterizerInit(Rasterizer* rasterizer, Blob* blob, int size);
+#define lovrRasterizerCreate(...) lovrRasterizerInit(lovrAlloc(Rasterizer, lovrRasterizerDestroy), __VA_ARGS__)
 void lovrRasterizerDestroy(void* ref);
 bool lovrRasterizerHasGlyph(Rasterizer* fontData, uint32_t character);
 bool lovrRasterizerHasGlyphs(Rasterizer* fontData, const char* str);

--- a/src/data/soundData.c
+++ b/src/data/soundData.c
@@ -2,24 +2,17 @@
 #include "lib/stb/stb_vorbis.h"
 #include <limits.h>
 
-SoundData* lovrSoundDataCreate(int samples, int sampleRate, int bitDepth, int channelCount) {
-  SoundData* soundData = lovrAlloc(SoundData, lovrSoundDataDestroy);
-  if (!soundData) return NULL;
-
+SoundData* lovrSoundDataInit(SoundData* soundData, int samples, int sampleRate, int bitDepth, int channelCount) {
   soundData->samples = samples;
   soundData->sampleRate = sampleRate;
   soundData->bitDepth = bitDepth;
   soundData->channelCount = channelCount;
   soundData->blob.size = samples * channelCount * (bitDepth / 8);
   soundData->blob.data = calloc(1, soundData->blob.size);
-
   return soundData;
 }
 
-SoundData* lovrSoundDataCreateFromAudioStream(AudioStream* audioStream) {
-  SoundData* soundData = lovrAlloc(SoundData, lovrSoundDataDestroy);
-  if (!soundData) return NULL;
-
+SoundData* lovrSoundDataInitFromAudioStream(SoundData* soundData, AudioStream* audioStream) {
   soundData->samples = audioStream->samples;
   soundData->sampleRate = audioStream->sampleRate;
   soundData->bitDepth = audioStream->bitDepth;
@@ -38,14 +31,10 @@ SoundData* lovrSoundDataCreateFromAudioStream(AudioStream* audioStream) {
   return soundData;
 }
 
-SoundData* lovrSoundDataCreateFromBlob(Blob* blob) {
-  SoundData* soundData = lovrAlloc(SoundData, lovrSoundDataDestroy);
-  if (!soundData) return NULL;
-
+SoundData* lovrSoundDataInitFromBlob(SoundData* soundData, Blob* blob) {
   soundData->bitDepth = 16;
   soundData->samples = stb_vorbis_decode_memory(blob->data, blob->size, &soundData->channelCount, &soundData->sampleRate, (short**) &soundData->blob.data);
   soundData->blob.size = soundData->samples * soundData->channelCount * (soundData->bitDepth / 8);
-
   return soundData;
 }
 

--- a/src/data/soundData.h
+++ b/src/data/soundData.h
@@ -14,9 +14,9 @@ typedef struct {
 SoundData* lovrSoundDataInit(SoundData* soundData, int samples, int sampleRate, int bitDepth, int channels);
 SoundData* lovrSoundDataInitFromAudioStream(SoundData* soundData, AudioStream* audioStream);
 SoundData* lovrSoundDataInitFromBlob(SoundData* soundData, Blob* blob);
-#define lovrSoundDataCreate(...) lovrSoundDataInit(lovrAlloc(SoundData, lovrSoundDataDestroy), __VA_ARGS__)
-#define lovrSoundDataCreateFromAudioStream(...) lovrSoundDataInitFromAudioStream(lovrAlloc(SoundData, lovrSoundDataDestroy), __VA_ARGS__)
-#define lovrSoundDataCreateFromBlob(...) lovrSoundDataInitFromBlob(lovrAlloc(SoundData, lovrSoundDataDestroy), __VA_ARGS__)
+#define lovrSoundDataCreate(...) lovrSoundDataInit(lovrAlloc(SoundData), __VA_ARGS__)
+#define lovrSoundDataCreateFromAudioStream(...) lovrSoundDataInitFromAudioStream(lovrAlloc(SoundData), __VA_ARGS__)
+#define lovrSoundDataCreateFromBlob(...) lovrSoundDataInitFromBlob(lovrAlloc(SoundData), __VA_ARGS__)
 float lovrSoundDataGetSample(SoundData* soundData, int index);
 void lovrSoundDataSetSample(SoundData* soundData, int index, float value);
 void lovrSoundDataDestroy(void* ref);

--- a/src/data/soundData.h
+++ b/src/data/soundData.h
@@ -11,9 +11,12 @@ typedef struct {
   int bitDepth;
 } SoundData;
 
-SoundData* lovrSoundDataCreate(int samples, int sampleRate, int bitDepth, int channels);
-SoundData* lovrSoundDataCreateFromAudioStream(AudioStream* audioStream);
-SoundData* lovrSoundDataCreateFromBlob(Blob* blob);
+SoundData* lovrSoundDataInit(SoundData* soundData, int samples, int sampleRate, int bitDepth, int channels);
+SoundData* lovrSoundDataInitFromAudioStream(SoundData* soundData, AudioStream* audioStream);
+SoundData* lovrSoundDataInitFromBlob(SoundData* soundData, Blob* blob);
+#define lovrSoundDataCreate(...) lovrSoundDataInit(lovrAlloc(SoundData, lovrSoundDataDestroy), __VA_ARGS__)
+#define lovrSoundDataCreateFromAudioStream(...) lovrSoundDataInitFromAudioStream(lovrAlloc(SoundData, lovrSoundDataDestroy), __VA_ARGS__)
+#define lovrSoundDataCreateFromBlob(...) lovrSoundDataInitFromBlob(lovrAlloc(SoundData, lovrSoundDataDestroy), __VA_ARGS__)
 float lovrSoundDataGetSample(SoundData* soundData, int index);
 void lovrSoundDataSetSample(SoundData* soundData, int index, float value);
 void lovrSoundDataDestroy(void* ref);

--- a/src/data/textureData.c
+++ b/src/data/textureData.c
@@ -112,10 +112,7 @@ static int parseDDS(uint8_t* data, size_t size, TextureData* textureData) {
   return 0;
 }
 
-TextureData* lovrTextureDataCreate(int width, int height, uint8_t value, TextureFormat format) {
-  TextureData* textureData = lovrAlloc(TextureData, lovrTextureDataDestroy);
-  if (!textureData) return NULL;
-
+TextureData* lovrTextureDataInit(TextureData* textureData, int width, int height, uint8_t value, TextureFormat format) {
   size_t pixelSize = 0;
   switch (format) {
     case FORMAT_RGB: pixelSize = 3; break;
@@ -152,10 +149,7 @@ TextureData* lovrTextureDataCreate(int width, int height, uint8_t value, Texture
   return textureData;
 }
 
-TextureData* lovrTextureDataCreateFromBlob(Blob* blob, bool flip) {
-  TextureData* textureData = lovrAlloc(TextureData, lovrTextureDataDestroy);
-  if (!textureData) return NULL;
-
+TextureData* lovrTextureDataInitFromBlob(TextureData* textureData, Blob* blob, bool flip) {
   vec_init(&textureData->mipmaps);
 
   if (!parseDDS(blob->data, blob->size, textureData)) {

--- a/src/data/textureData.h
+++ b/src/data/textureData.h
@@ -47,8 +47,8 @@ typedef struct {
 
 TextureData* lovrTextureDataInit(TextureData* textureData, int width, int height, uint8_t value, TextureFormat format);
 TextureData* lovrTextureDataInitFromBlob(TextureData* textureData, Blob* blob, bool flip);
-#define lovrTextureDataCreate(...) lovrTextureDataInit(lovrAlloc(TextureData, lovrTextureDataDestroy), __VA_ARGS__)
-#define lovrTextureDataCreateFromBlob(...) lovrTextureDataInitFromBlob(lovrAlloc(TextureData, lovrTextureDataDestroy), __VA_ARGS__)
+#define lovrTextureDataCreate(...) lovrTextureDataInit(lovrAlloc(TextureData), __VA_ARGS__)
+#define lovrTextureDataCreateFromBlob(...) lovrTextureDataInitFromBlob(lovrAlloc(TextureData), __VA_ARGS__)
 Color lovrTextureDataGetPixel(TextureData* textureData, int x, int y);
 void lovrTextureDataSetPixel(TextureData* textureData, int x, int y, Color color);
 bool lovrTextureDataEncode(TextureData* textureData, const char* filename);

--- a/src/data/textureData.h
+++ b/src/data/textureData.h
@@ -45,8 +45,10 @@ typedef struct {
   vec_mipmap_t mipmaps;
 } TextureData;
 
-TextureData* lovrTextureDataCreate(int width, int height, uint8_t value, TextureFormat format);
-TextureData* lovrTextureDataCreateFromBlob(Blob* blob, bool flip);
+TextureData* lovrTextureDataInit(TextureData* textureData, int width, int height, uint8_t value, TextureFormat format);
+TextureData* lovrTextureDataInitFromBlob(TextureData* textureData, Blob* blob, bool flip);
+#define lovrTextureDataCreate(...) lovrTextureDataInit(lovrAlloc(TextureData, lovrTextureDataDestroy), __VA_ARGS__)
+#define lovrTextureDataCreateFromBlob(...) lovrTextureDataInitFromBlob(lovrAlloc(TextureData, lovrTextureDataDestroy), __VA_ARGS__)
 Color lovrTextureDataGetPixel(TextureData* textureData, int x, int y);
 void lovrTextureDataSetPixel(TextureData* textureData, int x, int y, Color color);
 bool lovrTextureDataEncode(TextureData* textureData, const char* filename);

--- a/src/data/vertexData.c
+++ b/src/data/vertexData.c
@@ -14,10 +14,7 @@ void vertexFormatAppend(VertexFormat* format, const char* name, AttributeType ty
   format->stride += size * count;
 }
 
-VertexData* lovrVertexDataCreate(uint32_t count, VertexFormat* format) {
-  VertexData* vertexData = lovrAlloc(VertexData, lovrBlobDestroy);
-  if (!vertexData) return NULL;
-
+VertexData* lovrVertexDataInit(VertexData* vertexData, uint32_t count, VertexFormat* format) {
   if (format) {
     vertexData->format = *format;
   } else {

--- a/src/data/vertexData.h
+++ b/src/data/vertexData.h
@@ -47,5 +47,5 @@ void vertexFormatInit(VertexFormat* format);
 void vertexFormatAppend(VertexFormat* format, const char* name, AttributeType type, int count);
 
 VertexData* lovrVertexDataInit(VertexData* vertexData, uint32_t count, VertexFormat* format);
-#define lovrVertexDataCreate(...) lovrVertexDataInit(lovrAlloc(VertexData, lovrVertexDataDestroy), __VA_ARGS__)
+#define lovrVertexDataCreate(...) lovrVertexDataInit(lovrAlloc(VertexData), __VA_ARGS__)
 #define lovrVertexDataDestroy lovrBlobDestroy

--- a/src/data/vertexData.h
+++ b/src/data/vertexData.h
@@ -46,4 +46,6 @@ typedef struct {
 void vertexFormatInit(VertexFormat* format);
 void vertexFormatAppend(VertexFormat* format, const char* name, AttributeType type, int count);
 
-VertexData* lovrVertexDataCreate(uint32_t count, VertexFormat* format);
+VertexData* lovrVertexDataInit(VertexData* vertexData, uint32_t count, VertexFormat* format);
+#define lovrVertexDataCreate(...) lovrVertexDataInit(lovrAlloc(VertexData, lovrVertexDataDestroy), __VA_ARGS__)
+#define lovrVertexDataDestroy lovrBlobDestroy

--- a/src/filesystem/file.c
+++ b/src/filesystem/file.c
@@ -2,12 +2,8 @@
 #include <physfs.h>
 #include <stdlib.h>
 
-File* lovrFileCreate(const char* path) {
-  File* file = lovrAlloc(File, lovrFileDestroy);
-  if (!file) return NULL;
-
+File* lovrFileInit(File* file ,const char* path) {
   file->path = path;
-
   return file;
 }
 

--- a/src/filesystem/file.h
+++ b/src/filesystem/file.h
@@ -16,7 +16,7 @@ typedef struct {
 } File;
 
 File* lovrFileInit(File* file, const char* filename);
-#define lovrFileCreate(...) lovrFileInit(lovrAlloc(File, lovrFileDestroy), __VA_ARGS__)
+#define lovrFileCreate(...) lovrFileInit(lovrAlloc(File), __VA_ARGS__)
 void lovrFileDestroy(void* ref);
 int lovrFileOpen(File* file, FileMode mode);
 void lovrFileClose(File* file);

--- a/src/filesystem/file.h
+++ b/src/filesystem/file.h
@@ -15,7 +15,8 @@ typedef struct {
   FileMode mode;
 } File;
 
-File* lovrFileCreate(const char* filename);
+File* lovrFileInit(File* file, const char* filename);
+#define lovrFileCreate(...) lovrFileInit(lovrAlloc(File, lovrFileDestroy), __VA_ARGS__)
 void lovrFileDestroy(void* ref);
 int lovrFileOpen(File* file, FileMode mode);
 void lovrFileClose(File* file);

--- a/src/graphics/animator.c
+++ b/src/graphics/animator.c
@@ -12,10 +12,7 @@ static int trackSortCallback(const void* a, const void* b) {
   return ((Track*) a)->priority < ((Track*) b)->priority;
 }
 
-Animator* lovrAnimatorCreate(ModelData* modelData) {
-  Animator* animator = lovrAlloc(Animator, lovrAnimatorDestroy);
-  if (!animator) return NULL;
-
+Animator* lovrAnimatorInit(Animator* animator, ModelData* modelData) {
   lovrRetain(modelData);
   animator->modelData = modelData;
   map_init(&animator->trackMap);

--- a/src/graphics/animator.h
+++ b/src/graphics/animator.h
@@ -27,7 +27,8 @@ typedef struct {
   float speed;
 } Animator;
 
-Animator* lovrAnimatorCreate(ModelData* modelData);
+Animator* lovrAnimatorInit(Animator* animator, ModelData* modelData);
+#define lovrAnimatorCreate(...) lovrAnimatorInit(lovrAlloc(Animator, lovrAnimatorDestroy), __VA_ARGS__)
 void lovrAnimatorDestroy(void* ref);
 void lovrAnimatorReset(Animator* animator);
 void lovrAnimatorUpdate(Animator* animator, float dt);

--- a/src/graphics/animator.h
+++ b/src/graphics/animator.h
@@ -28,7 +28,7 @@ typedef struct {
 } Animator;
 
 Animator* lovrAnimatorInit(Animator* animator, ModelData* modelData);
-#define lovrAnimatorCreate(...) lovrAnimatorInit(lovrAlloc(Animator, lovrAnimatorDestroy), __VA_ARGS__)
+#define lovrAnimatorCreate(...) lovrAnimatorInit(lovrAlloc(Animator), __VA_ARGS__)
 void lovrAnimatorDestroy(void* ref);
 void lovrAnimatorReset(Animator* animator);
 void lovrAnimatorUpdate(Animator* animator, float dt);

--- a/src/graphics/buffer.h
+++ b/src/graphics/buffer.h
@@ -17,7 +17,8 @@ typedef struct {
   GPU_BUFFER_FIELDS
 } Buffer;
 
-Buffer* lovrBufferCreate(size_t size, void* data, BufferUsage usage, bool readable);
+Buffer* lovrBufferInit(Buffer* buffer, size_t size, void* data, BufferUsage usage, bool readable);
+#define lovrBufferCreate(...) lovrBufferInit(lovrAlloc(Buffer, lovrBufferDestroy), __VA_ARGS__)
 void lovrBufferDestroy(void* ref);
 size_t lovrBufferGetSize(Buffer* buffer);
 BufferUsage lovrBufferGetUsage(Buffer* buffer);

--- a/src/graphics/buffer.h
+++ b/src/graphics/buffer.h
@@ -18,7 +18,7 @@ typedef struct {
 } Buffer;
 
 Buffer* lovrBufferInit(Buffer* buffer, size_t size, void* data, BufferUsage usage, bool readable);
-#define lovrBufferCreate(...) lovrBufferInit(lovrAlloc(Buffer, lovrBufferDestroy), __VA_ARGS__)
+#define lovrBufferCreate(...) lovrBufferInit(lovrAlloc(Buffer), __VA_ARGS__)
 void lovrBufferDestroy(void* ref);
 size_t lovrBufferGetSize(Buffer* buffer);
 BufferUsage lovrBufferGetUsage(Buffer* buffer);

--- a/src/graphics/buffer.h
+++ b/src/graphics/buffer.h
@@ -1,3 +1,4 @@
+#include "graphics/opengl.h"
 #include <stdlib.h>
 
 #pragma once
@@ -8,7 +9,13 @@ typedef enum {
   USAGE_STREAM
 } BufferUsage;
 
-typedef struct Buffer Buffer;
+typedef struct {
+  Ref ref;
+  void* data;
+  size_t size;
+  BufferUsage usage;
+  GPU_BUFFER_FIELDS
+} Buffer;
 
 Buffer* lovrBufferCreate(size_t size, void* data, BufferUsage usage, bool readable);
 void lovrBufferDestroy(void* ref);

--- a/src/graphics/canvas.h
+++ b/src/graphics/canvas.h
@@ -37,8 +37,8 @@ typedef struct {
 
 Canvas* lovrCanvasInit(Canvas* canvas, int width, int height, CanvasFlags flags);
 Canvas* lovrCanvasInitFromHandle(Canvas* canvas, int width, int height, CanvasFlags flags, uint32_t framebuffer, uint32_t depthBuffer, uint32_t resolveBuffer, int attachmentCount, bool immortal);
-#define lovrCanvasCreate(...) lovrCanvasInit(lovrAlloc(Canvas, lovrCanvasDestroy), __VA_ARGS__)
-#define lovrCanvasCreateFromHandle(...) lovrCanvasInitFromHandle(lovrAlloc(Canvas, lovrCanvasDestroy), __VA_ARGS__)
+#define lovrCanvasCreate(...) lovrCanvasInit(lovrAlloc(Canvas), __VA_ARGS__)
+#define lovrCanvasCreateFromHandle(...) lovrCanvasInitFromHandle(lovrAlloc(Canvas), __VA_ARGS__)
 void lovrCanvasDestroy(void* ref);
 const Attachment* lovrCanvasGetAttachments(Canvas* canvas, int* count);
 void lovrCanvasSetAttachments(Canvas* canvas, Attachment* attachments, int count);

--- a/src/graphics/canvas.h
+++ b/src/graphics/canvas.h
@@ -1,4 +1,5 @@
 #include "graphics/texture.h"
+#include "graphics/opengl.h"
 
 #pragma once
 
@@ -21,7 +22,18 @@ typedef struct {
   bool mipmaps;
 } CanvasFlags;
 
-typedef struct Canvas Canvas;
+typedef struct {
+  Ref ref;
+  int width;
+  int height;
+  CanvasFlags flags;
+  Attachment attachments[MAX_CANVAS_ATTACHMENTS];
+  Attachment depth;
+  int attachmentCount;
+  bool needsAttach;
+  bool needsResolve;
+  GPU_CANVAS_FIELDS
+} Canvas;
 
 Canvas* lovrCanvasCreate(int width, int height, CanvasFlags flags);
 Canvas* lovrCanvasCreateFromHandle(int width, int height, CanvasFlags flags, uint32_t framebuffer, uint32_t depthBuffer, uint32_t resolveBuffer, int attachmentCount, bool immortal);

--- a/src/graphics/canvas.h
+++ b/src/graphics/canvas.h
@@ -35,8 +35,10 @@ typedef struct {
   GPU_CANVAS_FIELDS
 } Canvas;
 
-Canvas* lovrCanvasCreate(int width, int height, CanvasFlags flags);
-Canvas* lovrCanvasCreateFromHandle(int width, int height, CanvasFlags flags, uint32_t framebuffer, uint32_t depthBuffer, uint32_t resolveBuffer, int attachmentCount, bool immortal);
+Canvas* lovrCanvasInit(Canvas* canvas, int width, int height, CanvasFlags flags);
+Canvas* lovrCanvasInitFromHandle(Canvas* canvas, int width, int height, CanvasFlags flags, uint32_t framebuffer, uint32_t depthBuffer, uint32_t resolveBuffer, int attachmentCount, bool immortal);
+#define lovrCanvasCreate(...) lovrCanvasInit(lovrAlloc(Canvas, lovrCanvasDestroy), __VA_ARGS__)
+#define lovrCanvasCreateFromHandle(...) lovrCanvasInitFromHandle(lovrAlloc(Canvas, lovrCanvasDestroy), __VA_ARGS__)
 void lovrCanvasDestroy(void* ref);
 const Attachment* lovrCanvasGetAttachments(Canvas* canvas, int* count);
 void lovrCanvasSetAttachments(Canvas* canvas, Attachment* attachments, int count);

--- a/src/graphics/font.c
+++ b/src/graphics/font.c
@@ -23,10 +23,7 @@ static float* lovrFontAlignLine(float* x, float* lineEnd, float width, Horizonta
   return x;
 }
 
-Font* lovrFontCreate(Rasterizer* rasterizer) {
-  Font* font = lovrAlloc(Font, lovrFontDestroy);
-  if (!font) return NULL;
-
+Font* lovrFontInit(Font* font, Rasterizer* rasterizer) {
   lovrRetain(rasterizer);
   font->rasterizer = rasterizer;
   font->lineHeight = 1.f;

--- a/src/graphics/font.h
+++ b/src/graphics/font.h
@@ -39,7 +39,7 @@ typedef struct {
 } Font;
 
 Font* lovrFontInit(Font* font, Rasterizer* rasterizer);
-#define lovrFontCreate(...) lovrFontInit(lovrAlloc(Font, lovrFontDestroy), __VA_ARGS__)
+#define lovrFontCreate(...) lovrFontInit(lovrAlloc(Font), __VA_ARGS__)
 void lovrFontDestroy(void* ref);
 Rasterizer* lovrFontGetRasterizer(Font* font);
 void lovrFontRender(Font* font, const char* str, float wrap, HorizontalAlign halign, VerticalAlign valign, float* vertices, float* offsety, uint32_t* vertexCount);

--- a/src/graphics/font.h
+++ b/src/graphics/font.h
@@ -38,7 +38,8 @@ typedef struct {
   float pixelDensity;
 } Font;
 
-Font* lovrFontCreate(Rasterizer* rasterizer);
+Font* lovrFontInit(Font* font, Rasterizer* rasterizer);
+#define lovrFontCreate(...) lovrFontInit(lovrAlloc(Font, lovrFontDestroy), __VA_ARGS__)
 void lovrFontDestroy(void* ref);
 Rasterizer* lovrFontGetRasterizer(Font* font);
 void lovrFontRender(Font* font, const char* str, float wrap, HorizontalAlign halign, VerticalAlign valign, float* vertices, float* offsety, uint32_t* vertexCount);

--- a/src/graphics/material.c
+++ b/src/graphics/material.c
@@ -3,10 +3,7 @@
 #include <math.h>
 #include <stdlib.h>
 
-Material* lovrMaterialCreate() {
-  Material* material = lovrAlloc(Material, lovrMaterialDestroy);
-  if (!material) return NULL;
-
+Material* lovrMaterialInit(Material* material) {
   for (int i = 0; i < MAX_MATERIAL_SCALARS; i++) {
     material->scalars[i] = 1.f;
   }
@@ -20,7 +17,6 @@ Material* lovrMaterialCreate() {
   }
 
   lovrMaterialSetTransform(material, 0, 0, 1, 1, 0);
-
   return material;
 }
 

--- a/src/graphics/material.h
+++ b/src/graphics/material.h
@@ -37,7 +37,8 @@ typedef struct {
   bool dirty;
 } Material;
 
-Material* lovrMaterialCreate();
+Material* lovrMaterialInit(Material* material);
+#define lovrMaterialCreate() lovrMaterialInit(lovrAlloc(Material, lovrMaterialDestroy))
 void lovrMaterialDestroy(void* ref);
 void lovrMaterialBind(Material* material, Shader* shader);
 bool lovrMaterialIsDirty(Material* material);

--- a/src/graphics/material.h
+++ b/src/graphics/material.h
@@ -38,7 +38,7 @@ typedef struct {
 } Material;
 
 Material* lovrMaterialInit(Material* material);
-#define lovrMaterialCreate() lovrMaterialInit(lovrAlloc(Material, lovrMaterialDestroy))
+#define lovrMaterialCreate() lovrMaterialInit(lovrAlloc(Material))
 void lovrMaterialDestroy(void* ref);
 void lovrMaterialBind(Material* material, Shader* shader);
 bool lovrMaterialIsDirty(Material* material);

--- a/src/graphics/mesh.h
+++ b/src/graphics/mesh.h
@@ -54,7 +54,7 @@ typedef struct {
 } Mesh;
 
 Mesh* lovrMeshInit(Mesh* mesh, uint32_t count, VertexFormat format, DrawMode drawMode, BufferUsage usage, bool readable);
-#define lovrMeshCreate(...) lovrMeshInit(lovrAlloc(Mesh, lovrMeshDestroy), __VA_ARGS__)
+#define lovrMeshCreate(...) lovrMeshInit(lovrAlloc(Mesh), __VA_ARGS__)
 void lovrMeshDestroy(void* ref);
 void lovrMeshAttachAttribute(Mesh* mesh, const char* name, MeshAttribute* attribute);
 void lovrMeshDetachAttribute(Mesh* mesh, const char* name);

--- a/src/graphics/mesh.h
+++ b/src/graphics/mesh.h
@@ -53,7 +53,8 @@ typedef struct {
   GPU_MESH_FIELDS
 } Mesh;
 
-Mesh* lovrMeshCreate(uint32_t count, VertexFormat format, DrawMode drawMode, BufferUsage usage, bool readable);
+Mesh* lovrMeshInit(Mesh* mesh, uint32_t count, VertexFormat format, DrawMode drawMode, BufferUsage usage, bool readable);
+#define lovrMeshCreate(...) lovrMeshInit(lovrAlloc(Mesh, lovrMeshDestroy), __VA_ARGS__)
 void lovrMeshDestroy(void* ref);
 void lovrMeshAttachAttribute(Mesh* mesh, const char* name, MeshAttribute* attribute);
 void lovrMeshDetachAttribute(Mesh* mesh, const char* name);

--- a/src/graphics/mesh.h
+++ b/src/graphics/mesh.h
@@ -1,5 +1,6 @@
 #include "graphics/material.h"
 #include "graphics/shader.h"
+#include "graphics/opengl.h"
 #include "data/vertexData.h"
 #include "lib/map/map.h"
 #include <stdbool.h>
@@ -31,7 +32,26 @@ typedef enum {
   DRAW_TRIANGLE_FAN
 } DrawMode;
 
-typedef struct Mesh Mesh;
+typedef struct {
+  Ref ref;
+  uint32_t count;
+  DrawMode mode;
+  VertexFormat format;
+  bool readable;
+  bool dirty;
+  BufferUsage usage;
+  Buffer* vbo;
+  Buffer* ibo;
+  uint32_t indexCount;
+  size_t indexSize;
+  size_t indexCapacity;
+  uint32_t rangeStart;
+  uint32_t rangeCount;
+  Material* material;
+  map_attribute_t attributes;
+  MeshAttribute layout[MAX_ATTRIBUTES];
+  GPU_MESH_FIELDS
+} Mesh;
 
 Mesh* lovrMeshCreate(uint32_t count, VertexFormat format, DrawMode drawMode, BufferUsage usage, bool readable);
 void lovrMeshDestroy(void* ref);

--- a/src/graphics/model.c
+++ b/src/graphics/model.c
@@ -54,10 +54,7 @@ static void renderNode(Model* model, int nodeIndex, int instances) {
   }
 }
 
-Model* lovrModelCreate(ModelData* modelData) {
-  Model* model = lovrAlloc(Model, lovrModelDestroy);
-  if (!model) return NULL;
-
+Model* lovrModelInit(Model* model, ModelData* modelData) {
   lovrRetain(modelData);
   model->modelData = modelData;
   model->aabbDirty = true;

--- a/src/graphics/model.h
+++ b/src/graphics/model.h
@@ -23,7 +23,8 @@ typedef struct {
   bool aabbDirty;
 } Model;
 
-Model* lovrModelCreate(ModelData* modelData);
+Model* lovrModelInit(Model* model, ModelData* modelData);
+#define lovrModelCreate(...) lovrModelInit(lovrAlloc(Model, lovrModelDestroy), __VA_ARGS__)
 void lovrModelDestroy(void* ref);
 void lovrModelDraw(Model* model, mat4 transform, int instances);
 Animator* lovrModelGetAnimator(Model* model);

--- a/src/graphics/model.h
+++ b/src/graphics/model.h
@@ -24,7 +24,7 @@ typedef struct {
 } Model;
 
 Model* lovrModelInit(Model* model, ModelData* modelData);
-#define lovrModelCreate(...) lovrModelInit(lovrAlloc(Model, lovrModelDestroy), __VA_ARGS__)
+#define lovrModelCreate(...) lovrModelInit(lovrAlloc(Model), __VA_ARGS__)
 void lovrModelDestroy(void* ref);
 void lovrModelDraw(Model* model, mat4 transform, int instances);
 Animator* lovrModelGetAnimator(Model* model);

--- a/src/graphics/opengl.c
+++ b/src/graphics/opengl.c
@@ -1,3 +1,4 @@
+#include "graphics/opengl.h"
 #include "graphics/graphics.h"
 #include "graphics/buffer.h"
 #include "graphics/canvas.h"
@@ -13,15 +14,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-
-#if EMSCRIPTEN
-#include <GLES3/gl3.h>
-#include <GLES2/gl2ext.h>
-#include <GL/gl.h>
-#include <GL/glext.h>
-#else
-#include "lib/glad/glad.h"
-#endif
 
 // Types
 
@@ -79,94 +71,6 @@ static struct {
   GpuLimits limits;
   GpuStats stats;
 } state;
-
-struct Buffer {
-  Ref ref;
-  void* data;
-  size_t size;
-  GLsync lock;
-  uint32_t id;
-  BufferUsage usage;
-};
-
-struct ShaderBlock {
-  Ref ref;
-  BlockType type;
-  vec_uniform_t uniforms;
-  map_int_t uniformMap;
-  Buffer* buffer;
-  GLenum target;
-  uint8_t incoherent;
-};
-
-struct Shader {
-  Ref ref;
-  ShaderType type;
-  uint32_t program;
-  vec_uniform_t uniforms;
-  vec_block_t blocks[2];
-  map_int_t attributes;
-  map_int_t uniformMap;
-  map_int_t blockMap;
-  bool dirty;
-};
-
-struct Texture {
-  Ref ref;
-  TextureType type;
-  TextureFormat format;
-  int width;
-  int height;
-  int depth;
-  int mipmapCount;
-  GLuint id;
-  GLuint msaaId;
-  GLenum target;
-  TextureFilter filter;
-  TextureWrap wrap;
-  int msaa;
-  bool srgb;
-  bool mipmaps;
-  bool allocated;
-  uint8_t incoherent;
-};
-
-struct Canvas {
-  Ref ref;
-  int width;
-  int height;
-  CanvasFlags flags;
-  uint32_t framebuffer;
-  uint32_t resolveBuffer;
-  uint32_t depthBuffer;
-  Attachment attachments[MAX_CANVAS_ATTACHMENTS];
-  Attachment depth;
-  int attachmentCount;
-  bool needsAttach;
-  bool needsResolve;
-  bool immortal;
-};
-
-struct Mesh {
-  Ref ref;
-  uint32_t vao;
-  uint32_t count;
-  DrawMode mode;
-  VertexFormat format;
-  bool readable;
-  bool dirty;
-  BufferUsage usage;
-  Buffer* vbo;
-  Buffer* ibo;
-  uint32_t indexCount;
-  size_t indexSize;
-  size_t indexCapacity;
-  uint32_t rangeStart;
-  uint32_t rangeCount;
-  Material* material;
-  map_attribute_t attributes;
-  MeshAttribute layout[MAX_ATTRIBUTES];
-};
 
 // Helper functions
 

--- a/src/graphics/opengl.c
+++ b/src/graphics/opengl.c
@@ -875,10 +875,7 @@ const GpuStats* lovrGpuGetStats() {
 
 // Texture
 
-Texture* lovrTextureCreate(TextureType type, TextureData** slices, int sliceCount, bool srgb, bool mipmaps, int msaa) {
-  Texture* texture = lovrAlloc(Texture, lovrTextureDestroy);
-  if (!texture) return NULL;
-
+Texture* lovrTextureInit(Texture* texture, TextureType type, TextureData** slices, int sliceCount, bool srgb, bool mipmaps, int msaa) {
   texture->type = type;
   texture->srgb = srgb;
   texture->mipmaps = mipmaps;
@@ -904,10 +901,7 @@ Texture* lovrTextureCreate(TextureType type, TextureData** slices, int sliceCoun
   return texture;
 }
 
-Texture* lovrTextureCreateFromHandle(uint32_t handle, TextureType type) {
-  Texture* texture = lovrAlloc(Texture, lovrTextureDestroy);
-  if (!texture) return NULL;
-
+Texture* lovrTextureInitFromHandle(Texture* texture, uint32_t handle, TextureType type) {
   texture->type = type;
   texture->id = handle;
   texture->target = convertTextureTarget(type);
@@ -1147,10 +1141,7 @@ void lovrTextureSetWrap(Texture* texture, TextureWrap wrap) {
 
 // Canvas
 
-Canvas* lovrCanvasCreate(int width, int height, CanvasFlags flags) {
-  Canvas* canvas = lovrAlloc(Canvas, lovrCanvasDestroy);
-  if (!canvas) return NULL;
-
+Canvas* lovrCanvasInit(Canvas* canvas, int width, int height, CanvasFlags flags) {
   canvas->width = width;
   canvas->height = height;
   canvas->flags = flags;
@@ -1181,10 +1172,7 @@ Canvas* lovrCanvasCreate(int width, int height, CanvasFlags flags) {
   return canvas;
 }
 
-Canvas* lovrCanvasCreateFromHandle(int width, int height, CanvasFlags flags, uint32_t framebuffer, uint32_t depthBuffer, uint32_t resolveBuffer, int attachmentCount, bool immortal) {
-  Canvas* canvas = lovrAlloc(Canvas, lovrCanvasDestroy);
-  if (!canvas) return NULL;
-
+Canvas* lovrCanvasInitFromHandle(Canvas* canvas, int width, int height, CanvasFlags flags, uint32_t framebuffer, uint32_t depthBuffer, uint32_t resolveBuffer, int attachmentCount, bool immortal) {
   canvas->framebuffer = framebuffer;
   canvas->depthBuffer = depthBuffer;
   canvas->resolveBuffer = resolveBuffer;
@@ -1193,7 +1181,6 @@ Canvas* lovrCanvasCreateFromHandle(int width, int height, CanvasFlags flags, uin
   canvas->height = height;
   canvas->flags = flags;
   canvas->immortal = immortal;
-
   return canvas;
 }
 
@@ -1397,10 +1384,7 @@ TextureData* lovrCanvasNewTextureData(Canvas* canvas, int index) {
 
 // Buffer
 
-Buffer* lovrBufferCreate(size_t size, void* data, BufferUsage usage, bool readable) {
-  Buffer* buffer = lovrAlloc(Buffer, lovrBufferDestroy);
-  if (!buffer) return NULL;
-
+Buffer* lovrBufferInit(Buffer* buffer, size_t size, void* data, BufferUsage usage, bool readable) {
   buffer->size = size;
   buffer->usage = usage;
   glGenBuffers(1, &buffer->id);
@@ -1725,10 +1709,7 @@ static void lovrShaderSetupUniforms(Shader* shader) {
   }
 }
 
-Shader* lovrShaderCreateGraphics(const char* vertexSource, const char* fragmentSource) {
-  Shader* shader = lovrAlloc(Shader, lovrShaderDestroy);
-  if (!shader) return NULL;
-
+Shader* lovrShaderInitGraphics(Shader* shader, const char* vertexSource, const char* fragmentSource) {
 #if defined(EMSCRIPTEN) || defined(__ANDROID__)
   const char* vertexHeader = "#version 300 es\nprecision mediump float;\nprecision mediump int;\n";
   const char* fragmentHeader = vertexHeader;
@@ -1796,10 +1777,7 @@ Shader* lovrShaderCreateGraphics(const char* vertexSource, const char* fragmentS
   return shader;
 }
 
-Shader* lovrShaderCreateCompute(const char* source) {
-  Shader* shader = lovrAlloc(Shader, lovrShaderDestroy);
-  if (!shader) return NULL;
-
+Shader* lovrShaderInitCompute(Shader* shader, const char* source) {
 #ifdef EMSCRIPTEN
   lovrThrow("Compute shaders are not supported on this system");
 #else
@@ -1818,13 +1796,13 @@ Shader* lovrShaderCreateCompute(const char* source) {
   return shader;
 }
 
-Shader* lovrShaderCreateDefault(DefaultShader type) {
+Shader* lovrShaderInitDefault(Shader* shader, DefaultShader type) {
   switch (type) {
-    case SHADER_DEFAULT: return lovrShaderCreateGraphics(NULL, NULL);
-    case SHADER_CUBE: return lovrShaderCreateGraphics(lovrCubeVertexShader, lovrCubeFragmentShader);
-    case SHADER_PANO: return lovrShaderCreateGraphics(lovrCubeVertexShader, lovrPanoFragmentShader);
-    case SHADER_FONT: return lovrShaderCreateGraphics(NULL, lovrFontFragmentShader);
-    case SHADER_FILL: return lovrShaderCreateGraphics(lovrFillVertexShader, NULL);
+    case SHADER_DEFAULT: return lovrShaderInitGraphics(shader, NULL, NULL);
+    case SHADER_CUBE: return lovrShaderInitGraphics(shader, lovrCubeVertexShader, lovrCubeFragmentShader);
+    case SHADER_PANO: return lovrShaderInitGraphics(shader, lovrCubeVertexShader, lovrPanoFragmentShader);
+    case SHADER_FONT: return lovrShaderInitGraphics(shader, NULL, lovrFontFragmentShader);
+    case SHADER_FILL: return lovrShaderInitGraphics(shader, lovrFillVertexShader, NULL);
     default: lovrThrow("Unknown default shader type"); return NULL;
   }
 }
@@ -2084,10 +2062,7 @@ void lovrShaderSetBlock(Shader* shader, const char* name, ShaderBlock* source, U
 
 // ShaderBlock
 
-ShaderBlock* lovrShaderBlockCreate(vec_uniform_t* uniforms, BlockType type, BufferUsage usage) {
-  ShaderBlock* block = lovrAlloc(ShaderBlock, lovrShaderBlockDestroy);
-  if (!block) return NULL;
-
+ShaderBlock* lovrShaderBlockInit(ShaderBlock* block, vec_uniform_t* uniforms, BlockType type, BufferUsage usage) {
   lovrAssert(type != BLOCK_STORAGE || state.features.computeShaders, "Writable ShaderBlocks are not supported on this system");
 
   vec_init(&block->uniforms);
@@ -2193,10 +2168,7 @@ Buffer* lovrShaderBlockGetBuffer(ShaderBlock* block) {
 
 // Mesh
 
-Mesh* lovrMeshCreate(uint32_t count, VertexFormat format, DrawMode mode, BufferUsage usage, bool readable) {
-  Mesh* mesh = lovrAlloc(Mesh, lovrMeshDestroy);
-  if (!mesh) return NULL;
-
+Mesh* lovrMeshInit(Mesh* mesh, uint32_t count, VertexFormat format, DrawMode mode, BufferUsage usage, bool readable) {
   mesh->count = count;
   mesh->mode = mode;
   mesh->format = format;

--- a/src/graphics/opengl.h
+++ b/src/graphics/opengl.h
@@ -1,0 +1,36 @@
+#if EMSCRIPTEN
+#include <GLES3/gl3.h>
+#include <GLES2/gl2ext.h>
+#include <GL/gl.h>
+#include <GL/glext.h>
+#else
+#include "lib/glad/glad.h"
+#endif
+
+#pragma once
+
+#define GPU_BUFFER_FIELDS \
+  GLsync lock; \
+  uint32_t id;
+
+#define GPU_CANVAS_FIELDS \
+  uint32_t framebuffer; \
+  uint32_t resolveBuffer; \
+  uint32_t depthBuffer; \
+  bool immortal;
+
+#define GPU_MESH_FIELDS \
+  uint32_t vao;
+
+#define GPU_SHADER_FIELDS \
+  uint32_t program;
+
+#define GPU_SHADER_BLOCK_FIELDS \
+  GLenum target; \
+  uint8_t incoherent;
+
+#define GPU_TEXTURE_FIELDS \
+  GLuint id; \
+  GLuint msaaId; \
+  GLenum target; \
+  uint8_t incoherent;

--- a/src/graphics/shader.h
+++ b/src/graphics/shader.h
@@ -104,9 +104,12 @@ typedef struct {
   GPU_SHADER_FIELDS
 } Shader;
 
-Shader* lovrShaderCreateGraphics(const char* vertexSource, const char* fragmentSource);
-Shader* lovrShaderCreateCompute(const char* source);
-Shader* lovrShaderCreateDefault(DefaultShader type);
+Shader* lovrShaderInitGraphics(Shader* shader, const char* vertexSource, const char* fragmentSource);
+Shader* lovrShaderInitCompute(Shader* shader, const char* source);
+Shader* lovrShaderInitDefault(Shader* shader, DefaultShader type);
+#define lovrShaderCreateGraphics(...) lovrShaderInitGraphics(lovrAlloc(Shader, lovrShaderDestroy), __VA_ARGS__)
+#define lovrShaderCreateCompute(...) lovrShaderInitCompute(lovrAlloc(Shader, lovrShaderDestroy), __VA_ARGS__)
+#define lovrShaderCreateDefault(...) lovrShaderInitDefault(lovrAlloc(Shader, lovrShaderDestroy), __VA_ARGS__)
 void lovrShaderDestroy(void* ref);
 ShaderType lovrShaderGetType(Shader* shader);
 void lovrShaderBind(Shader* shader);
@@ -122,7 +125,8 @@ void lovrShaderSetImages(Shader* shader, const char* name, Image* data, int star
 void lovrShaderSetColor(Shader* shader, const char* name, Color color);
 void lovrShaderSetBlock(Shader* shader, const char* name, ShaderBlock* block, UniformAccess access);
 
-ShaderBlock* lovrShaderBlockCreate(vec_uniform_t* uniforms, BlockType type, BufferUsage usage);
+ShaderBlock* lovrShaderBlockInit(ShaderBlock* block, vec_uniform_t* uniforms, BlockType type, BufferUsage usage);
+#define lovrShaderBlockCreate(...) lovrShaderBlockInit(lovrAlloc(ShaderBlock, lovrShaderBlockDestroy), __VA_ARGS__)
 void lovrShaderBlockDestroy(void* ref);
 BlockType lovrShaderBlockGetType(ShaderBlock* block);
 char* lovrShaderBlockGetShaderCode(ShaderBlock* block, const char* blockName, size_t* length);

--- a/src/graphics/shader.h
+++ b/src/graphics/shader.h
@@ -1,5 +1,6 @@
 #include "graphics/buffer.h"
 #include "graphics/texture.h"
+#include "graphics/opengl.h"
 #include "lib/map/map.h"
 #include "lib/vec/vec.h"
 #include <stdbool.h>
@@ -73,8 +74,14 @@ typedef struct {
 
 typedef vec_t(Uniform) vec_uniform_t;
 
-typedef struct Shader Shader;
-typedef struct ShaderBlock ShaderBlock;
+typedef struct {
+  Ref ref;
+  BlockType type;
+  vec_uniform_t uniforms;
+  map_int_t uniformMap;
+  Buffer* buffer;
+  GPU_SHADER_BLOCK_FIELDS
+} ShaderBlock;
 
 typedef struct {
   vec_uniform_t uniforms;
@@ -84,6 +91,18 @@ typedef struct {
 } UniformBlock;
 
 typedef vec_t(UniformBlock) vec_block_t;
+
+typedef struct {
+  Ref ref;
+  ShaderType type;
+  vec_uniform_t uniforms;
+  vec_block_t blocks[2];
+  map_int_t attributes;
+  map_int_t uniformMap;
+  map_int_t blockMap;
+  bool dirty;
+  GPU_SHADER_FIELDS
+} Shader;
 
 Shader* lovrShaderCreateGraphics(const char* vertexSource, const char* fragmentSource);
 Shader* lovrShaderCreateCompute(const char* source);

--- a/src/graphics/shader.h
+++ b/src/graphics/shader.h
@@ -107,9 +107,9 @@ typedef struct {
 Shader* lovrShaderInitGraphics(Shader* shader, const char* vertexSource, const char* fragmentSource);
 Shader* lovrShaderInitCompute(Shader* shader, const char* source);
 Shader* lovrShaderInitDefault(Shader* shader, DefaultShader type);
-#define lovrShaderCreateGraphics(...) lovrShaderInitGraphics(lovrAlloc(Shader, lovrShaderDestroy), __VA_ARGS__)
-#define lovrShaderCreateCompute(...) lovrShaderInitCompute(lovrAlloc(Shader, lovrShaderDestroy), __VA_ARGS__)
-#define lovrShaderCreateDefault(...) lovrShaderInitDefault(lovrAlloc(Shader, lovrShaderDestroy), __VA_ARGS__)
+#define lovrShaderCreateGraphics(...) lovrShaderInitGraphics(lovrAlloc(Shader), __VA_ARGS__)
+#define lovrShaderCreateCompute(...) lovrShaderInitCompute(lovrAlloc(Shader), __VA_ARGS__)
+#define lovrShaderCreateDefault(...) lovrShaderInitDefault(lovrAlloc(Shader), __VA_ARGS__)
 void lovrShaderDestroy(void* ref);
 ShaderType lovrShaderGetType(Shader* shader);
 void lovrShaderBind(Shader* shader);
@@ -126,7 +126,7 @@ void lovrShaderSetColor(Shader* shader, const char* name, Color color);
 void lovrShaderSetBlock(Shader* shader, const char* name, ShaderBlock* block, UniformAccess access);
 
 ShaderBlock* lovrShaderBlockInit(ShaderBlock* block, vec_uniform_t* uniforms, BlockType type, BufferUsage usage);
-#define lovrShaderBlockCreate(...) lovrShaderBlockInit(lovrAlloc(ShaderBlock, lovrShaderBlockDestroy), __VA_ARGS__)
+#define lovrShaderBlockCreate(...) lovrShaderBlockInit(lovrAlloc(ShaderBlock), __VA_ARGS__)
 void lovrShaderBlockDestroy(void* ref);
 BlockType lovrShaderBlockGetType(ShaderBlock* block);
 char* lovrShaderBlockGetShaderCode(ShaderBlock* block, const char* blockName, size_t* length);

--- a/src/graphics/texture.h
+++ b/src/graphics/texture.h
@@ -1,4 +1,5 @@
 #include "data/textureData.h"
+#include "graphics/opengl.h"
 #include <stdbool.h>
 
 #pragma once
@@ -34,7 +35,22 @@ typedef struct {
   WrapMode r;
 } TextureWrap;
 
-typedef struct Texture Texture;
+typedef struct {
+  Ref ref;
+  TextureType type;
+  TextureFormat format;
+  int width;
+  int height;
+  int depth;
+  int mipmapCount;
+  TextureFilter filter;
+  TextureWrap wrap;
+  int msaa;
+  bool srgb;
+  bool mipmaps;
+  bool allocated;
+  GPU_TEXTURE_FIELDS
+} Texture;
 
 Texture* lovrTextureCreate(TextureType type, TextureData** slices, int sliceCount, bool srgb, bool mipmaps, int msaa);
 Texture* lovrTextureCreateFromHandle(uint32_t handle, TextureType type);

--- a/src/graphics/texture.h
+++ b/src/graphics/texture.h
@@ -52,8 +52,10 @@ typedef struct {
   GPU_TEXTURE_FIELDS
 } Texture;
 
-Texture* lovrTextureCreate(TextureType type, TextureData** slices, int sliceCount, bool srgb, bool mipmaps, int msaa);
-Texture* lovrTextureCreateFromHandle(uint32_t handle, TextureType type);
+Texture* lovrTextureInit(Texture* texture, TextureType type, TextureData** slices, int sliceCount, bool srgb, bool mipmaps, int msaa);
+Texture* lovrTextureInitFromHandle(Texture* texture, uint32_t handle, TextureType type);
+#define lovrTextureCreate(...) lovrTextureInit(lovrAlloc(Texture, lovrTextureDestroy), __VA_ARGS__)
+#define lovrTextureCreateFromHandle(...) lovrTextureInitFromHandle(lovrAlloc(Texture, lovrTextureDestroy), __VA_ARGS__)
 void lovrTextureDestroy(void* ref);
 void lovrTextureAllocate(Texture* texture, int width, int height, int depth, TextureFormat format);
 void lovrTextureReplacePixels(Texture* texture, TextureData* data, int x, int y, int slice, int mipmap);

--- a/src/graphics/texture.h
+++ b/src/graphics/texture.h
@@ -54,8 +54,8 @@ typedef struct {
 
 Texture* lovrTextureInit(Texture* texture, TextureType type, TextureData** slices, int sliceCount, bool srgb, bool mipmaps, int msaa);
 Texture* lovrTextureInitFromHandle(Texture* texture, uint32_t handle, TextureType type);
-#define lovrTextureCreate(...) lovrTextureInit(lovrAlloc(Texture, lovrTextureDestroy), __VA_ARGS__)
-#define lovrTextureCreateFromHandle(...) lovrTextureInitFromHandle(lovrAlloc(Texture, lovrTextureDestroy), __VA_ARGS__)
+#define lovrTextureCreate(...) lovrTextureInit(lovrAlloc(Texture), __VA_ARGS__)
+#define lovrTextureCreateFromHandle(...) lovrTextureInitFromHandle(lovrAlloc(Texture), __VA_ARGS__)
 void lovrTextureDestroy(void* ref);
 void lovrTextureAllocate(Texture* texture, int width, int height, int depth, TextureFormat format);
 void lovrTextureReplacePixels(Texture* texture, TextureData* data, int x, int y, int slice, int mipmap);

--- a/src/headset/fake.c
+++ b/src/headset/fake.c
@@ -54,7 +54,7 @@ static bool fakeInit(float offset, int msaa) {
   mat4_identity(state.transform);
 
   vec_init(&state.controllers);
-  Controller* controller = lovrAlloc(Controller, free);
+  Controller* controller = lovrAlloc(Controller);
   controller->id = 0;
   vec_push(&state.controllers, controller);
 

--- a/src/headset/headset.h
+++ b/src/headset/headset.h
@@ -111,3 +111,4 @@ extern HeadsetInterface* lovrHeadsetDriver;
 
 bool lovrHeadsetInit(HeadsetDriver* drivers, int count, float offset, int msaa);
 void lovrHeadsetDestroy();
+#define lovrControllerDestroy free

--- a/src/headset/oculus.c
+++ b/src/headset/oculus.c
@@ -109,7 +109,7 @@ static bool oculusInit(float offset, int msaa) {
   vec_init(&state.controllers);
 
   for (ovrHandType hand = ovrHand_Left; hand < ovrHand_Count; hand++) {
-    Controller* controller = lovrAlloc(Controller, free);
+    Controller* controller = lovrAlloc(Controller);
     controller->id = hand;
     vec_push(&state.controllers, controller);
   }

--- a/src/headset/oculus_mobile.c
+++ b/src/headset/oculus_mobile.c
@@ -110,7 +110,7 @@ static Controller *controller;
 
 static Controller** oculusMobileGetControllers(uint8_t* count) {
   if (!controller)
-    controller = lovrAlloc(Controller, free);
+    controller = lovrAlloc(Controller);
   *count = bridgeLovrMobileData.updateData.goPresent; // TODO: Figure out what multi controller Oculus Mobile looks like and support it
   return &controller;
 }

--- a/src/headset/openvr.c
+++ b/src/headset/openvr.c
@@ -172,8 +172,7 @@ static bool openvrInit(float offset, int msaa) {
   vec_init(&state.controllers);
   for (uint32_t i = 0; i < k_unMaxTrackedDeviceCount; i++) {
     if (isController(i)) {
-      Controller* controller = lovrAlloc(Controller, free);
-      if (!controller) continue;
+      Controller* controller = lovrAlloc(Controller);
       controller->id = i;
       vec_push(&state.controllers, controller);
     }
@@ -416,7 +415,7 @@ static ModelData* openvrControllerNewModelData(Controller* controller) {
 
   RenderModel_t* vrModel = state.deviceModels[id];
 
-  ModelData* modelData = lovrAlloc(ModelData, lovrModelDataDestroy);
+  ModelData* modelData = lovrAlloc(ModelData);
 
   VertexFormat format;
   vertexFormatInit(&format);
@@ -553,8 +552,7 @@ static void openvrUpdate(float dt) {
       case EVREventType_VREvent_TrackedDeviceActivated: {
         uint32_t id = vrEvent.trackedDeviceIndex;
         if (isController(id)) {
-          Controller* controller = lovrAlloc(Controller, free);
-          if (!controller) break;
+          Controller* controller = lovrAlloc(Controller);
           controller->id = id;
           vec_push(&state.controllers, controller);
           lovrRetain(controller);

--- a/src/headset/openvr.c
+++ b/src/headset/openvr.c
@@ -416,8 +416,7 @@ static ModelData* openvrControllerNewModelData(Controller* controller) {
 
   RenderModel_t* vrModel = state.deviceModels[id];
 
-  ModelData* modelData = lovrModelDataCreateEmpty();
-  if (!modelData) return NULL;
+  ModelData* modelData = lovrAlloc(ModelData, lovrModelDataDestroy);
 
   VertexFormat format;
   vertexFormatInit(&format);

--- a/src/headset/webvr.c
+++ b/src/headset/webvr.c
@@ -41,7 +41,7 @@ typedef struct {
 static HeadsetState state;
 
 static void onControllerAdded(uint32_t id) {
-  Controller* controller = lovrAlloc(Controller, free);
+  Controller* controller = lovrAlloc(Controller);
   controller->id = id;
   vec_push(&state.controllers, controller);
   lovrRetain(controller);

--- a/src/math/curve.c
+++ b/src/math/curve.c
@@ -37,13 +37,9 @@ static void evaluate(float* P, int n, float t, vec3 p) {
   }
 }
 
-Curve* lovrCurveCreate(int sizeHint) {
-  Curve* curve = lovrAlloc(Curve, lovrCurveDestroy);
-  if (!curve) return NULL;
-
+Curve* lovrCurveInit(Curve* curve, int sizeHint) {
   vec_init(&curve->points);
   lovrAssert(!vec_reserve(&curve->points, sizeHint * 3), "Out of memory");
-
   return curve;
 }
 

--- a/src/math/curve.h
+++ b/src/math/curve.h
@@ -8,7 +8,7 @@ typedef struct {
 } Curve;
 
 Curve* lovrCurveInit(Curve* curve, int sizeHint);
-#define lovrCurveCreate(...) lovrCurveInit(lovrAlloc(Curve, lovrCurveDestroy), __VA_ARGS__)
+#define lovrCurveCreate(...) lovrCurveInit(lovrAlloc(Curve), __VA_ARGS__)
 void lovrCurveDestroy(void* ref);
 void lovrCurveEvaluate(Curve* curve, float t, vec3 point);
 void lovrCurveGetTangent(Curve* curve, float t, vec3 point);

--- a/src/math/curve.h
+++ b/src/math/curve.h
@@ -7,7 +7,8 @@ typedef struct {
   vec_float_t points;
 } Curve;
 
-Curve* lovrCurveCreate(int sizeHint);
+Curve* lovrCurveInit(Curve* curve, int sizeHint);
+#define lovrCurveCreate(...) lovrCurveInit(lovrAlloc(Curve, lovrCurveDestroy), __VA_ARGS__)
 void lovrCurveDestroy(void* ref);
 void lovrCurveEvaluate(Curve* curve, float t, vec3 point);
 void lovrCurveGetTangent(Curve* curve, float t, vec3 point);

--- a/src/math/math.c
+++ b/src/math/math.c
@@ -3,6 +3,7 @@
 #include "util.h"
 #include <math.h>
 #include <string.h>
+#include <stdlib.h>
 #include <time.h>
 
 static MathState state;

--- a/src/math/pool.c
+++ b/src/math/pool.c
@@ -7,16 +7,12 @@ static const size_t sizeOfMathType[] = {
   [MATH_MAT4] = 16 * sizeof(float)
 };
 
-Pool* lovrPoolCreate(size_t size) {
-  Pool* pool = lovrAlloc(Pool, lovrPoolDestroy);
-  if (!pool) return NULL;
-
+Pool* lovrPoolInit(Pool* pool, size_t size) {
   pool->size = size;
   pool->data = calloc(1, size + POOL_ALIGN - 1);
   pool->head = (uint8_t*) ALIGN((uint8_t*) pool->data + POOL_ALIGN - 1, POOL_ALIGN);
   lovrAssert(pool->data, "Could not allocate Pool memory");
   pool->usage = 0;
-
   return pool;
 }
 

--- a/src/math/pool.h
+++ b/src/math/pool.h
@@ -20,7 +20,8 @@ typedef struct {
   uint8_t* head;
 } Pool;
 
-Pool* lovrPoolCreate(size_t size);
+Pool* lovrPoolInit(Pool* pool, size_t size);
+#define lovrPoolCreate(...) lovrPoolInit(lovrAlloc(Pool, lovrPoolDestroy), __VA_ARGS__)
 void lovrPoolDestroy(void* ref);
 float* lovrPoolAllocate(Pool* pool, MathType type);
 void lovrPoolDrain(Pool* pool);

--- a/src/math/pool.h
+++ b/src/math/pool.h
@@ -21,7 +21,7 @@ typedef struct {
 } Pool;
 
 Pool* lovrPoolInit(Pool* pool, size_t size);
-#define lovrPoolCreate(...) lovrPoolInit(lovrAlloc(Pool, lovrPoolDestroy), __VA_ARGS__)
+#define lovrPoolCreate(...) lovrPoolInit(lovrAlloc(Pool), __VA_ARGS__)
 void lovrPoolDestroy(void* ref);
 float* lovrPoolAllocate(Pool* pool, MathType type);
 void lovrPoolDrain(Pool* pool);

--- a/src/math/randomGenerator.c
+++ b/src/math/randomGenerator.c
@@ -22,14 +22,10 @@ static uint64_t wangHash64(uint64_t key) {
 // George Marsaglia, "Xorshift RNGs", Journal of Statistical Software, Vol.8 (Issue 14), 2003
 // Use an 'Xorshift*' variant, as shown here: http://xorshift.di.unimi.it
 
-RandomGenerator* lovrRandomGeneratorCreate() {
-  RandomGenerator* generator = lovrAlloc(RandomGenerator, free);
-  if (!generator) return NULL;
-
+RandomGenerator* lovrRandomGeneratorInit(RandomGenerator* generator) {
   Seed seed = { .b32 = { .lo = 0xCBBF7A44, .hi = 0x0139408D } };
   lovrRandomGeneratorSetSeed(generator, seed);
   generator->lastRandomNormal = INFINITY;
-
   return generator;
 }
 

--- a/src/math/randomGenerator.h
+++ b/src/math/randomGenerator.h
@@ -21,7 +21,7 @@ typedef struct {
 } RandomGenerator;
 
 RandomGenerator* lovrRandomGeneratorInit(RandomGenerator* generator);
-#define lovrRandomGeneratorCreate() lovrRandomGeneratorInit(lovrAlloc(RandomGenerator, lovrRandomGeneratorDestroy))
+#define lovrRandomGeneratorCreate() lovrRandomGeneratorInit(lovrAlloc(RandomGenerator))
 #define lovrRandomGeneratorDestroy free
 Seed lovrRandomGeneratorGetSeed(RandomGenerator* generator);
 void lovrRandomGeneratorSetSeed(RandomGenerator* generator, Seed seed);

--- a/src/math/randomGenerator.h
+++ b/src/math/randomGenerator.h
@@ -20,7 +20,9 @@ typedef struct {
   double lastRandomNormal;
 } RandomGenerator;
 
-RandomGenerator* lovrRandomGeneratorCreate();
+RandomGenerator* lovrRandomGeneratorInit(RandomGenerator* generator);
+#define lovrRandomGeneratorCreate() lovrRandomGeneratorInit(lovrAlloc(RandomGenerator, lovrRandomGeneratorDestroy))
+#define lovrRandomGeneratorDestroy free
 Seed lovrRandomGeneratorGetSeed(RandomGenerator* generator);
 void lovrRandomGeneratorSetSeed(RandomGenerator* generator, Seed seed);
 void lovrRandomGeneratorGetState(RandomGenerator* generator, char* state, size_t length);

--- a/src/physics/physics.h
+++ b/src/physics/physics.h
@@ -89,7 +89,7 @@ bool lovrPhysicsInit();
 void lovrPhysicsDestroy();
 
 World* lovrWorldInit(World* world, float xg, float yg, float zg, bool allowSleep, const char** tags, int tagCount);
-#define lovrWorldCreate(...) lovrWorldInit(lovrAlloc(World, lovrWorldDestroy), __VA_ARGS__)
+#define lovrWorldCreate(...) lovrWorldInit(lovrAlloc(World), __VA_ARGS__)
 void lovrWorldDestroy(void* ref);
 void lovrWorldDestroyData(World* world);
 void lovrWorldUpdate(World* world, float dt, CollisionResolver resolver, void* userdata);
@@ -111,7 +111,7 @@ int lovrWorldEnableCollisionBetween(World* world, const char* tag1, const char* 
 int lovrWorldIsCollisionEnabledBetween(World* world, const char* tag1, const char* tag);
 
 Collider* lovrColliderInit(Collider* collider, World* world, float x, float y, float z);
-#define lovrColliderCreate(...) lovrColliderInit(lovrAlloc(Collider, lovrColliderDestroy), __VA_ARGS__)
+#define lovrColliderCreate(...) lovrColliderInit(lovrAlloc(Collider), __VA_ARGS__)
 void lovrColliderDestroy(void* ref);
 void lovrColliderDestroyData(Collider* collider);
 World* lovrColliderGetWorld(Collider* collider);
@@ -179,24 +179,28 @@ void lovrShapeGetMass(Shape* shape, float density, float* cx, float* cy, float* 
 void lovrShapeGetAABB(Shape* shape, float aabb[6]);
 
 SphereShape* lovrSphereShapeInit(SphereShape* sphere, float radius);
-#define lovrSphereShapeCreate(...) lovrSphereShapeInit(lovrAlloc(SphereShape, lovrShapeDestroy), __VA_ARGS__)
+#define lovrSphereShapeCreate(...) lovrSphereShapeInit(lovrAlloc(SphereShape), __VA_ARGS__)
+#define lovrSphereShapeDestroy lovrShapeDestroy
 float lovrSphereShapeGetRadius(SphereShape* sphere);
 void lovrSphereShapeSetRadius(SphereShape* sphere, float radius);
 
 BoxShape* lovrBoxShapeInit(BoxShape* box, float x, float y, float z);
-#define lovrBoxShapeCreate(...) lovrBoxShapeInit(lovrAlloc(BoxShape, lovrShapeDestroy), __VA_ARGS__)
+#define lovrBoxShapeCreate(...) lovrBoxShapeInit(lovrAlloc(BoxShape), __VA_ARGS__)
+#define lovrBoxShapeDestroy lovrShapeDestroy
 void lovrBoxShapeGetDimensions(BoxShape* box, float* x, float* y, float* z);
 void lovrBoxShapeSetDimensions(BoxShape* box, float x, float y, float z);
 
 CapsuleShape* lovrCapsuleShapeInit(CapsuleShape* capsule, float radius, float length);
-#define lovrCapsuleShapeCreate(...) lovrCapsuleShapeInit(lovrAlloc(CapsuleShape, lovrShapeDestroy), __VA_ARGS__)
+#define lovrCapsuleShapeCreate(...) lovrCapsuleShapeInit(lovrAlloc(CapsuleShape), __VA_ARGS__)
+#define lovrCapsuleShapeDestroy lovrShapeDestroy
 float lovrCapsuleShapeGetRadius(CapsuleShape* capsule);
 void lovrCapsuleShapeSetRadius(CapsuleShape* capsule, float radius);
 float lovrCapsuleShapeGetLength(CapsuleShape* capsule);
 void lovrCapsuleShapeSetLength(CapsuleShape* capsule, float length);
 
 CylinderShape* lovrCylinderShapeInit(CylinderShape* cylinder, float radius, float length);
-#define lovrCylinderShapeCreate(...) lovrCylinderShapeInit(lovrAlloc(CylinderShape, lovrShapeDestroy), __VA_ARGS__)
+#define lovrCylinderShapeCreate(...) lovrCylinderShapeInit(lovrAlloc(CylinderShape), __VA_ARGS__)
+#define lovrCylinderShapeDestroy lovrShapeDestroy
 float lovrCylinderShapeGetRadius(CylinderShape* cylinder);
 void lovrCylinderShapeSetRadius(CylinderShape* cylinder, float radius);
 float lovrCylinderShapeGetLength(CylinderShape* cylinder);
@@ -210,19 +214,22 @@ void* lovrJointGetUserData(Joint* joint);
 void lovrJointSetUserData(Joint* joint, void* data);
 
 BallJoint* lovrBallJointInit(BallJoint* joint, Collider* a, Collider* b, float x, float y, float z);
-#define lovrBallJointCreate(...) lovrBallJointInit(lovrAlloc(BallJoint, lovrJointDestroy), __VA_ARGS__)
+#define lovrBallJointCreate(...) lovrBallJointInit(lovrAlloc(BallJoint), __VA_ARGS__)
+#define lovrBallJointDestroy lovrJointDestroy
 void lovrBallJointGetAnchors(BallJoint* joint, float* x1, float* y1, float* z1, float* x2, float* y2, float* z2);
 void lovrBallJointSetAnchor(BallJoint* joint, float x, float y, float z);
 
 DistanceJoint* lovrDistanceJointInit(DistanceJoint* joint, Collider* a, Collider* b, float x1, float y1, float z1, float x2, float y2, float z2);
-#define lovrDistanceJointCreate(...) lovrDistanceJointInit(lovrAlloc(DistanceJoint, lovrJointDestroy), __VA_ARGS__)
+#define lovrDistanceJointCreate(...) lovrDistanceJointInit(lovrAlloc(DistanceJoint), __VA_ARGS__)
+#define lovrDistanceJointDestroy lovrJointDestroy
 void lovrDistanceJointGetAnchors(DistanceJoint* joint, float* x1, float* y1, float* z1, float* x2, float* y2, float* z2);
 void lovrDistanceJointSetAnchors(DistanceJoint* joint, float x1, float y1, float z1, float x2, float y2, float z2);
 float lovrDistanceJointGetDistance(DistanceJoint* joint);
 void lovrDistanceJointSetDistance(DistanceJoint* joint, float distance);
 
 HingeJoint* lovrHingeJointInit(HingeJoint* joint, Collider* a, Collider* b, float x, float y, float z, float ax, float ay, float az);
-#define lovrHingeJointCreate(...) lovrHingeJointInit(lovrAlloc(HingeJoint, lovrJointDestroy), __VA_ARGS__)
+#define lovrHingeJointCreate(...) lovrHingeJointInit(lovrAlloc(HingeJoint), __VA_ARGS__)
+#define lovrHingeJointDestroy lovrJointDestroy
 void lovrHingeJointGetAnchors(HingeJoint* joint, float* x1, float* y1, float* z1, float* x2, float* y2, float* z2);
 void lovrHingeJointSetAnchor(HingeJoint* joint, float x, float y, float z);
 void lovrHingeJointGetAxis(HingeJoint* joint, float* x, float* y, float* z);
@@ -234,7 +241,8 @@ float lovrHingeJointGetUpperLimit(HingeJoint* joint);
 void lovrHingeJointSetUpperLimit(HingeJoint* joint, float limit);
 
 SliderJoint* lovrSliderJointInit(SliderJoint* joint, Collider* a, Collider* b, float ax, float ay, float az);
-#define lovrSliderJointCreate(...) lovrSliderJointInit(lovrAlloc(SliderJoint, lovrJointDestroy), __VA_ARGS__)
+#define lovrSliderJointCreate(...) lovrSliderJointInit(lovrAlloc(SliderJoint), __VA_ARGS__)
+#define lovrSliderJointDestroy lovrJointDestroy
 void lovrSliderJointGetAxis(SliderJoint* joint, float* x, float* y, float* z);
 void lovrSliderJointSetAxis(SliderJoint* joint, float x, float y, float z);
 float lovrSliderJointGetPosition(SliderJoint* joint);

--- a/src/physics/physics.h
+++ b/src/physics/physics.h
@@ -88,7 +88,8 @@ typedef struct {
 bool lovrPhysicsInit();
 void lovrPhysicsDestroy();
 
-World* lovrWorldCreate(float xg, float yg, float zg, bool allowSleep, const char** tags, int tagCount);
+World* lovrWorldInit(World* world, float xg, float yg, float zg, bool allowSleep, const char** tags, int tagCount);
+#define lovrWorldCreate(...) lovrWorldInit(lovrAlloc(World, lovrWorldDestroy), __VA_ARGS__)
 void lovrWorldDestroy(void* ref);
 void lovrWorldDestroyData(World* world);
 void lovrWorldUpdate(World* world, float dt, CollisionResolver resolver, void* userdata);
@@ -109,7 +110,8 @@ int lovrWorldDisableCollisionBetween(World* world, const char* tag1, const char*
 int lovrWorldEnableCollisionBetween(World* world, const char* tag1, const char* tag2);
 int lovrWorldIsCollisionEnabledBetween(World* world, const char* tag1, const char* tag);
 
-Collider* lovrColliderCreate(World* world, float x, float y, float z);
+Collider* lovrColliderInit(Collider* collider, World* world, float x, float y, float z);
+#define lovrColliderCreate(...) lovrColliderInit(lovrAlloc(Collider, lovrColliderDestroy), __VA_ARGS__)
 void lovrColliderDestroy(void* ref);
 void lovrColliderDestroyData(Collider* collider);
 World* lovrColliderGetWorld(Collider* collider);
@@ -176,21 +178,25 @@ void lovrShapeSetOrientation(Shape* shape, float angle, float x, float y, float 
 void lovrShapeGetMass(Shape* shape, float density, float* cx, float* cy, float* cz, float* mass, float inertia[6]);
 void lovrShapeGetAABB(Shape* shape, float aabb[6]);
 
-SphereShape* lovrSphereShapeCreate(float radius);
+SphereShape* lovrSphereShapeInit(SphereShape* sphere, float radius);
+#define lovrSphereShapeCreate(...) lovrSphereShapeInit(lovrAlloc(SphereShape, lovrShapeDestroy), __VA_ARGS__)
 float lovrSphereShapeGetRadius(SphereShape* sphere);
 void lovrSphereShapeSetRadius(SphereShape* sphere, float radius);
 
-BoxShape* lovrBoxShapeCreate(float x, float y, float z);
+BoxShape* lovrBoxShapeInit(BoxShape* box, float x, float y, float z);
+#define lovrBoxShapeCreate(...) lovrBoxShapeInit(lovrAlloc(BoxShape, lovrShapeDestroy), __VA_ARGS__)
 void lovrBoxShapeGetDimensions(BoxShape* box, float* x, float* y, float* z);
 void lovrBoxShapeSetDimensions(BoxShape* box, float x, float y, float z);
 
-CapsuleShape* lovrCapsuleShapeCreate(float radius, float length);
+CapsuleShape* lovrCapsuleShapeInit(CapsuleShape* capsule, float radius, float length);
+#define lovrCapsuleShapeCreate(...) lovrCapsuleShapeInit(lovrAlloc(CapsuleShape, lovrShapeDestroy), __VA_ARGS__)
 float lovrCapsuleShapeGetRadius(CapsuleShape* capsule);
 void lovrCapsuleShapeSetRadius(CapsuleShape* capsule, float radius);
 float lovrCapsuleShapeGetLength(CapsuleShape* capsule);
 void lovrCapsuleShapeSetLength(CapsuleShape* capsule, float length);
 
-CylinderShape* lovrCylinderShapeCreate(float radius, float length);
+CylinderShape* lovrCylinderShapeInit(CylinderShape* cylinder, float radius, float length);
+#define lovrCylinderShapeCreate(...) lovrCylinderShapeInit(lovrAlloc(CylinderShape, lovrShapeDestroy), __VA_ARGS__)
 float lovrCylinderShapeGetRadius(CylinderShape* cylinder);
 void lovrCylinderShapeSetRadius(CylinderShape* cylinder, float radius);
 float lovrCylinderShapeGetLength(CylinderShape* cylinder);
@@ -203,17 +209,20 @@ void lovrJointGetColliders(Joint* joint, Collider** a, Collider** b);
 void* lovrJointGetUserData(Joint* joint);
 void lovrJointSetUserData(Joint* joint, void* data);
 
-BallJoint* lovrBallJointCreate(Collider* a, Collider* b, float x, float y, float z);
+BallJoint* lovrBallJointInit(BallJoint* joint, Collider* a, Collider* b, float x, float y, float z);
+#define lovrBallJointCreate(...) lovrBallJointInit(lovrAlloc(BallJoint, lovrJointDestroy), __VA_ARGS__)
 void lovrBallJointGetAnchors(BallJoint* joint, float* x1, float* y1, float* z1, float* x2, float* y2, float* z2);
 void lovrBallJointSetAnchor(BallJoint* joint, float x, float y, float z);
 
-DistanceJoint* lovrDistanceJointCreate(Collider* a, Collider* b, float x1, float y1, float z1, float x2, float y2, float z2);
+DistanceJoint* lovrDistanceJointInit(DistanceJoint* joint, Collider* a, Collider* b, float x1, float y1, float z1, float x2, float y2, float z2);
+#define lovrDistanceJointCreate(...) lovrDistanceJointInit(lovrAlloc(DistanceJoint, lovrJointDestroy), __VA_ARGS__)
 void lovrDistanceJointGetAnchors(DistanceJoint* joint, float* x1, float* y1, float* z1, float* x2, float* y2, float* z2);
 void lovrDistanceJointSetAnchors(DistanceJoint* joint, float x1, float y1, float z1, float x2, float y2, float z2);
 float lovrDistanceJointGetDistance(DistanceJoint* joint);
 void lovrDistanceJointSetDistance(DistanceJoint* joint, float distance);
 
-HingeJoint* lovrHingeJointCreate(Collider* a, Collider* b, float x, float y, float z, float ax, float ay, float az);
+HingeJoint* lovrHingeJointInit(HingeJoint* joint, Collider* a, Collider* b, float x, float y, float z, float ax, float ay, float az);
+#define lovrHingeJointCreate(...) lovrHingeJointInit(lovrAlloc(HingeJoint, lovrJointDestroy), __VA_ARGS__)
 void lovrHingeJointGetAnchors(HingeJoint* joint, float* x1, float* y1, float* z1, float* x2, float* y2, float* z2);
 void lovrHingeJointSetAnchor(HingeJoint* joint, float x, float y, float z);
 void lovrHingeJointGetAxis(HingeJoint* joint, float* x, float* y, float* z);
@@ -224,7 +233,8 @@ void lovrHingeJointSetLowerLimit(HingeJoint* joint, float limit);
 float lovrHingeJointGetUpperLimit(HingeJoint* joint);
 void lovrHingeJointSetUpperLimit(HingeJoint* joint, float limit);
 
-SliderJoint* lovrSliderJointCreate(Collider* a, Collider* b, float ax, float ay, float az);
+SliderJoint* lovrSliderJointInit(SliderJoint* joint, Collider* a, Collider* b, float ax, float ay, float az);
+#define lovrSliderJointCreate(...) lovrSliderJointInit(lovrAlloc(SliderJoint, lovrJointDestroy), __VA_ARGS__)
 void lovrSliderJointGetAxis(SliderJoint* joint, float* x, float* y, float* z);
 void lovrSliderJointSetAxis(SliderJoint* joint, float x, float y, float z);
 float lovrSliderJointGetPosition(SliderJoint* joint);

--- a/src/thread/channel.c
+++ b/src/thread/channel.c
@@ -3,14 +3,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-Channel* lovrChannelCreate() {
-  Channel* channel = lovrAlloc(Channel, lovrChannelDestroy);
-  if (!channel) return NULL;
-
+Channel* lovrChannelInit(Channel* channel) {
   vec_init(&channel->messages);
   mtx_init(&channel->lock, mtx_plain | mtx_timed);
   cnd_init(&channel->cond);
-
   return channel;
 }
 

--- a/src/thread/channel.h
+++ b/src/thread/channel.h
@@ -17,7 +17,7 @@ struct Channel {
 };
 
 Channel* lovrChannelInit(Channel* channel);
-#define lovrChannelCreate() lovrChannelInit(lovrAlloc(Channel, lovrChannelDestroy))
+#define lovrChannelCreate() lovrChannelInit(lovrAlloc(Channel))
 void lovrChannelDestroy(void* ref);
 bool lovrChannelPush(Channel* channel, Variant variant, double timeout, uint64_t* id);
 bool lovrChannelPop(Channel* channel, Variant* variant, double timeout);

--- a/src/thread/channel.h
+++ b/src/thread/channel.h
@@ -16,7 +16,8 @@ struct Channel {
   uint64_t received;
 };
 
-Channel* lovrChannelCreate();
+Channel* lovrChannelInit(Channel* channel);
+#define lovrChannelCreate() lovrChannelInit(lovrAlloc(Channel, lovrChannelDestroy))
 void lovrChannelDestroy(void* ref);
 bool lovrChannelPush(Channel* channel, Variant variant, double timeout, uint64_t* id);
 bool lovrChannelPop(Channel* channel, Variant* variant, double timeout);

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -4,13 +4,13 @@
 
 static ThreadState state;
 
-bool lovrThreadInit() {
+bool lovrThreadModuleInit() {
   if (state.initialized) return false;
   map_init(&state.channels);
   return state.initialized = true;
 }
 
-void lovrThreadDeinit() {
+void lovrThreadModuleDestroy() {
   if (!state.initialized) return;
   const char* key;
   map_iter_t iter = map_iter(&state.channels);

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -34,16 +34,12 @@ Channel* lovrThreadGetChannel(const char* name) {
   }
 }
 
-Thread* lovrThreadCreate(int (*runner)(void*), const char* body) {
-  Thread* thread = lovrAlloc(Thread, lovrThreadDestroy);
-  if (!thread) return NULL;
-
+Thread* lovrThreadInit(Thread* thread, int (*runner)(void*), const char* body) {
   thread->runner = runner;
   thread->body = body;
   thread->error = NULL;
   thread->running = false;
   mtx_init(&thread->lock, mtx_plain);
-
   return thread;
 }
 

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -26,7 +26,8 @@ bool lovrThreadModuleInit();
 void lovrThreadModuleDestroy();
 struct Channel* lovrThreadGetChannel(const char* name);
 
-Thread* lovrThreadCreate(int (*runner)(void*), const char* body);
+Thread* lovrThreadInit(Thread* thread, int (*runner)(void*), const char* body);
+#define lovrThreadCreate(...) lovrThreadInit(lovrAlloc(Thread, lovrThreadDestroy), __VA_ARGS__)
 void lovrThreadDestroy(void* ref);
 void lovrThreadStart(Thread* thread);
 void lovrThreadWait(Thread* thread);

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -27,7 +27,7 @@ void lovrThreadModuleDestroy();
 struct Channel* lovrThreadGetChannel(const char* name);
 
 Thread* lovrThreadInit(Thread* thread, int (*runner)(void*), const char* body);
-#define lovrThreadCreate(...) lovrThreadInit(lovrAlloc(Thread, lovrThreadDestroy), __VA_ARGS__)
+#define lovrThreadCreate(...) lovrThreadInit(lovrAlloc(Thread), __VA_ARGS__)
 void lovrThreadDestroy(void* ref);
 void lovrThreadStart(Thread* thread);
 void lovrThreadWait(Thread* thread);

--- a/src/thread/thread.h
+++ b/src/thread/thread.h
@@ -22,8 +22,8 @@ typedef struct {
   bool running;
 } Thread;
 
-bool lovrThreadInit();
-void lovrThreadDeinit();
+bool lovrThreadModuleInit();
+void lovrThreadModuleDestroy();
 struct Channel* lovrThreadGetChannel(const char* name);
 
 Thread* lovrThreadCreate(int (*runner)(void*), const char* body);

--- a/src/util.c
+++ b/src/util.c
@@ -29,10 +29,12 @@ void lovrThrow(const char* format, ...) {
 }
 
 void* _lovrAlloc(const char* type, size_t size, void (*destructor)(void*)) {
-  void* object = calloc(1, size);
-  if (!object) return NULL;
-  *((Ref*) object) = (Ref) { .free = destructor, .type = type, .count = 1 };
-  return object;
+  Ref* ref = calloc(1, size);
+  if (!ref) return lovrThrow("Out of memory"), NULL;
+  ref->free = destructor;
+  ref->type = type;
+  ref->count = 1;
+  return ref;
 }
 
 void lovrRetain(void* object) {

--- a/src/util.h
+++ b/src/util.h
@@ -23,7 +23,7 @@
 #define CHECK_SIZEOF(T) int(*_o)[sizeof(T)]=1
 
 #define lovrAssert(c, ...) if (!(c)) { lovrThrow(__VA_ARGS__); }
-#define lovrAlloc(T, destructor) (T*) _lovrAlloc(#T, sizeof(T), destructor)
+#define lovrAlloc(T) (T*) _lovrAlloc(#T, sizeof(T), lovr ## T ## Destroy)
 
 #define MAX(a, b) (a > b ? a : b)
 #define MIN(a, b) (a < b ? a : b)


### PR DESCRIPTION
Changes:

- An error is thrown when allocating an object fails in `lovrAlloc` (instead of crashing on NULL or, in the best case, returning nil to Lua, which most people aren't handling anyway).
- `lovrAlloc` doesn't take a destructor anymore.  Instead, the destructor needs to follow the naming convention of `lovr<Type>Destroy`.
- Functions that create objects (`lovr*Create`) do not allocate memory on the heap anymore.  Instead, they accept a pointer to memory to initialize.  The pointer must be zero'd.  That way, creating an object doesn't need to always involve a heap allocation, allowing people to use custom allocators or allocate memory on the stack.
- Graphics objects are no longer opaque.  I like this better, since sometimes you just gotta have access to the native API.  This also became necessary since now we need to know the size of the structs if we're gonna allocate memory for them.