### PR TITLE
Window pixel density

### DIFF
--- a/src/api/graphics.c
+++ b/src/api/graphics.c
@@ -338,6 +338,11 @@ static int l_lovrGraphicsGetDimensions(lua_State* L) {
   return 2;
 }
 
+static int l_lovrGraphicsGetPixelDensity(lua_State* L) {
+  lua_pushnumber(L, lovrGraphicsGetPixelDensity());
+  return 1;
+}
+
 static int l_lovrGraphicsHasWindow(lua_State *L) {
   bool window = lovrPlatformHasWindow();
   lua_pushboolean(L, window);
@@ -1358,6 +1363,7 @@ static const luaL_Reg lovrGraphics[] = {
   { "getWidth", l_lovrGraphicsGetWidth },
   { "getHeight", l_lovrGraphicsGetHeight },
   { "getDimensions", l_lovrGraphicsGetDimensions },
+  { "getPixelDensity", l_lovrGraphicsGetPixelDensity },
   { "hasWindow", l_lovrGraphicsHasWindow },
   { "getSupported", l_lovrGraphicsGetSupported },
   { "getSystemLimits", l_lovrGraphicsGetSystemLimits },

--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -213,6 +213,13 @@ int lovrGraphicsGetHeight() {
   return state.height;
 }
 
+float lovrGraphicsGetPixelDensity() {
+  int width, framebufferWidth;
+  lovrPlatformGetWindowSize(&width, NULL);
+  lovrPlatformGetFramebufferSize(&framebufferWidth, NULL);
+  return (float) framebufferWidth / (float) width;
+}
+
 void lovrGraphicsSetCamera(Camera* camera, bool clear) {
   lovrGraphicsFlush();
 

--- a/src/graphics/graphics.h
+++ b/src/graphics/graphics.h
@@ -199,6 +199,7 @@ void lovrGraphicsPresent();
 void lovrGraphicsCreateWindow(WindowFlags* flags);
 int lovrGraphicsGetWidth();
 int lovrGraphicsGetHeight();
+float lovrGraphicsGetPixelDensity();
 void lovrGraphicsSetCamera(Camera* camera, bool clear);
 Buffer* lovrGraphicsGetIdentityBuffer();
 #define lovrGraphicsGetSupported lovrGpuGetSupported

--- a/src/platform/glfw.h
+++ b/src/platform/glfw.h
@@ -136,7 +136,8 @@ void lovrPlatformGetWindowSize(int* width, int* height) {
   if (state.window) {
     glfwGetWindowSize(state.window, width, height);
   } else {
-    *width = *height = 0;
+    if (*width) *width = 0;
+    if (*height) *height = 0;
   }
 }
 
@@ -144,7 +145,8 @@ void lovrPlatformGetFramebufferSize(int* width, int* height) {
   if (state.window) {
     glfwGetFramebufferSize(state.window, width, height);
   } else {
-    *width = *height = 0;
+    if (*width) *width = 0;
+    if (*height) *height = 0;
   }
 }
 


### PR DESCRIPTION
Adds `lovr.graphics.getPixelDensity` to determine the density of pixels per screen coordinate.  The graphics module is the best place for it right now, but hopefully soon there is a better place for window-related stuff.