### PR TITLE
Small portability compile fixes in headers

### DIFF
--- a/src/lib/sds/sds.h
+++ b/src/lib/sds/sds.h
@@ -35,7 +35,7 @@
 #define __SDS_H
 
 #define SDS_MAX_PREALLOC (1024*1024)
-const char *SDS_NOINIT;
+extern const char *SDS_NOINIT;
 
 #include <sys/types.h>
 #include <stdarg.h>

--- a/src/luax.h
+++ b/src/luax.h
@@ -19,6 +19,7 @@ void* _luax_totype(lua_State* L, int index, const char* type);
 void* _luax_checktype(lua_State* L, int index, const char* type);
 void luax_pushobject(lua_State* L, void* object);
 void luax_vthrow(lua_State* L, const char* format, va_list args);
+void luax_traceback(lua_State* L, lua_State* T, const char* message, int level);
 int luax_getstack(lua_State* L);
 int luax_getstack_panic(lua_State *L);
 void luax_pushconf(lua_State* L);


### PR DESCRIPTION
Here are 2 small fixes that I remember fixing the build on… … some platform or other. I don't remember what platforms.

luax_traceback is currently used in oculus_mobile.c, so it needs to be in the header. That's reasonable.

I cannot exactly remember why the sds.h change was needed. I think maybe I wanted to include sds.h in a .cpp file in my fork. Maybe that's not a fix worth including in main lovr because it contains no cpp files. But the change seems to be harmless.