### PR TITLE
Always check malloc result; Less calloc;

### DIFF
--- a/src/api/data.c
+++ b/src/api/data.c
@@ -14,15 +14,18 @@ static int l_lovrDataNewBlob(lua_State* L) {
   if (type == LUA_TNUMBER) {
     size = lua_tonumber(L, 1);
     data = calloc(1, size);
+    lovrAssert(data, "Out of memory");
   } else if (type == LUA_TSTRING) {
     const char* str = luaL_checklstring(L, 1, &size);
     data = malloc(size + 1);
+    lovrAssert(data, "Out of memory");
     memcpy(data, str, size);
     data[size] = '\0';
   } else {
     Blob* blob = luax_checktype(L, 1, Blob);
     size = blob->size;
     data = malloc(size);
+    lovrAssert(data, "Out of memory");
   }
   const char* name = luaL_optstring(L, 2, "");
   Blob* blob = lovrBlobCreate(data, size, name);

--- a/src/api/event.c
+++ b/src/api/event.c
@@ -36,8 +36,10 @@ void luax_checkvariant(lua_State* L, int index, Variant* variant) {
       variant->type = TYPE_STRING;
       size_t length;
       const char* string = lua_tolstring(L, index, &length);
-      variant->value.string = calloc(1, length + 1);
+      variant->value.string = malloc(length + 1);
+      lovrAssert(variant->value.string, "Out of memory");
       memcpy(variant->value.string, string, length);
+      variant->value.string[length] = '\0';
       break;
 
     case LUA_TUSERDATA:

--- a/src/api/types/curve.c
+++ b/src/api/types/curve.c
@@ -29,6 +29,7 @@ int l_lovrCurveRender(lua_State* L) {
   float t1 = luaL_optnumber(L, 3, 0.);
   float t2 = luaL_optnumber(L, 4, 1.);
   float* points = malloc(3 * n * sizeof(float));
+  lovrAssert(points, "Out of memory");
   lovrCurveRender(curve, t1, t2, points, n);
   lua_createtable(L, n, 0);
   for (int i = 0; i < 3 * n; i++) {

--- a/src/data/audioStream.c
+++ b/src/data/audioStream.c
@@ -16,6 +16,7 @@ AudioStream* lovrAudioStreamInit(AudioStream* stream, Blob* blob, size_t bufferS
   stream->decoder = decoder;
   stream->bufferSize = stream->channelCount * bufferSize * sizeof(short);
   stream->buffer = malloc(stream->bufferSize);
+  lovrAssert(stream->buffer, "Out of memory");
   stream->blob = blob;
   lovrRetain(blob);
 

--- a/src/data/soundData.c
+++ b/src/data/soundData.c
@@ -9,6 +9,7 @@ SoundData* lovrSoundDataInit(SoundData* soundData, int samples, int sampleRate, 
   soundData->channelCount = channelCount;
   soundData->blob.size = samples * channelCount * (bitDepth / 8);
   soundData->blob.data = calloc(1, soundData->blob.size);
+  lovrAssert(soundData->blob.data, "Out of memory");
   return soundData;
 }
 
@@ -19,6 +20,7 @@ SoundData* lovrSoundDataInitFromAudioStream(SoundData* soundData, AudioStream* a
   soundData->channelCount = audioStream->channelCount;
   soundData->blob.size = audioStream->samples * audioStream->channelCount * (audioStream->bitDepth / 8);
   soundData->blob.data = calloc(1, soundData->blob.size);
+  lovrAssert(soundData->blob.data, "Out of memory");
 
   int samples;
   short* buffer = soundData->blob.data;

--- a/src/data/textureData.c
+++ b/src/data/textureData.c
@@ -144,7 +144,9 @@ TextureData* lovrTextureDataInit(TextureData* textureData, int width, int height
   textureData->height = height;
   textureData->format = format;
   textureData->blob.size = size;
-  textureData->blob.data = memset(malloc(size), value, size);
+  textureData->blob.data = malloc(size);
+  lovrAssert(textureData->blob.data, "Out of memory");
+  memset(textureData->blob.data, value, size);
   vec_init(&textureData->mipmaps);
   return textureData;
 }

--- a/src/filesystem/filesystem.c
+++ b/src/filesystem/filesystem.c
@@ -39,6 +39,7 @@ bool lovrFilesystemInit(const char* argExe, const char* argGame, const char* arg
   }
 
   state.source = malloc(LOVR_PATH_MAX * sizeof(char));
+  lovrAssert(state.source, "Out of memory");
   state.identity = NULL;
   state.isFused = true;
   vec_init(&state.requirePattern[0]);
@@ -259,6 +260,7 @@ int lovrFilesystemSetIdentity(const char* identity) {
   } else {
     state.savePathRelative = malloc(LOVR_PATH_MAX);
     state.savePathFull = malloc(LOVR_PATH_MAX);
+    lovrAssert(state.savePathRelative && state.savePathFull, "Out of memory");
     if (!state.savePathRelative || !state.savePathFull) {
       return 1;
     }

--- a/src/graphics/model.c
+++ b/src/graphics/model.c
@@ -86,10 +86,12 @@ Model* lovrModelInit(Model* model, ModelData* modelData) {
 
   if (modelData->textures.length > 0) {
     model->textures = calloc(modelData->textures.length, sizeof(Texture*));
+    lovrAssert(model->textures, "Out of memory");
   }
 
   if (modelData->materialCount > 0) {
     model->materials = calloc(modelData->materialCount, sizeof(Material*));
+    lovrAssert(model->materials, "Out of memory");
     for (int i = 0; i < modelData->materialCount; i++) {
       ModelMaterial* materialData = &modelData->materials[i];
       Material* material = lovrMaterialCreate();
@@ -130,6 +132,7 @@ Model* lovrModelInit(Model* model, ModelData* modelData) {
   }
 
   model->nodeTransforms = malloc(16 * modelData->nodeCount * sizeof(float));
+  lovrAssert(model->nodeTransforms, "Out of memory");
   for (int i = 0; i < modelData->nodeCount; i++) {
     ModelNode* node = &model->modelData->nodes[i];
     mat4 transform = model->nodeTransforms[i];

--- a/src/graphics/opengl.c
+++ b/src/graphics/opengl.c
@@ -1547,7 +1547,8 @@ Buffer* lovrBufferInit(Buffer* buffer, size_t size, void* data, BufferType type,
     buffer->data = glMapBufferRange(glType, 0, size, flags | GL_MAP_FLUSH_EXPLICIT_BIT);
   } else {
 #endif
-    buffer->data = calloc(1, size);
+    buffer->data = malloc(size);
+    lovrAssert(buffer->data, "Out of memory");
     glBufferData(glType, size, data, convertBufferUsage(usage));
 
     if (data) {
@@ -1603,6 +1604,7 @@ static GLuint compileShader(GLenum type, const char** sources, int count) {
     int logLength;
     glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
     char* log = malloc(logLength);
+    lovrAssert(log, "Out of memory");
     glGetShaderInfoLog(shader, logLength, &logLength, log);
     lovrThrow("Could not compile shader:\n%s", log);
   }
@@ -1619,6 +1621,7 @@ static GLuint linkProgram(GLuint program) {
     int logLength;
     glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength);
     char* log = malloc(logLength);
+    lovrAssert(log, "Out of memory");
     glGetProgramInfoLog(program, logLength, &logLength, log);
     lovrThrow("Could not link shader:\n%s", log);
   }
@@ -1760,22 +1763,26 @@ static void lovrShaderSetupUniforms(Shader* shader) {
       case UNIFORM_FLOAT:
         uniform.size = uniform.components * uniform.count * sizeof(float);
         uniform.value.data = calloc(1, uniform.size);
+        lovrAssert(uniform.value.data, "Out of memory");
         break;
 
       case UNIFORM_INT:
         uniform.size = uniform.components * uniform.count * sizeof(int);
         uniform.value.data = calloc(1, uniform.size);
+        lovrAssert(uniform.value.data, "Out of memory");
         break;
 
       case UNIFORM_MATRIX:
         uniform.size = uniform.components * uniform.components * uniform.count * sizeof(float);
         uniform.value.data = calloc(1, uniform.size);
+        lovrAssert(uniform.value.data, "Out of memory");
         break;
 
       case UNIFORM_SAMPLER:
       case UNIFORM_IMAGE:
         uniform.size = uniform.count * (uniform.type == UNIFORM_SAMPLER ? sizeof(Texture*) : sizeof(Image));
         uniform.value.data = calloc(1, uniform.size);
+        lovrAssert(uniform.value.data, "Out of memory");
 
         // Use the value for ints to bind texture slots, but use the value for textures afterwards.
         for (int i = 0; i < uniform.count; i++) {

--- a/src/graphics/shader.c
+++ b/src/graphics/shader.c
@@ -226,6 +226,7 @@ char* lovrShaderBlockGetShaderCode(ShaderBlock* block, const char* blockName, si
 
   // Allocate
   char* code = malloc(size + 1);
+  lovrAssert(code, "Out of memory");
 
   // Concatenate
   char* s = code;

--- a/src/util.c
+++ b/src/util.c
@@ -29,8 +29,8 @@ void lovrThrow(const char* format, ...) {
 }
 
 void* _lovrAlloc(const char* type, size_t size, void (*destructor)(void*)) {
-  Ref* ref = calloc(1, size);
-  if (!ref) return lovrThrow("Out of memory"), NULL;
+  Ref* ref = malloc(size);
+  lovrAssert(ref, "Out of memory");
   ref->destructor = destructor;
   ref->type = type;
   ref->count = 1;


### PR DESCRIPTION
Some more questions:

- Should there be some kind of allocation helper so you don't need
  to always check the result?
- Throwing an error on OOM is convenient and is probably correct 90%
  of the time, it even provides a nice error message instead of a
  nil dereference somewhere.  But it's inflexible.  Is it the right
  thing to do?