### PR TITLE
ShaderBlock:getValue; Shader:send vector fixes;

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -61,6 +61,7 @@ extern const char* ArcModes[];
 extern const char* AttributeTypes[];
 extern const char* BlendAlphaModes[];
 extern const char* BlendModes[];
+extern const char* BlockTypes[];
 extern const char* BufferUsages[];
 extern const char* CompareModes[];
 extern const char* ControllerAxes[];

--- a/src/api/graphics.c
+++ b/src/api/graphics.c
@@ -936,6 +936,7 @@ static int l_lovrGraphicsNewShaderBlock(lua_State* L) {
 
   BlockType type = BLOCK_UNIFORM;
   BufferUsage usage = USAGE_DYNAMIC;
+  bool readable = false;
 
   if (lua_istable(L, 2)) {
     lua_getfield(L, 2, "usage");
@@ -945,11 +946,15 @@ static int l_lovrGraphicsNewShaderBlock(lua_State* L) {
     lua_getfield(L, 2, "writable");
     type = lua_toboolean(L, -1) ? BLOCK_STORAGE : BLOCK_UNIFORM;
     lua_pop(L, 1);
+
+    lua_getfield(L, 2, "readable");
+    readable = lua_toboolean(L, -1);
+    lua_pop(L, 1);
   }
 
   lovrAssert(type != BLOCK_STORAGE || lovrGraphicsGetSupported()->computeShaders, "Writable ShaderBlocks are not supported on this system");
   size_t size = lovrShaderComputeUniformLayout(&uniforms);
-  Buffer* buffer = lovrBufferCreate(size, NULL, type == BLOCK_STORAGE ? BUFFER_SHADER_STORAGE : BUFFER_UNIFORM, usage, false);
+  Buffer* buffer = lovrBufferCreate(size, NULL, type == BLOCK_STORAGE ? BUFFER_SHADER_STORAGE : BUFFER_UNIFORM, usage, readable);
   ShaderBlock* block = lovrShaderBlockCreate(type, buffer, &uniforms);
   luax_pushobject(L, block);
   vec_deinit(&uniforms);

--- a/src/api/types/shader.c
+++ b/src/api/types/shader.c
@@ -86,10 +86,13 @@ int luax_checkuniform(lua_State* L, int index, const Uniform* uniform, void* des
       }
     }
   } else {
-    luaL_checktype(L, index, LUA_TTABLE);
-    lua_rawgeti(L, index, 1);
-    bool wrappedTable = !lua_isnumber(L, -1);
-    lua_pop(L, 1);
+    bool wrappedTable = false;
+
+    if (lua_istable(L, index)) {
+      lua_rawgeti(L, index, 1);
+      wrappedTable = !lua_isnumber(L, -1);
+      lua_pop(L, 1);
+    }
 
     if (wrappedTable) {
       int length = lua_objlen(L, index);

--- a/src/api/types/shaderBlock.c
+++ b/src/api/types/shaderBlock.c
@@ -2,9 +2,9 @@
 #include "api/graphics.h"
 #include "graphics/shader.h"
 
-int l_lovrShaderBlockIsWritable(lua_State* L) {
+int l_lovrShaderBlockGetType(lua_State* L) {
   ShaderBlock* block = luax_checktype(L, 1, ShaderBlock);
-  lua_pushboolean(L, lovrShaderBlockGetType(block) == BLOCK_STORAGE);
+  lua_pushstring(L, BlockTypes[lovrShaderBlockGetType(block)]);
   return 1;
 }
 
@@ -47,13 +47,13 @@ int l_lovrShaderBlockSend(lua_State* L) {
   }
 }
 
-int l_lovrShaderBlockGetValue(lua_State* L) {
+int l_lovrShaderBlockRead(lua_State* L) {
   ShaderBlock* block = luax_checktype(L, 1, ShaderBlock);
   const char* name = luaL_checkstring(L, 2);
   const Uniform* uniform = lovrShaderBlockGetUniform(block, name);
   lovrAssert(uniform, "Unknown uniform for ShaderBlock '%s'", name);
   Buffer* buffer = lovrShaderBlockGetBuffer(block);
-  lovrAssert(lovrBufferIsReadable(buffer), "ShaderBlock:getValue requires the ShaderBlock to be created with the readable flag");
+  lovrAssert(lovrBufferIsReadable(buffer), "ShaderBlock:read requires the ShaderBlock to be created with the readable flag");
   union { float* floats; int* ints; } data = { .floats = lovrBufferMap(buffer, uniform->offset) };
   int components = uniform->components;
 
@@ -107,11 +107,11 @@ int l_lovrShaderBlockGetShaderCode(lua_State* L) {
 }
 
 const luaL_Reg lovrShaderBlock[] = {
-  { "isWritable", l_lovrShaderBlockIsWritable },
+  { "getType", l_lovrShaderBlockGetType },
   { "getSize", l_lovrShaderBlockGetSize },
   { "getOffset", l_lovrShaderBlockGetOffset },
+  { "read", l_lovrShaderBlockRead },
   { "send", l_lovrShaderBlockSend },
-  { "getValue", l_lovrShaderBlockGetValue },
   { "getShaderCode", l_lovrShaderBlockGetShaderCode },
   { NULL, NULL }
 };

--- a/src/graphics/graphics.h
+++ b/src/graphics/graphics.h
@@ -276,7 +276,7 @@ void lovrGraphicsFill(Texture* texture, float u, float v, float w, float h);
 // GPU
 
 typedef struct {
-  bool computeShaders;
+  bool compute;
   bool singlepass;
 } GpuFeatures;
 

--- a/src/graphics/shader.h
+++ b/src/graphics/shader.h
@@ -18,7 +18,7 @@ typedef enum {
 
 typedef enum {
   BLOCK_UNIFORM,
-  BLOCK_STORAGE
+  BLOCK_COMPUTE
 } BlockType;
 
 typedef enum {


### PR DESCRIPTION
Allows you to read back values from a ShaderBlock.

- This is also probably useful for Shaders and their uniforms.
- This creates SO MANY tables.  It feels so bad to expose this.  But
  also it's the only way to read values back from a compute operation,
  so it's pretty indispensable.  In the future there could be a Blob
  variant.
- readable and writable are confusing now, since writable means "write from shader" and readable means "read from Lua".  Proposal to change writable to shaderwritable?  Anything better?