### PR TITLE
Update type system;

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,7 @@ endif()
 set(LOVR_SRC
   src/main.c
   src/util.c
+  src/types.c
   src/luax.c
   src/api/lovr.c
   src/lib/math.c

--- a/src/api/audio.c
+++ b/src/api/audio.c
@@ -111,8 +111,8 @@ static int l_lovrAudioNewMicrophone(lua_State* L) {
   int bitDepth = luaL_optinteger(L, 4, 16);
   int channelCount = luaL_optinteger(L, 5, 1);
   Microphone* microphone = lovrMicrophoneCreate(name, samples, sampleRate, bitDepth, channelCount);
-  luax_pushobject(L, microphone);
-  lovrRelease(microphone);
+  luax_pushtype(L, Microphone, microphone);
+  lovrRelease(Microphone, microphone);
   return 1;
 }
 
@@ -131,12 +131,12 @@ static int l_lovrAudioNewSource(lua_State* L) {
       } else {
         Blob* blob = luax_readblob(L, 1, "Source");
         soundData = lovrSoundDataCreateFromBlob(blob);
-        lovrRelease(blob);
+        lovrRelease(Blob, blob);
       }
 
       lovrAssert(soundData, "Could not create static Source");
       source = lovrSourceCreateStatic(soundData);
-      lovrRelease(soundData);
+      lovrRelease(SoundData, soundData);
     }
   } else {
     if (stream) {
@@ -146,13 +146,13 @@ static int l_lovrAudioNewSource(lua_State* L) {
       stream = lovrAudioStreamCreate(blob, 4096);
       lovrAssert(stream, "Could not create stream Source");
       source = lovrSourceCreateStream(stream);
-      lovrRelease(blob);
-      lovrRelease(stream);
+      lovrRelease(Blob, blob);
+      lovrRelease(AudioStream, stream);
     }
   }
 
-  luax_pushobject(L, source);
-  lovrRelease(source);
+  luax_pushtype(L, Source, source);
+  lovrRelease(Source, source);
   return 1;
 }
 
@@ -248,8 +248,8 @@ static const luaL_Reg lovrAudio[] = {
 int luaopen_lovr_audio(lua_State* L) {
   lua_newtable(L);
   luaL_register(L, NULL, lovrAudio);
-  luax_registertype(L, "Microphone", lovrMicrophone);
-  luax_registertype(L, "Source", lovrSource);
+  luax_registertype(L, Microphone);
+  luax_registertype(L, Source);
   if (lovrAudioInit()) {
     luax_atexit(L, lovrAudioDestroy);
   }

--- a/src/api/data.c
+++ b/src/api/data.c
@@ -30,8 +30,8 @@ static int l_lovrDataNewBlob(lua_State* L) {
   }
   const char* name = luaL_optstring(L, 2, "");
   Blob* blob = lovrBlobCreate(data, size, name);
-  luax_pushobject(L, blob);
-  lovrRelease(blob);
+  luax_pushtype(L, Blob, blob);
+  lovrRelease(Blob, blob);
   return 1;
 }
 
@@ -39,18 +39,18 @@ static int l_lovrDataNewAudioStream(lua_State* L) {
   Blob* blob = luax_readblob(L, 1, "AudioStream");
   size_t bufferSize = luaL_optinteger(L, 2, 4096);
   AudioStream* stream = lovrAudioStreamCreate(blob, bufferSize);
-  luax_pushobject(L, stream);
-  lovrRelease(blob);
-  lovrRelease(stream);
+  luax_pushtype(L, AudioStream, stream);
+  lovrRelease(Blob, blob);
+  lovrRelease(AudioStream, stream);
   return 1;
 }
 
 static int l_lovrDataNewModelData(lua_State* L) {
   Blob* blob = luax_readblob(L, 1, "Model");
   ModelData* modelData = lovrModelDataCreate(blob);
-  luax_pushobject(L, modelData);
-  lovrRelease(blob);
-  lovrRelease(modelData);
+  luax_pushtype(L, ModelData, modelData);
+  lovrRelease(Blob, blob);
+  lovrRelease(ModelData, modelData);
   return 1;
 }
 
@@ -66,9 +66,9 @@ static int l_lovrDataNewRasterizer(lua_State* L) {
   }
 
   Rasterizer* rasterizer = lovrRasterizerCreate(blob, size);
-  luax_pushobject(L, rasterizer);
-  lovrRelease(blob);
-  lovrRelease(rasterizer);
+  luax_pushtype(L, Rasterizer, rasterizer);
+  lovrRelease(Blob, blob);
+  lovrRelease(Rasterizer, rasterizer);
   return 1;
 }
 
@@ -79,24 +79,24 @@ static int l_lovrDataNewSoundData(lua_State* L) {
     int bitDepth = luaL_optinteger(L, 3, 16);
     int channelCount = luaL_optinteger(L, 4, 2);
     SoundData* soundData = lovrSoundDataCreate(samples, sampleRate, bitDepth, channelCount);
-    luax_pushobject(L, soundData);
-    lovrRelease(soundData);
+    luax_pushtype(L, SoundData, soundData);
+    lovrRelease(SoundData, soundData);
     return 1;
   }
 
   AudioStream* audioStream = luax_totype(L, 1, AudioStream);
   if (audioStream) {
     SoundData* soundData = lovrSoundDataCreateFromAudioStream(audioStream);
-    luax_pushobject(L, soundData);
-    lovrRelease(soundData);
+    luax_pushtype(L, SoundData, soundData);
+    lovrRelease(SoundData, soundData);
     return 1;
   }
 
   Blob* blob = luax_readblob(L, 1, "SoundData");
   SoundData* soundData = lovrSoundDataCreateFromBlob(blob);
-  luax_pushobject(L, soundData);
-  lovrRelease(blob);
-  lovrRelease(soundData);
+  luax_pushtype(L, SoundData, soundData);
+  lovrRelease(Blob, blob);
+  lovrRelease(SoundData, soundData);
   return 1;
 }
 
@@ -111,11 +111,11 @@ static int l_lovrDataNewTextureData(lua_State* L) {
     Blob* blob = luax_readblob(L, 1, "Texture");
     bool flip = lua_isnoneornil(L, 2) ? true : lua_toboolean(L, 2);
     textureData = lovrTextureDataCreateFromBlob(blob, flip);
-    lovrRelease(blob);
+    lovrRelease(Blob, blob);
   }
 
-  luax_pushobject(L, textureData);
-  lovrRelease(textureData);
+  luax_pushtype(L, TextureData, textureData);
+  lovrRelease(TextureData, textureData);
   return 1;
 }
 
@@ -132,11 +132,11 @@ static const luaL_Reg lovrData[] = {
 int luaopen_lovr_data(lua_State* L) {
   lua_newtable(L);
   luaL_register(L, NULL, lovrData);
-  luax_registertype(L, "Blob", lovrBlob);
-  luax_registertype(L, "AudioStream", lovrAudioStream);
-  luax_registertype(L, "ModelData", lovrModelData);
-  luax_registertype(L, "Rasterizer", lovrRasterizer);
-  luax_extendtype(L, "Blob", "SoundData", lovrBlob, lovrSoundData);
-  luax_extendtype(L, "Blob", "TextureData", lovrBlob, lovrTextureData);
+  luax_registertype(L, Blob);
+  luax_registertype(L, AudioStream);
+  luax_registertype(L, ModelData);
+  luax_registertype(L, Rasterizer);
+  luax_extendtype(L, Blob, SoundData);
+  luax_extendtype(L, Blob, TextureData);
   return 1;
 }

--- a/src/api/filesystem.c
+++ b/src/api/filesystem.c
@@ -280,8 +280,8 @@ static int l_lovrFilesystemNewBlob(lua_State* L) {
   uint8_t* data = lovrFilesystemRead(path, -1, &size);
   lovrAssert(data, "Could not load file '%s'", path);
   Blob* blob = lovrBlobCreate((void*) data, size, path);
-  luax_pushobject(L, blob);
-  lovrRelease(blob);
+  luax_pushtype(L, Blob, blob);
+  lovrRelease(Blob, blob);
   return 1;
 }
 

--- a/src/api/graphics.c
+++ b/src/api/graphics.c
@@ -272,7 +272,7 @@ static TextureData* luax_checktexturedata(lua_State* L, int index, bool flip) {
   if (!textureData) {
     Blob* blob = luax_readblob(L, index, "Texture");
     textureData = lovrTextureDataCreateFromBlob(blob, flip);
-    lovrRelease(blob);
+    lovrRelease(Blob, blob);
   }
 
   return textureData;
@@ -321,7 +321,7 @@ static int l_lovrGraphicsCreateWindow(lua_State* L) {
 
   lovrGraphicsCreateWindow(&flags);
   luax_atexit(L, lovrGraphicsDestroy); // The lua_State that creates the window shall be the one to destroy it
-  lovrRelease(textureData);
+  lovrRelease(TextureData, textureData);
   return 0;
 }
 
@@ -444,7 +444,7 @@ static int l_lovrGraphicsSetBlendMode(lua_State* L) {
 
 static int l_lovrGraphicsGetCanvas(lua_State* L) {
   Canvas* canvas = lovrGraphicsGetCanvas();
-  luax_pushobject(L, canvas);
+  luax_pushtype(L, Canvas, canvas);
   return 1;
 }
 
@@ -514,7 +514,7 @@ static int l_lovrGraphicsSetDepthTest(lua_State* L) {
 
 static int l_lovrGraphicsGetFont(lua_State* L) {
   Font* font = lovrGraphicsGetFont();
-  luax_pushobject(L, font);
+  luax_pushtype(L, Font, font);
   return 1;
 }
 
@@ -554,7 +554,7 @@ static int l_lovrGraphicsSetPointSize(lua_State* L) {
 
 static int l_lovrGraphicsGetShader(lua_State* L) {
   Shader* shader = lovrGraphicsGetShader();
-  luax_pushobject(L, shader);
+  luax_pushtype(L, Shader, shader);
   return 1;
 }
 
@@ -903,8 +903,8 @@ static int l_lovrGraphicsCompute(lua_State* L) {
 static int l_lovrGraphicsNewAnimator(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
   Animator* animator = lovrAnimatorCreate(model->data);
-  luax_pushobject(L, animator);
-  lovrRelease(animator);
+  luax_pushtype(L, Animator, animator);
+  lovrRelease(Animator, animator);
   return 1;
 }
 
@@ -961,10 +961,10 @@ static int l_lovrGraphicsNewShaderBlock(lua_State* L) {
   size_t size = lovrShaderComputeUniformLayout(&uniforms);
   Buffer* buffer = lovrBufferCreate(size, NULL, type == BLOCK_COMPUTE ? BUFFER_SHADER_STORAGE : BUFFER_UNIFORM, usage, readable);
   ShaderBlock* block = lovrShaderBlockCreate(type, buffer, &uniforms);
-  luax_pushobject(L, block);
+  luax_pushtype(L, ShaderBlock, block);
   vec_deinit(&uniforms);
-  lovrRelease(buffer);
-  lovrRelease(block);
+  lovrRelease(Buffer, buffer);
+  lovrRelease(ShaderBlock, block);
   return 1;
 }
 
@@ -1057,12 +1057,12 @@ static int l_lovrGraphicsNewCanvas(lua_State* L) {
   if (attachmentCount > 0) {
     lovrCanvasSetAttachments(canvas, attachments, attachmentCount);
     if (anonymous) {
-      lovrRelease(attachments[0].texture);
+      lovrRelease(Texture, attachments[0].texture);
     }
   }
 
-  luax_pushobject(L, canvas);
-  lovrRelease(canvas);
+  luax_pushtype(L, Canvas, canvas);
+  lovrRelease(Canvas, canvas);
   return 1;
 }
 
@@ -1081,13 +1081,13 @@ static int l_lovrGraphicsNewFont(lua_State* L) {
     }
 
     rasterizer = lovrRasterizerCreate(blob, size);
-    lovrRelease(blob);
+    lovrRelease(Blob, blob);
   }
 
   Font* font = lovrFontCreate(rasterizer);
-  luax_pushobject(L, font);
-  lovrRelease(rasterizer);
-  lovrRelease(font);
+  luax_pushtype(L, Font, font);
+  lovrRelease(Rasterizer, rasterizer);
+  lovrRelease(Font, font);
   return 1;
 }
 
@@ -1101,9 +1101,9 @@ static int l_lovrGraphicsNewMaterial(lua_State* L) {
     TextureData* textureData = lovrTextureDataCreateFromBlob(blob, true);
     Texture* texture = lovrTextureCreate(TEXTURE_2D, &textureData, 1, true, true, 0);
     lovrMaterialSetTexture(material, TEXTURE_DIFFUSE, texture);
-    lovrRelease(blob);
-    lovrRelease(textureData);
-    lovrRelease(texture);
+    lovrRelease(Blob, blob);
+    lovrRelease(TextureData, textureData);
+    lovrRelease(Texture, texture);
   } else if (lua_isuserdata(L, index)) {
     Texture* texture = luax_checktexture(L, index);
     lovrMaterialSetTexture(material, TEXTURE_DIFFUSE, texture);
@@ -1115,8 +1115,8 @@ static int l_lovrGraphicsNewMaterial(lua_State* L) {
     lovrMaterialSetColor(material, COLOR_DIFFUSE, color);
   }
 
-  luax_pushobject(L, material);
-  lovrRelease(material);
+  luax_pushtype(L, Material, material);
+  lovrRelease(Material, material);
   return 1;
 }
 
@@ -1253,10 +1253,10 @@ static int l_lovrGraphicsNewMesh(lua_State* L) {
   }
 
   lovrBufferMarkRange(vertexBuffer, 0, count * stride);
-  lovrRelease(vertexBuffer);
+  lovrRelease(Buffer, vertexBuffer);
 
-  luax_pushobject(L, mesh);
-  lovrRelease(mesh);
+  luax_pushtype(L, Mesh, mesh);
+  lovrRelease(Mesh, mesh);
   return 1;
 }
 
@@ -1266,13 +1266,13 @@ static int l_lovrGraphicsNewModel(lua_State* L) {
   if (!modelData) {
     Blob* blob = luax_readblob(L, 1, "Model");
     modelData = lovrModelDataCreate(blob);
-    lovrRelease(blob);
+    lovrRelease(Blob, blob);
   }
 
   Model* model = lovrModelCreate(modelData);
-  luax_pushobject(L, model);
-  lovrRelease(modelData);
-  lovrRelease(model);
+  luax_pushtype(L, Model, model);
+  lovrRelease(ModelData, modelData);
+  lovrRelease(Model, model);
   return 1;
 }
 
@@ -1307,8 +1307,8 @@ static int l_lovrGraphicsNewShader(lua_State* L) {
   const char* vertexSource = lua_tostring(L, 1);
   const char* fragmentSource = lua_tostring(L, 2);
   Shader* shader = lovrShaderCreateGraphics(vertexSource, fragmentSource);
-  luax_pushobject(L, shader);
-  lovrRelease(shader);
+  luax_pushtype(L, Shader, shader);
+  lovrRelease(Shader, shader);
   return 1;
 }
 
@@ -1316,8 +1316,8 @@ static int l_lovrGraphicsNewComputeShader(lua_State* L) {
   luax_readshadersource(L, 1);
   const char* source = lua_tostring(L, 1);
   Shader* shader = lovrShaderCreateCompute(source);
-  luax_pushobject(L, shader);
-  lovrRelease(shader);
+  luax_pushtype(L, Shader, shader);
+  lovrRelease(Shader, shader);
   return 1;
 }
 
@@ -1397,13 +1397,13 @@ static int l_lovrGraphicsNewTexture(lua_State* L) {
         lovrTextureAllocate(texture, textureData->width, textureData->height, depth, textureData->format);
       }
       lovrTextureReplacePixels(texture, textureData, 0, 0, i, 0);
-      lovrRelease(textureData);
+      lovrRelease(TextureData, textureData);
       lua_pop(L, 1);
     }
   }
 
-  luax_pushobject(L, texture);
-  lovrRelease(texture);
+  luax_pushtype(L, Texture, texture);
+  lovrRelease(Texture, texture);
   return 1;
 }
 
@@ -1503,15 +1503,15 @@ static const luaL_Reg lovrGraphics[] = {
 int luaopen_lovr_graphics(lua_State* L) {
   lua_newtable(L);
   luaL_register(L, NULL, lovrGraphics);
-  luax_registertype(L, "Animator", lovrAnimator);
-  luax_registertype(L, "Font", lovrFont);
-  luax_registertype(L, "Material", lovrMaterial);
-  luax_registertype(L, "Mesh", lovrMesh);
-  luax_registertype(L, "Model", lovrModel);
-  luax_registertype(L, "Shader", lovrShader);
-  luax_registertype(L, "ShaderBlock", lovrShaderBlock);
-  luax_registertype(L, "Texture", lovrTexture);
-  luax_registertype(L, "Canvas", lovrCanvas);
+  luax_registertype(L, Animator);
+  luax_registertype(L, Font);
+  luax_registertype(L, Material);
+  luax_registertype(L, Mesh);
+  luax_registertype(L, Model);
+  luax_registertype(L, Shader);
+  luax_registertype(L, ShaderBlock);
+  luax_registertype(L, Texture);
+  luax_registertype(L, Canvas);
 
   luax_pushconf(L);
 

--- a/src/api/headset.c
+++ b/src/api/headset.c
@@ -251,7 +251,7 @@ static int l_lovrHeadsetGetControllers(lua_State* L) {
   Controller** controllers = lovrHeadsetDriver->getControllers(&count);
   lua_createtable(L, count, 0);
   for (uint8_t i = 0; i < count; i++) {
-    luax_pushobject(L, controllers[i]);
+    luax_pushtype(L, Controller, controllers[i]);
     lua_rawseti(L, -2, i + 1);
   }
   return 1;
@@ -294,9 +294,10 @@ static int l_lovrHeadsetUpdate(lua_State* L) {
 
 static int l_lovrHeadsetGetMirrorTexture(lua_State* L) {
   Texture *texture = NULL;
-  if (lovrHeadsetDriver->getMirrorTexture)
+  if (lovrHeadsetDriver->getMirrorTexture) {
     texture = lovrHeadsetDriver->getMirrorTexture();
-  luax_pushobject(L, texture);
+  }
+  luax_pushtype(L, Texture, texture);
 
   return 1;
 }
@@ -331,7 +332,7 @@ static const luaL_Reg lovrHeadset[] = {
 int luaopen_lovr_headset(lua_State* L) {
   lua_newtable(L);
   luaL_register(L, NULL, lovrHeadset);
-  luax_registertype(L, "Controller", lovrController);
+  luax_registertype(L, Controller);
 
   luax_pushconf(L);
   lua_getfield(L, -1, "headset");

--- a/src/api/math.c
+++ b/src/api/math.c
@@ -74,7 +74,7 @@ static int l_lovrMathNewCurve(lua_State* L) {
 
   if (top == 1 && lua_type(L, 1) == LUA_TNUMBER) {
     Curve* curve = lovrCurveCreate(luaL_checkinteger(L, 1));
-    luax_pushobject(L, curve);
+    luax_pushtype(L, Curve, curve);
     return 1;
   }
 
@@ -102,16 +102,16 @@ static int l_lovrMathNewCurve(lua_State* L) {
     }
   }
 
-  luax_pushobject(L, curve);
-  lovrRelease(curve);
+  luax_pushtype(L, Curve, curve);
+  lovrRelease(Curve, curve);
   return 1;
 }
 
 static int l_lovrMathNewPool(lua_State* L) {
   size_t size = luaL_optinteger(L, 1, DEFAULT_POOL_SIZE);
   Pool* pool = lovrPoolCreate(size);
-  luax_pushobject(L, pool);
-  lovrRelease(pool);
+  luax_pushtype(L, Pool, pool);
+  lovrRelease(Pool, pool);
   return 1;
 }
 
@@ -121,8 +121,8 @@ static int l_lovrMathNewRandomGenerator(lua_State* L) {
     Seed seed = luax_checkrandomseed(L, 1);
     lovrRandomGeneratorSetSeed(generator, seed);
   }
-  luax_pushobject(L, generator);
-  lovrRelease(generator);
+  luax_pushtype(L, RandomGenerator, generator);
+  lovrRelease(RandomGenerator, generator);
   return 1;
 }
 
@@ -168,25 +168,25 @@ static int l_lovrMathNoise(lua_State* L) {
 }
 
 static int l_lovrMathRandom(lua_State* L) {
-  luax_pushobject(L, lovrMathGetRandomGenerator());
+  luax_pushtype(L, RandomGenerator, lovrMathGetRandomGenerator());
   lua_insert(L, 1);
   return l_lovrRandomGeneratorRandom(L);
 }
 
 static int l_lovrMathRandomNormal(lua_State* L) {
-  luax_pushobject(L, lovrMathGetRandomGenerator());
+  luax_pushtype(L, RandomGenerator, lovrMathGetRandomGenerator());
   lua_insert(L, 1);
   return l_lovrRandomGeneratorRandomNormal(L);
 }
 
 static int l_lovrMathGetRandomSeed(lua_State* L) {
-  luax_pushobject(L, lovrMathGetRandomGenerator());
+  luax_pushtype(L, RandomGenerator, lovrMathGetRandomGenerator());
   lua_insert(L, 1);
   return l_lovrRandomGeneratorGetSeed(L);
 }
 
 static int l_lovrMathSetRandomSeed(lua_State* L) {
-  luax_pushobject(L, lovrMathGetRandomGenerator());
+  luax_pushtype(L, RandomGenerator, lovrMathGetRandomGenerator());
   lua_insert(L, 1);
   return l_lovrRandomGeneratorSetSeed(L);
 }
@@ -283,12 +283,12 @@ static int l_lovrLightUserdataOp(lua_State* L) {
 int luaopen_lovr_math(lua_State* L) {
   lua_newtable(L);
   luaL_register(L, NULL, lovrMath);
-  luax_registertype(L, "Curve", lovrCurve);
-  luax_registertype(L, "Pool", lovrPool);
-  luax_registertype(L, "RandomGenerator", lovrRandomGenerator);
+  luax_registertype(L, Curve);
+  luax_registertype(L, Pool);
+  luax_registertype(L, RandomGenerator);
 
   for (int i = 0; i < MAX_MATH_TYPES; i++) {
-    luax_registertype(L, lovrMathTypeNames[i], lovrMathTypes[i]);
+    _luax_registertype(L, lovrMathTypeNames[i], lovrMathTypes[i], NULL);
     luaL_getmetatable(L, lovrMathTypeNames[i]);
 
     // Remove usual __gc handler

--- a/src/api/physics.c
+++ b/src/api/physics.c
@@ -39,8 +39,8 @@ static int l_lovrPhysicsNewWorld(lua_State* L) {
     tagCount = 0;
   }
   World* world = lovrWorldCreate(xg, yg, zg, allowSleep, tags, tagCount);
-  luax_pushobject(L, world);
-  lovrRelease(world);
+  luax_pushtype(L, World, world);
+  lovrRelease(World, world);
   return 1;
 }
 
@@ -51,8 +51,8 @@ static int l_lovrPhysicsNewBallJoint(lua_State* L) {
   float y = luax_checkfloat(L, 4);
   float z = luax_checkfloat(L, 5);
   BallJoint* joint = lovrBallJointCreate(a, b, x, y, z);
-  luax_pushobject(L, joint);
-  lovrRelease(joint);
+  luax_pushtype(L, BallJoint, joint);
+  lovrRelease(Joint, joint);
   return 1;
 }
 
@@ -61,8 +61,8 @@ static int l_lovrPhysicsNewBoxShape(lua_State* L) {
   float y = luax_optfloat(L, 2, x);
   float z = luax_optfloat(L, 3, x);
   BoxShape* box = lovrBoxShapeCreate(x, y, z);
-  luax_pushobject(L, box);
-  lovrRelease(box);
+  luax_pushtype(L, BoxShape, box);
+  lovrRelease(Shape, box);
   return 1;
 }
 
@@ -70,8 +70,8 @@ static int l_lovrPhysicsNewCapsuleShape(lua_State* L) {
   float radius = luax_optfloat(L, 1, 1.f);
   float length = luax_optfloat(L, 2, 1.f);
   CapsuleShape* capsule = lovrCapsuleShapeCreate(radius, length);
-  luax_pushobject(L, capsule);
-  lovrRelease(capsule);
+  luax_pushtype(L, CapsuleShape, capsule);
+  lovrRelease(Shape, capsule);
   return 1;
 }
 
@@ -79,8 +79,8 @@ static int l_lovrPhysicsNewCylinderShape(lua_State* L) {
   float radius = luax_optfloat(L, 1, 1.f);
   float length = luax_optfloat(L, 2, 1.f);
   CylinderShape* cylinder = lovrCylinderShapeCreate(radius, length);
-  luax_pushobject(L, cylinder);
-  lovrRelease(cylinder);
+  luax_pushtype(L, CylinderShape, cylinder);
+  lovrRelease(Shape, cylinder);
   return 1;
 }
 
@@ -94,8 +94,8 @@ static int l_lovrPhysicsNewDistanceJoint(lua_State* L) {
   float y2 = luax_checkfloat(L, 7);
   float z2 = luax_checkfloat(L, 8);
   DistanceJoint* joint = lovrDistanceJointCreate(a, b, x1, y1, z1, x2, y2, z2);
-  luax_pushobject(L, joint);
-  lovrRelease(joint);
+  luax_pushtype(L, DistanceJoint, joint);
+  lovrRelease(Joint, joint);
   return 1;
 }
 
@@ -109,8 +109,8 @@ static int l_lovrPhysicsNewHingeJoint(lua_State* L) {
   float ay = luax_checkfloat(L, 7);
   float az = luax_checkfloat(L, 8);
   HingeJoint* joint = lovrHingeJointCreate(a, b, x, y, z, ax, ay, az);
-  luax_pushobject(L, joint);
-  lovrRelease(joint);
+  luax_pushtype(L, HingeJoint, joint);
+  lovrRelease(Joint, joint);
   return 1;
 }
 
@@ -121,16 +121,16 @@ static int l_lovrPhysicsNewSliderJoint(lua_State* L) {
   float ay = luax_checkfloat(L, 4);
   float az = luax_checkfloat(L, 5);
   SliderJoint* joint = lovrSliderJointCreate(a, b, ax, ay, az);
-  luax_pushobject(L, joint);
-  lovrRelease(joint);
+  luax_pushtype(L, SliderJoint, joint);
+  lovrRelease(Joint, joint);
   return 1;
 }
 
 static int l_lovrPhysicsNewSphereShape(lua_State* L) {
   float radius = luax_optfloat(L, 1, 1.f);
   SphereShape* sphere = lovrSphereShapeCreate(radius);
-  luax_pushobject(L, sphere);
-  lovrRelease(sphere);
+  luax_pushtype(L, SphereShape, sphere);
+  lovrRelease(Shape, sphere);
   return 1;
 }
 
@@ -150,16 +150,16 @@ static const luaL_Reg lovrPhysics[] = {
 int luaopen_lovr_physics(lua_State* L) {
   lua_newtable(L);
   luaL_register(L, NULL, lovrPhysics);
-  luax_registertype(L, "World", lovrWorld);
-  luax_registertype(L, "Collider", lovrCollider);
-  luax_extendtype(L, "Joint", "BallJoint", lovrJoint, lovrBallJoint);
-  luax_extendtype(L, "Joint", "DistanceJoint", lovrJoint, lovrDistanceJoint);
-  luax_extendtype(L, "Joint", "HingeJoint", lovrJoint, lovrHingeJoint);
-  luax_extendtype(L, "Joint", "SliderJoint", lovrJoint, lovrSliderJoint);
-  luax_extendtype(L, "Shape", "SphereShape", lovrShape, lovrSphereShape);
-  luax_extendtype(L, "Shape", "BoxShape", lovrShape, lovrBoxShape);
-  luax_extendtype(L, "Shape", "CapsuleShape", lovrShape, lovrCapsuleShape);
-  luax_extendtype(L, "Shape", "CylinderShape", lovrShape, lovrCylinderShape);
+  luax_registertype(L, World);
+  luax_registertype(L, Collider);
+  luax_extendtype(L, Joint, BallJoint);
+  luax_extendtype(L, Joint, DistanceJoint);
+  luax_extendtype(L, Joint, HingeJoint);
+  luax_extendtype(L, Joint, SliderJoint);
+  luax_extendtype(L, Shape, SphereShape);
+  luax_extendtype(L, Shape, BoxShape);
+  luax_extendtype(L, Shape, CapsuleShape);
+  luax_extendtype(L, Shape, CylinderShape);
   if (lovrPhysicsInit()) {
     luax_atexit(L, lovrPhysicsDestroy);
   }

--- a/src/api/physics.h
+++ b/src/api/physics.h
@@ -1,0 +1,5 @@
+#include "api.h"
+#include "physics/physics.h"
+
+void luax_pushshape(lua_State* L, Shape* shape);
+void luax_pushjoint(lua_State* L, Joint* joint);

--- a/src/api/thread.c
+++ b/src/api/thread.c
@@ -1,5 +1,6 @@
 #include "api.h"
 #include "event/event.h"
+#include "thread/channel.h"
 #include "thread/thread.h"
 
 static int threadRunner(void* data) {
@@ -28,7 +29,7 @@ static int threadRunner(void* data) {
   mtx_lock(&thread->lock);
   thread->running = false;
   mtx_unlock(&thread->lock);
-  lovrRelease(thread);
+  lovrRelease(Thread, thread);
 
   if (thread->error) {
     lovrEventPush((Event) {
@@ -46,15 +47,15 @@ static int threadRunner(void* data) {
 static int l_lovrThreadNewThread(lua_State* L) {
   const char* body = luaL_checkstring(L, 1);
   Thread* thread = lovrThreadCreate(threadRunner, body);
-  luax_pushobject(L, thread);
-  lovrRelease(thread);
+  luax_pushtype(L, Thread, thread);
+  lovrRelease(Thread, thread);
   return 1;
 }
 
 static int l_lovrThreadGetChannel(lua_State* L) {
   const char* name = luaL_checkstring(L, 1);
   Channel* channel = lovrThreadGetChannel(name);
-  luax_pushobject(L, channel);
+  luax_pushtype(L, Channel, channel);
   return 1;
 }
 
@@ -67,8 +68,8 @@ static const luaL_Reg lovrThreadModule[] = {
 int luaopen_lovr_thread(lua_State* L) {
   lua_newtable(L);
   luaL_register(L, NULL, lovrThreadModule);
-  luax_registertype(L, "Thread", lovrThread);
-  luax_registertype(L, "Channel", lovrChannel);
+  luax_registertype(L, Thread);
+  luax_registertype(L, Channel);
   if (lovrThreadModuleInit()) {
     luax_atexit(L, lovrThreadModuleDestroy);
   }

--- a/src/api/types/audioStream.c
+++ b/src/api/types/audioStream.c
@@ -8,8 +8,8 @@ static int l_lovrAudioStreamDecode(lua_State* L) {
   if (samples > 0) {
     SoundData* soundData = lovrSoundDataCreate(samples / stream->channelCount, stream->sampleRate, stream->bitDepth, stream->channelCount);
     memcpy(soundData->blob.data, stream->buffer, samples * (stream->bitDepth / 8));
-    luax_pushobject(L, soundData);
-    lovrRelease(soundData);
+    luax_pushtype(L, SoundData, soundData);
+    lovrRelease(SoundData, soundData);
   } else {
     lua_pushnil(L);
   }

--- a/src/api/types/canvas.c
+++ b/src/api/types/canvas.c
@@ -68,8 +68,8 @@ static int l_lovrCanvasNewTextureData(lua_State* L) {
   lovrCanvasGetAttachments(canvas, &count);
   lovrAssert(index >= 0 && index < count, "Can not create a TextureData from Texture #%d of Canvas (it only has %d textures)", index, count);
   TextureData* textureData = lovrCanvasNewTextureData(canvas, index);
-  luax_pushobject(L, textureData);
-  lovrRelease(textureData);
+  luax_pushtype(L, TextureData, textureData);
+  lovrRelease(TextureData, textureData);
   return 1;
 }
 
@@ -89,7 +89,7 @@ static int l_lovrCanvasGetTexture(lua_State* L) {
   int count;
   const Attachment* attachments = lovrCanvasGetAttachments(canvas, &count);
   for (int i = 0; i < count; i++) {
-    luax_pushobject(L, attachments[i].texture);
+    luax_pushtype(L, Texture, attachments[i].texture);
   }
   return count;
 }
@@ -125,7 +125,7 @@ static int l_lovrCanvasGetDimensions(lua_State* L) {
 static int l_lovrCanvasGetDepthTexture(lua_State* L) {
   Canvas* canvas = luax_checktype(L, 1, Canvas);
   Texture* texture = lovrCanvasGetDepthTexture(canvas);
-  luax_pushobject(L, texture);
+  luax_pushtype(L, Texture, texture);
   return 1;
 }
 

--- a/src/api/types/collider.c
+++ b/src/api/types/collider.c
@@ -1,4 +1,5 @@
 #include "api.h"
+#include "api/physics.h"
 #include "physics/physics.h"
 #include <stdbool.h>
 
@@ -11,7 +12,7 @@ static int l_lovrColliderDestroy(lua_State* L) {
 static int l_lovrColliderGetWorld(lua_State* L) {
   Collider* collider = luax_checktype(L, 1, Collider);
   World* world = lovrColliderGetWorld(collider);
-  luax_pushobject(L, world);
+  luax_pushtype(L, World, world);
   return 1;
 }
 
@@ -34,7 +35,7 @@ static int l_lovrColliderGetShapes(lua_State* L) {
   lua_newtable(L);
   vec_void_t* shapes = lovrColliderGetShapes(collider);
   for (int i = 0; i < shapes->length; i++) {
-    luax_pushobject(L, shapes->data[i]);
+    luax_pushshape(L, shapes->data[i]);
     lua_rawseti(L, -2, i + 1);
   }
   return 1;
@@ -45,7 +46,7 @@ static int l_lovrColliderGetJoints(lua_State* L) {
   lua_newtable(L);
   vec_void_t* joints = lovrColliderGetJoints(collider);
   for (int i = 0; i < joints->length; i++) {
-    luax_pushobject(L, joints->data[i]);
+    luax_pushjoint(L, joints->data[i]);
     lua_rawseti(L, -2, i + 1);
   }
   return 1;

--- a/src/api/types/controller.c
+++ b/src/api/types/controller.c
@@ -106,9 +106,9 @@ static int l_lovrControllerNewModel(lua_State* L) {
   ModelData* modelData = lovrHeadsetDriver->controllerNewModelData(controller);
   if (modelData) {
     Model* model = lovrModelCreate(modelData);
-    luax_pushobject(L, model);
-    lovrRelease(modelData);
-    lovrRelease(model);
+    luax_pushtype(L, Model, model);
+    lovrRelease(ModelData, modelData);
+    lovrRelease(Model, model);
   } else {
     lua_pushnil(L);
   }

--- a/src/api/types/curve.c
+++ b/src/api/types/curve.c
@@ -46,7 +46,7 @@ static int l_lovrCurveSlice(lua_State* L) {
   float t1 = luax_checkfloat(L, 2);
   float t2 = luax_checkfloat(L, 3);
   Curve* subcurve = lovrCurveSlice(curve, t1, t2);
-  luax_pushobject(L, subcurve);
+  luax_pushtype(L, Curve, subcurve);
   return 1;
 }
 

--- a/src/api/types/font.c
+++ b/src/api/types/font.c
@@ -82,7 +82,7 @@ static int l_lovrFontSetPixelDensity(lua_State* L) {
 
 static int l_lovrFontGetRasterizer(lua_State* L) {
   Font* font = luax_checktype(L, 1, Font);
-  luax_pushobject(L, lovrFontGetRasterizer(font));
+  luax_pushtype(L, Rasterizer, lovrFontGetRasterizer(font));
   return 1;
 }
 

--- a/src/api/types/joints.c
+++ b/src/api/types/joints.c
@@ -1,6 +1,15 @@
 #include "api.h"
 #include "physics/physics.h"
 
+void luax_pushjoint(lua_State* L, Joint* joint) {
+  switch (joint->type) {
+    case JOINT_BALL: luax_pushtype(L, BallJoint, joint); break;
+    case JOINT_DISTANCE: luax_pushtype(L, DistanceJoint, joint); break;
+    case JOINT_HINGE: luax_pushtype(L, HingeJoint, joint); break;
+    case JOINT_SLIDER: luax_pushtype(L, SliderJoint, joint); break;
+  }
+}
+
 static int l_lovrJointDestroy(lua_State* L) {
   Joint* joint = luax_checktype(L, 1, Joint);
   lovrJointDestroyData(joint);
@@ -18,8 +27,8 @@ static int l_lovrJointGetColliders(lua_State* L) {
   Collider* a;
   Collider* b;
   lovrJointGetColliders(joint, &a, &b);
-  luax_pushobject(L, a);
-  luax_pushobject(L, b);
+  luax_pushtype(L, Collider, a);
+  luax_pushtype(L, Collider, b);
   return 2;
 }
 

--- a/src/api/types/material.c
+++ b/src/api/types/material.c
@@ -46,7 +46,7 @@ static int l_lovrMaterialGetTexture(lua_State* L) {
   Material* material = luax_checktype(L, 1, Material);
   MaterialTexture textureType = luaL_checkoption(L, 2, "diffuse", MaterialTextures);
   Texture* texture = lovrMaterialGetTexture(material, textureType);
-  luax_pushobject(L, texture);
+  luax_pushtype(L, Texture, texture);
   return 1;
 }
 

--- a/src/api/types/mesh.c
+++ b/src/api/types/mesh.c
@@ -471,7 +471,7 @@ static int l_lovrMeshSetDrawRange(lua_State* L) {
 static int l_lovrMeshGetMaterial(lua_State* L) {
   Mesh* mesh = luax_checktype(L, 1, Mesh);
   Material* material = lovrMeshGetMaterial(mesh);
-  luax_pushobject(L, material);
+  luax_pushtype(L, Material, material);
   return 1;
 }
 

--- a/src/api/types/microphone.c
+++ b/src/api/types/microphone.c
@@ -16,8 +16,8 @@ static int l_lovrMicrophoneGetChannelCount(lua_State* L) {
 static int l_lovrMicrophoneGetData(lua_State* L) {
   Microphone* microphone = luax_checktype(L, 1, Microphone);
   SoundData* soundData = lovrMicrophoneGetData(microphone);
-  luax_pushobject(L, soundData);
-  lovrRelease(soundData);
+  luax_pushtype(L, SoundData, soundData);
+  lovrRelease(SoundData, soundData);
   return 1;
 }
 

--- a/src/api/types/model.c
+++ b/src/api/types/model.c
@@ -13,7 +13,7 @@ static int l_lovrModelDraw(lua_State* L) {
 
 static int l_lovrModelGetAnimator(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  luax_pushobject(L, lovrModelGetAnimator(model));
+  luax_pushtype(L, Model, lovrModelGetAnimator(model));
   return 1;
 }
 
@@ -31,7 +31,7 @@ static int l_lovrModelSetAnimator(lua_State* L) {
 static int l_lovrModelGetMaterial(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
   Material* material = lovrModelGetMaterial(model);
-  luax_pushobject(L, material);
+  luax_pushtype(L, Material, material);
   return 1;
 }
 

--- a/src/api/types/shapes.c
+++ b/src/api/types/shapes.c
@@ -1,5 +1,15 @@
 #include "api.h"
+#include "api/physics.h"
 #include "physics/physics.h"
+
+void luax_pushshape(lua_State* L, Shape* shape) {
+  switch (shape->type) {
+    case SHAPE_SPHERE: luax_pushtype(L, SphereShape, shape); break;
+    case SHAPE_BOX: luax_pushtype(L, BoxShape, shape); break;
+    case SHAPE_CAPSULE: luax_pushtype(L, CapsuleShape, shape); break;
+    case SHAPE_CYLINDER: luax_pushtype(L, CylinderShape, shape); break;
+  }
+}
 
 static int l_lovrShapeDestroy(lua_State* L) {
   Shape* shape = luax_checktype(L, 1, Shape);
@@ -15,7 +25,7 @@ static int l_lovrShapeGetType(lua_State* L) {
 
 static int l_lovrShapeGetCollider(lua_State* L) {
   Shape* shape = luax_checktype(L, 1, Shape);
-  luax_pushobject(L, lovrShapeGetCollider(shape));
+  luax_pushtype(L, Collider, lovrShapeGetCollider(shape));
   return 1;
 }
 

--- a/src/api/types/world.c
+++ b/src/api/types/world.c
@@ -1,11 +1,12 @@
 #include "api.h"
+#include "api/physics.h"
 #include "physics/physics.h"
 #include <stdbool.h>
 
 static void collisionResolver(World* world, void* userdata) {
   lua_State* L = userdata;
   luaL_checktype(L, -1, LUA_TFUNCTION);
-  luax_pushobject(L, world);
+  luax_pushtype(L, World, world);
   lua_call(L, 1, 0);
 }
 
@@ -14,8 +15,8 @@ static int nextOverlap(lua_State* L) {
   Shape* a;
   Shape* b;
   if (lovrWorldGetNextOverlap(world, &a, &b)) {
-    luax_pushobject(L, a);
-    luax_pushobject(L, b);
+    luax_pushshape(L, a);
+    luax_pushshape(L, b);
     return 2;
   } else {
     lua_pushnil(L);
@@ -27,7 +28,7 @@ static void raycastCallback(Shape* shape, float x, float y, float z, float nx, f
   lua_State* L = userdata;
   luaL_checktype(L, -1, LUA_TFUNCTION);
   lua_pushvalue(L, -1);
-  luax_pushobject(L, shape);
+  luax_pushshape(L, shape);
   lua_pushnumber(L, x);
   lua_pushnumber(L, y);
   lua_pushnumber(L, z);
@@ -43,8 +44,8 @@ static int l_lovrWorldNewCollider(lua_State* L) {
   float y = luax_optfloat(L, 3, 0.f);
   float z = luax_optfloat(L, 4, 0.f);
   Collider* collider = lovrColliderCreate(world, x, y, z);
-  luax_pushobject(L, collider);
-  lovrRelease(collider);
+  luax_pushtype(L, Collider, collider);
+  lovrRelease(Collider, collider);
   return 1;
 }
 
@@ -59,9 +60,9 @@ static int l_lovrWorldNewBoxCollider(lua_State* L) {
   Collider* collider = lovrColliderCreate(world, x, y, z);
   BoxShape* shape = lovrBoxShapeCreate(sx, sy, sz);
   lovrColliderAddShape(collider, shape);
-  luax_pushobject(L, collider);
-  lovrRelease(collider);
-  lovrRelease(shape);
+  luax_pushtype(L, Collider, collider);
+  lovrRelease(Collider, collider);
+  lovrRelease(Shape, shape);
   return 1;
 }
 
@@ -75,9 +76,9 @@ static int l_lovrWorldNewCapsuleCollider(lua_State* L) {
   Collider* collider = lovrColliderCreate(world, x, y, z);
   CapsuleShape* shape = lovrCapsuleShapeCreate(radius, length);
   lovrColliderAddShape(collider, shape);
-  luax_pushobject(L, collider);
-  lovrRelease(collider);
-  lovrRelease(shape);
+  luax_pushtype(L, Collider, collider);
+  lovrRelease(Collider, collider);
+  lovrRelease(Shape, shape);
   return 1;
 }
 
@@ -91,9 +92,9 @@ static int l_lovrWorldNewCylinderCollider(lua_State* L) {
   Collider* collider = lovrColliderCreate(world, x, y, z);
   CylinderShape* shape = lovrCylinderShapeCreate(radius, length);
   lovrColliderAddShape(collider, shape);
-  luax_pushobject(L, collider);
-  lovrRelease(collider);
-  lovrRelease(shape);
+  luax_pushtype(L, Collider, collider);
+  lovrRelease(Collider, collider);
+  lovrRelease(Shape, shape);
   return 1;
 }
 
@@ -106,9 +107,9 @@ static int l_lovrWorldNewSphereCollider(lua_State* L) {
   Collider* collider = lovrColliderCreate(world, x, y, z);
   SphereShape* shape = lovrSphereShapeCreate(radius);
   lovrColliderAddShape(collider, shape);
-  luax_pushobject(L, collider);
-  lovrRelease(collider);
-  lovrRelease(shape);
+  luax_pushtype(L, Collider, collider);
+  lovrRelease(Collider, collider);
+  lovrRelease(Shape, shape);
   return 1;
 }
 

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -52,7 +52,7 @@ void lovrAudioDestroy() {
   alcDestroyContext(state.context);
   alcCloseDevice(state.device);
   for (int i = 0; i < state.sources.length; i++) {
-    lovrRelease(state.sources.data[i]);
+    lovrRelease(Source, state.sources.data[i]);
   }
   vec_deinit(&state.sources);
   memset(&state, 0, sizeof(AudioState));
@@ -79,7 +79,7 @@ void lovrAudioUpdate() {
     } else if (isStopped) {
       lovrAudioStreamRewind(source->stream);
       vec_splice(&state.sources, i, 1);
-      lovrRelease(source);
+      lovrRelease(Source, source);
     }
   }
 }

--- a/src/audio/source.c
+++ b/src/audio/source.c
@@ -36,8 +36,8 @@ void lovrSourceDestroy(void* ref) {
   Source* source = ref;
   alDeleteSources(1, &source->id);
   alDeleteBuffers(source->type == SOURCE_STATIC ? 1 : SOURCE_BUFFERS, source->buffers);
-  lovrRelease(source->soundData);
-  lovrRelease(source->stream);
+  lovrRelease(SoundData, source->soundData);
+  lovrRelease(Source, source->stream);
 }
 
 SourceType lovrSourceGetType(Source* source) {

--- a/src/data/audioStream.c
+++ b/src/data/audioStream.c
@@ -26,7 +26,7 @@ AudioStream* lovrAudioStreamInit(AudioStream* stream, Blob* blob, size_t bufferS
 void lovrAudioStreamDestroy(void* ref) {
   AudioStream* stream = ref;
   stb_vorbis_close(stream->decoder);
-  lovrRelease(stream->blob);
+  lovrRelease(Blob, stream->blob);
   free(stream->buffer);
 }
 

--- a/src/data/modelData.c
+++ b/src/data/modelData.c
@@ -14,10 +14,10 @@ ModelData* lovrModelDataInit(ModelData* model, Blob* source) {
 void lovrModelDataDestroy(void* ref) {
   ModelData* model = ref;
   for (int i = 0; i < model->blobCount; i++) {
-    lovrRelease(model->blobs[i]);
+    lovrRelease(Blob, model->blobs[i]);
   }
   for (int i = 0; i < model->textureCount; i++) {
-    lovrRelease(model->textures[i]);
+    lovrRelease(TextureData, model->textures[i]);
   }
   free(model->data);
 }

--- a/src/data/modelData_gltf.c
+++ b/src/data/modelData_gltf.c
@@ -596,7 +596,7 @@ ModelData* lovrModelDataInitGltf(ModelData* model, Blob* source) {
           Blob* blob = lovrBlobCreate(buffer->data, buffer->size, NULL);
           *texture = lovrTextureDataCreateFromBlob(blob, false);
           blob->data = NULL; // FIXME
-          lovrRelease(blob);
+          lovrRelease(Blob, blob);
         } else if (STR_EQ(key, "uri")) {
           size_t size = 0;
           char filename[1024];
@@ -607,7 +607,7 @@ ModelData* lovrModelDataInitGltf(ModelData* model, Blob* source) {
           lovrAssert(data && size > 0, "Unable to read texture from '%s'", filename);
           Blob* blob = lovrBlobCreate(data, size, NULL);
           *texture = lovrTextureDataCreateFromBlob(blob, false);
-          lovrRelease(blob);
+          lovrRelease(Blob, blob);
         } else {
           token += NOM_VALUE(json, token);
         }

--- a/src/data/modelData_obj.c
+++ b/src/data/modelData_obj.c
@@ -66,7 +66,7 @@ static void parseMtl(char* path, vec_void_t* textures, vec_material_t* materials
       material->filters[TEXTURE_DIFFUSE].mode = FILTER_TRILINEAR;
       material->wraps[TEXTURE_DIFFUSE] = (TextureWrap) { .s = WRAP_REPEAT, .t = WRAP_REPEAT };
       vec_push(textures, texture);
-      lovrRelease(blob);
+      lovrRelease(Blob, blob);
     } else {
       char* newline = memchr(s, '\n', length);
       lineLength = newline - s + 1;

--- a/src/data/rasterizer.c
+++ b/src/data/rasterizer.c
@@ -33,7 +33,7 @@ Rasterizer* lovrRasterizerInit(Rasterizer* rasterizer, Blob* blob, float size) {
 
 void lovrRasterizerDestroy(void* ref) {
   Rasterizer* rasterizer = ref;
-  lovrRelease(rasterizer->blob);
+  lovrRelease(Blob, rasterizer->blob);
 }
 
 bool lovrRasterizerHasGlyph(Rasterizer* rasterizer, uint32_t character) {

--- a/src/data/textureData.c
+++ b/src/data/textureData.c
@@ -231,7 +231,7 @@ bool lovrTextureDataEncode(TextureData* textureData, const char* filename) {
 
 void lovrTextureDataDestroy(void* ref) {
   TextureData* textureData = ref;
-  lovrRelease(textureData->source);
+  lovrRelease(Blob, textureData->source);
   vec_deinit(&textureData->mipmaps);
   lovrBlobDestroy(ref);
 }

--- a/src/event/event.c
+++ b/src/event/event.c
@@ -8,7 +8,7 @@ static EventState state;
 void lovrVariantDestroy(Variant* variant) {
   switch (variant->type) {
     case TYPE_STRING: free(variant->value.string); return;
-    case TYPE_OBJECT: lovrRelease(variant->value.ref); return;
+    //case TYPE_OBJECT: lovrRelease(variant->value.ref); return;
     default: return;
   }
 }

--- a/src/event/event.c
+++ b/src/event/event.c
@@ -8,7 +8,6 @@ static EventState state;
 void lovrVariantDestroy(Variant* variant) {
   switch (variant->type) {
     case TYPE_STRING: free(variant->value.string); return;
-    //case TYPE_OBJECT: lovrRelease(variant->value.ref); return;
     default: return;
   }
 }

--- a/src/event/event.h
+++ b/src/event/event.h
@@ -33,7 +33,11 @@ typedef union {
   bool boolean;
   double number;
   char* string;
-  Ref* ref;
+  struct {
+    Type type;
+    Ref* pointer;
+    const char* name;
+  } ref;
 } VariantValue;
 
 typedef struct {

--- a/src/event/event.h
+++ b/src/event/event.h
@@ -33,15 +33,12 @@ typedef union {
   bool boolean;
   double number;
   char* string;
-  struct {
-    Type type;
-    Ref* pointer;
-    const char* name;
-  } ref;
+  void* object;
 } VariantValue;
 
 typedef struct {
   VariantType type;
+  Type lovrType; // This could go in the union, but having it here keeps the struct 16 bytes
   VariantValue value;
 } Variant;
 

--- a/src/graphics/animator.c
+++ b/src/graphics/animator.c
@@ -34,7 +34,7 @@ Animator* lovrAnimatorInit(Animator* animator, ModelData* data) {
 
 void lovrAnimatorDestroy(void* ref) {
   Animator* animator = ref;
-  lovrRelease(animator->data);
+  lovrRelease(Animator, animator->data);
   vec_deinit(&animator->tracks);
 }
 

--- a/src/graphics/canvas.c
+++ b/src/graphics/canvas.c
@@ -28,7 +28,7 @@ void lovrCanvasSetAttachments(Canvas* canvas, Attachment* attachments, int count
   }
 
   for (int i = 0; i < canvas->attachmentCount; i++) {
-    lovrRelease(canvas->attachments[i].texture);
+    lovrRelease(Texture, canvas->attachments[i].texture);
   }
 
   memcpy(canvas->attachments, attachments, count * sizeof(Attachment));

--- a/src/graphics/font.c
+++ b/src/graphics/font.c
@@ -51,13 +51,13 @@ Font* lovrFontInit(Font* font, Rasterizer* rasterizer) {
 
 void lovrFontDestroy(void* ref) {
   Font* font = ref;
-  lovrRelease(font->rasterizer);
-  lovrRelease(font->texture);
+  lovrRelease(Rasterizer, font->rasterizer);
+  lovrRelease(Texture, font->texture);
   const char* key;
   map_iter_t iter = map_iter(&font->atlas.glyphs);
   while ((key = map_next(&font->atlas.glyphs, &iter)) != NULL) {
     Glyph* glyph = map_get(&font->atlas.glyphs, key);
-    lovrRelease(glyph->data);
+    lovrRelease(TextureData, glyph->data);
   }
   map_deinit(&font->atlas.glyphs);
   map_deinit(&font->kerning);
@@ -342,10 +342,10 @@ void lovrFontExpandTexture(Font* font) {
 // TODO we only need the TextureData here to clear the texture, but it's a big waste of memory.
 // Could look into using glClearTexImage when supported to make this more efficient.
 void lovrFontCreateTexture(Font* font) {
-  lovrRelease(font->texture);
+  lovrRelease(Texture, font->texture);
   TextureData* textureData = lovrTextureDataCreate(font->atlas.width, font->atlas.height, 0x0, FORMAT_RGB);
   font->texture = lovrTextureCreate(TEXTURE_2D, &textureData, 1, false, false, 0);
   lovrTextureSetFilter(font->texture, (TextureFilter) { .mode = FILTER_BILINEAR });
   lovrTextureSetWrap(font->texture, (TextureWrap) { .s = WRAP_CLAMP, .t = WRAP_CLAMP });
-  lovrRelease(textureData);
+  lovrRelease(TextureData, textureData);
 }

--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -164,19 +164,19 @@ void lovrGraphicsDestroy() {
   lovrGraphicsSetFont(NULL);
   lovrGraphicsSetCanvas(NULL);
   for (int i = 0; i < MAX_DEFAULT_SHADERS; i++) {
-    lovrRelease(state.defaultShaders[i]);
+    lovrRelease(Shader, state.defaultShaders[i]);
   }
   for (int i = 0; i < MAX_BUFFER_ROLES; i++) {
-    lovrRelease(state.buffers[i]);
+    lovrRelease(Buffer, state.buffers[i]);
     for (int j = 0; j < MAX_LOCKS; j++) {
       lovrGpuDestroyLock(state.locks[i][j]);
     }
   }
-  lovrRelease(state.mesh);
-  lovrRelease(state.instancedMesh);
-  lovrRelease(state.identityBuffer);
-  lovrRelease(state.defaultMaterial);
-  lovrRelease(state.defaultFont);
+  lovrRelease(Mesh, state.mesh);
+  lovrRelease(Mesh, state.instancedMesh);
+  lovrRelease(Buffer, state.identityBuffer);
+  lovrRelease(Material, state.defaultMaterial);
+  lovrRelease(Font, state.defaultFont);
   lovrGpuDestroy();
   memset(&state, 0, sizeof(GraphicsState));
 }
@@ -310,7 +310,7 @@ void lovrGraphicsSetCanvas(Canvas* canvas) {
   }
 
   lovrRetain(canvas);
-  lovrRelease(state.canvas);
+  lovrRelease(Canvas, state.canvas);
   state.canvas = canvas;
 }
 
@@ -353,7 +353,7 @@ Font* lovrGraphicsGetFont() {
     if (!state.defaultFont) {
       Rasterizer* rasterizer = lovrRasterizerCreate(NULL, 32);
       state.defaultFont = lovrFontCreate(rasterizer);
-      lovrRelease(rasterizer);
+      lovrRelease(Rasterizer, rasterizer);
     }
 
     lovrGraphicsSetFont(state.defaultFont);
@@ -364,7 +364,7 @@ Font* lovrGraphicsGetFont() {
 
 void lovrGraphicsSetFont(Font* font) {
   lovrRetain(font);
-  lovrRelease(state.font);
+  lovrRelease(Font, state.font);
   state.font = font;
 }
 
@@ -396,7 +396,7 @@ Shader* lovrGraphicsGetShader() {
 void lovrGraphicsSetShader(Shader* shader) {
   lovrAssert(!shader || lovrShaderGetType(shader) == SHADER_GRAPHICS, "Compute shaders can not be set as the active shader");
   lovrRetain(shader);
-  lovrRelease(state.shader);
+  lovrRelease(Shader, state.shader);
   state.shader = shader;
 }
 

--- a/src/graphics/material.c
+++ b/src/graphics/material.c
@@ -25,7 +25,7 @@ void lovrMaterialDestroy(void* ref) {
   Material* material = ref;
   lovrGraphicsFlushMaterial(material);
   for (int i = 0; i < MAX_MATERIAL_TEXTURES; i++) {
-    lovrRelease(material->textures[i]);
+    lovrRelease(Texture, material->textures[i]);
   }
 }
 
@@ -75,7 +75,7 @@ void lovrMaterialSetTexture(Material* material, MaterialTexture textureType, Tex
   if (material->textures[textureType] != texture) {
     lovrGraphicsFlushMaterial(material);
     lovrRetain(texture);
-    lovrRelease(material->textures[textureType]);
+    lovrRelease(Texture, material->textures[textureType]);
     material->textures[textureType] = texture;
   }
 }

--- a/src/graphics/mesh.c
+++ b/src/graphics/mesh.c
@@ -38,7 +38,7 @@ void lovrMeshDetachAttribute(Mesh* mesh, const char* name) {
   lovrAssert(index, "No attached attribute named '%s' was found", name);
   MeshAttribute* attribute = &mesh->attributes[*index];
   lovrGraphicsFlushMesh(mesh);
-  lovrRelease(attribute->buffer);
+  lovrRelease(Buffer, attribute->buffer);
   map_remove(&mesh->attributeMap, name);
   mesh->attributeNames[*index][0] = '\0';
   memmove(mesh->attributeNames + *index, mesh->attributeNames + *index + 1, (mesh->attributeCount - *index - 1) * MAX_ATTRIBUTE_NAME_LENGTH * sizeof(char));
@@ -100,6 +100,6 @@ Material* lovrMeshGetMaterial(Mesh* mesh) {
 
 void lovrMeshSetMaterial(Mesh* mesh, Material* material) {
   lovrRetain(material);
-  lovrRelease(mesh->material);
+  lovrRelease(Material, mesh->material);
   mesh->material = material;
 }

--- a/src/graphics/model.c
+++ b/src/graphics/model.c
@@ -186,12 +186,12 @@ Model* lovrModelInit(Model* model, ModelData* data) {
 void lovrModelDestroy(void* ref) {
   Model* model = ref;
   for (int i = 0; i < model->data->bufferCount; i++) {
-    lovrRelease(model->buffers[i]);
+    lovrRelease(Buffer, model->buffers[i]);
   }
   for (int i = 0; i < model->data->primitiveCount; i++) {
-    lovrRelease(model->meshes[i]);
+    lovrRelease(Mesh, model->meshes[i]);
   }
-  lovrRelease(model->data);
+  lovrRelease(ModelData, model->data);
 }
 
 void lovrModelDraw(Model* model, mat4 transform, int instances) {
@@ -206,7 +206,7 @@ Animator* lovrModelGetAnimator(Model* model) {
 void lovrModelSetAnimator(Model* model, Animator* animator) {
   if (model->animator != animator) {
     lovrRetain(animator);
-    lovrRelease(model->animator);
+    lovrRelease(Animator, model->animator);
     model->animator = animator;
   }
 }
@@ -217,7 +217,7 @@ Material* lovrModelGetMaterial(Model* model) {
 
 void lovrModelSetMaterial(Model* model, Material* material) {
   lovrRetain(material);
-  lovrRelease(model->userMaterial);
+  lovrRelease(Material, model->userMaterial);
   model->userMaterial = material;
 }
 

--- a/src/graphics/opengl.c
+++ b/src/graphics/opengl.c
@@ -323,7 +323,7 @@ static Texture* lovrGpuGetDefaultTexture() {
   if (!state.defaultTexture) {
     TextureData* textureData = lovrTextureDataCreate(1, 1, 0xff, FORMAT_RGBA);
     state.defaultTexture = lovrTextureCreate(TEXTURE_2D, &textureData, 1, true, false, 0);
-    lovrRelease(textureData);
+    lovrRelease(TextureData, textureData);
   }
 
   return state.defaultTexture;
@@ -453,7 +453,7 @@ static void lovrGpuBindTexture(Texture* texture, int slot) {
 
   if (texture != state.textures[slot]) {
     lovrRetain(texture);
-    lovrRelease(state.textures[slot]);
+    lovrRelease(Texture, state.textures[slot]);
     state.textures[slot] = texture;
     if (state.activeTexture != slot) {
       glActiveTexture(GL_TEXTURE0 + slot);
@@ -481,7 +481,7 @@ static void lovrGpuBindImage(Image* image, int slot) {
     int slice = layered ? 0 : image->slice;
 
     lovrRetain(texture);
-    lovrRelease(state.images[slot].texture);
+    lovrRelease(Texture, state.images[slot].texture);
     glBindImageTexture(slot, texture->id, image->mipmap, layered, slice, glAccess, glFormat);
     memcpy(state.images + slot, image, sizeof(Image));
   }
@@ -994,12 +994,12 @@ void lovrGpuInit(bool srgb, getProcAddressProc getProcAddress) {
 }
 
 void lovrGpuDestroy() {
-  lovrRelease(state.defaultTexture);
+  lovrRelease(Texture, state.defaultTexture);
   for (int i = 0; i < MAX_TEXTURES; i++) {
-    lovrRelease(state.textures[i]);
+    lovrRelease(Texture, state.textures[i]);
   }
   for (int i = 0; i < MAX_IMAGES; i++) {
-    lovrRelease(state.images[i].texture);
+    lovrRelease(Texture, state.images[i].texture);
   }
   for (int i = 0; i < MAX_BARRIERS; i++) {
     vec_deinit(&state.incoherents[i]);
@@ -1470,9 +1470,9 @@ void lovrCanvasDestroy(void* ref) {
     glDeleteFramebuffers(1, &canvas->resolveBuffer);
   }
   for (int i = 0; i < canvas->attachmentCount; i++) {
-    lovrRelease(canvas->attachments[i].texture);
+    lovrRelease(Texture, canvas->attachments[i].texture);
   }
-  lovrRelease(canvas->depth.texture);
+  lovrRelease(Texture, canvas->depth.texture);
 }
 
 void lovrCanvasResolve(Canvas* canvas) {
@@ -1937,7 +1937,7 @@ void lovrShaderDestroy(void* ref) {
   for (BlockType type = BLOCK_UNIFORM; type <= BLOCK_COMPUTE; type++) {
     UniformBlock* block; int i;
     vec_foreach_ptr(&shader->blocks[type], block, i) {
-      lovrRelease(block->source);
+      lovrRelease(Buffer, block->source);
     }
   }
   vec_deinit(&shader->uniforms);
@@ -1966,19 +1966,19 @@ void lovrMeshDestroy(void* ref) {
   lovrGraphicsFlushMesh(mesh);
   glDeleteVertexArrays(1, &mesh->vao);
   for (int i = 0; i < mesh->attributeCount; i++) {
-    lovrRelease(mesh->attributes[i].buffer);
+    lovrRelease(Buffer, mesh->attributes[i].buffer);
   }
   map_deinit(&mesh->attributeMap);
-  lovrRelease(mesh->vertexBuffer);
-  lovrRelease(mesh->indexBuffer);
-  lovrRelease(mesh->material);
+  lovrRelease(Buffer, mesh->vertexBuffer);
+  lovrRelease(Buffer, mesh->indexBuffer);
+  lovrRelease(Material, mesh->material);
 }
 
 void lovrMeshSetIndexBuffer(Mesh* mesh, Buffer* buffer, uint32_t indexCount, size_t indexSize, size_t offset) {
   if (mesh->indexBuffer != buffer || mesh->indexCount != indexCount || mesh->indexSize != indexSize) {
     lovrGraphicsFlushMesh(mesh);
     lovrRetain(buffer);
-    lovrRelease(mesh->indexBuffer);
+    lovrRelease(Buffer, mesh->indexBuffer);
     mesh->indexBuffer = buffer;
     mesh->indexCount = indexCount;
     mesh->indexSize = indexSize;

--- a/src/graphics/shader.c
+++ b/src/graphics/shader.c
@@ -148,7 +148,7 @@ void lovrShaderSetBlock(Shader* shader, const char* name, Buffer* buffer, size_t
   if (block->source != buffer || block->offset != offset || block->size != size) {
     lovrGraphicsFlushShader(shader);
     lovrRetain(buffer);
-    lovrRelease(block->source);
+    lovrRelease(Buffer, block->source);
     block->access = access;
     block->source = buffer;
     block->offset = offset;
@@ -195,7 +195,7 @@ ShaderBlock* lovrShaderBlockInit(ShaderBlock* block, BlockType type, Buffer* buf
 
 void lovrShaderBlockDestroy(void* ref) {
   ShaderBlock* block = ref;
-  lovrRelease(block->buffer);
+  lovrRelease(Buffer, block->buffer);
   vec_deinit(&block->uniforms);
   map_deinit(&block->uniformMap);
 }

--- a/src/headset/desktop.c
+++ b/src/headset/desktop.c
@@ -61,7 +61,7 @@ static bool desktopInit(float offset, int msaa) {
 static void desktopDestroy() {
   Controller *controller; int i;
   vec_foreach(&state.controllers, controller, i) {
-    lovrRelease(controller);
+    lovrRelease(Controller, controller);
   }
   vec_deinit(&state.controllers);
   memset(&state, 0, sizeof(state));

--- a/src/headset/headset.c
+++ b/src/headset/headset.c
@@ -49,3 +49,7 @@ void lovrHeadsetDestroy() {
     lovrHeadsetDriver = NULL;
   }
 }
+
+void lovrControllerDestroy(void* ref) {
+  //
+}

--- a/src/headset/headset.h
+++ b/src/headset/headset.h
@@ -112,4 +112,4 @@ extern HeadsetInterface* lovrHeadsetDriver;
 
 bool lovrHeadsetInit(HeadsetDriver* drivers, int count, float offset, int msaa);
 void lovrHeadsetDestroy(void);
-#define lovrControllerDestroy NULL
+void lovrControllerDestroy(void* ref);

--- a/src/headset/oculus.c
+++ b/src/headset/oculus.c
@@ -118,7 +118,7 @@ static bool oculusInit(float offset, int msaa) {
 static void oculusDestroy() {
   Controller *controller; int i;
   vec_foreach(&state.controllers, controller, i) {
-    lovrRelease(controller);
+    lovrRelease(Controller, controller);
   }
   vec_deinit(&state.controllers);
 
@@ -126,7 +126,7 @@ static void oculusDestroy() {
   map_iter_t iter = map_iter(&state.textureLookup);
   while ((key = map_next(&state.textureLookup, &iter)) != NULL) {
     Texture* texture = *(Texture**) map_get(&state.textureLookup, key);
-    lovrRelease(texture);
+    lovrRelease(Texture, texture);
   }
   map_deinit(&state.textureLookup);
 
@@ -140,7 +140,7 @@ static void oculusDestroy() {
     state.chain = NULL;
   }
 
-  lovrRelease(state.canvas);
+  lovrRelease(Canvas, state.canvas);
   ovr_Destroy(state.session);
   ovr_Shutdown();
   memset(&state, 0, sizeof(state));

--- a/src/headset/openvr.c
+++ b/src/headset/openvr.c
@@ -178,7 +178,7 @@ static bool openvrInit(float offset, int msaa) {
 }
 
 static void openvrDestroy() {
-  lovrRelease(state.canvas);
+  lovrRelease(Canvas, state.canvas);
   for (int i = 0; i < 16; i++) {
     if (state.deviceModels[i]) {
       state.renderModels->FreeRenderModel(state.deviceModels[i]);
@@ -191,7 +191,7 @@ static void openvrDestroy() {
   }
   Controller* controller; int i;
   vec_foreach(&state.controllers, controller, i) {
-    lovrRelease(controller);
+    lovrRelease(Controller, controller);
   }
   vec_deinit(&state.boundsGeometry);
   vec_deinit(&state.controllers);
@@ -494,7 +494,7 @@ static void openvrRenderTo(void (*callback)(void*), void* userdata) {
     Texture* texture = lovrTextureCreate(TEXTURE_2D, NULL, 0, true, false, state.msaa);
     lovrTextureAllocate(texture, width * 2, height, 1, FORMAT_RGBA);
     lovrCanvasSetAttachments(state.canvas, &(Attachment) { texture, 0, 0 }, 1);
-    lovrRelease(texture);
+    lovrRelease(Texture, texture);
   }
 
   Camera camera = { .canvas = state.canvas, .viewMatrix = { MAT4_IDENTITY, MAT4_IDENTITY } };
@@ -552,7 +552,7 @@ static void openvrUpdate(float dt) {
             lovrRetain(controller);
             lovrEventPush((Event) { .type = EVENT_CONTROLLER_REMOVED, .data.controller = { controller, 0 } });
             vec_swapsplice(&state.controllers, i, 1);
-            lovrRelease(controller);
+            lovrRelease(Controller, controller);
             break;
           }
         }

--- a/src/headset/webvr.c
+++ b/src/headset/webvr.c
@@ -59,7 +59,7 @@ static void onControllerRemoved(uint32_t id) {
         .data.controller = { controller, 0 }
       });
       vec_splice(&state.controllers, i, 1);
-      lovrRelease(controller);
+      lovrRelease(Controller, controller);
       break;
     }
   }

--- a/src/luax.c
+++ b/src/luax.c
@@ -6,11 +6,6 @@
 #include <stdarg.h>
 #include <stdbool.h>
 
-typedef struct {
-  Type type;
-  Ref* ref;
-} Proxy;
-
 static int luax_meta__tostring(lua_State* L) {
   lua_getfield(L, -1, "name");
   return 1;

--- a/src/luax.h
+++ b/src/luax.h
@@ -2,12 +2,16 @@
 #include <lauxlib.h>
 #include <lualib.h>
 #include "lib/map/map.h"
+#include "types.h"
 #include "util.h"
 
 #pragma once
 
-#define luax_totype(L, i, T) ((T*) _luax_totype(L, i, #T))
-#define luax_checktype(L, i, T) ((T*) _luax_checktype(L, i, #T))
+#define luax_registertype(L, T) _luax_registertype(L, #T, lovr ## T, lovr ## T ## Destroy)
+#define luax_extendtype(L, S, T) _luax_extendtype(L, #T, lovr ## S, lovr ## T, lovr ## T ## Destroy)
+#define luax_totype(L, i, T) (T*) _luax_totype(L, i, T_ ## T)
+#define luax_checktype(L, i, T) (T*) _luax_checktype(L, i, T_ ## T, #T)
+#define luax_pushtype(L, T, p) _luax_pushtype(L, p, T_ ## T, #T)
 #define luax_checkfloat(L, i) (float) luaL_checknumber(L, i)
 #define luax_optfloat(L, i, x) (float) luaL_optnumber(L, i, x)
 #define luax_geterror(L) lua_getfield(L, LUA_REGISTRYINDEX, "_lovrerror")
@@ -18,11 +22,11 @@ typedef void (*luax_destructor)(void);
 int luax_print(lua_State* L);
 void luax_atexit(lua_State* L, luax_destructor destructor);
 void luax_registerloader(lua_State* L, lua_CFunction loader, int index);
-void luax_registertype(lua_State* L, const char* name, const luaL_Reg* functions);
-void luax_extendtype(lua_State* L, const char* base, const char* name, const luaL_Reg* baseFunctions, const luaL_Reg* functions);
-void* _luax_totype(lua_State* L, int index, const char* type);
-void* _luax_checktype(lua_State* L, int index, const char* type);
-void luax_pushobject(lua_State* L, void* object);
+void _luax_registertype(lua_State* L, const char* name, const luaL_Reg* functions, lovrDestructor* destructor);
+void _luax_extendtype(lua_State* L, const char* name, const luaL_Reg* baseFunctions, const luaL_Reg* functions, lovrDestructor* destructor);
+void* _luax_totype(lua_State* L, int index, Type type);
+void* _luax_checktype(lua_State* L, int index, Type type, const char* debug);
+void _luax_pushtype(lua_State* L, void* object, Type type, const char* name);
 void luax_vthrow(lua_State* L, const char* format, va_list args);
 void luax_traceback(lua_State* L, lua_State* T, const char* message, int level);
 int luax_getstack(lua_State* L);

--- a/src/luax.h
+++ b/src/luax.h
@@ -7,6 +7,11 @@
 
 #pragma once
 
+typedef struct {
+  Type type;
+  Ref* ref;
+} Proxy;
+
 #define luax_registertype(L, T) _luax_registertype(L, #T, lovr ## T, lovr ## T ## Destroy)
 #define luax_extendtype(L, S, T) _luax_extendtype(L, #T, lovr ## S, lovr ## T, lovr ## T ## Destroy)
 #define luax_totype(L, i, T) (T*) _luax_totype(L, i, T_ ## T)

--- a/src/math/math.c
+++ b/src/math/math.c
@@ -18,7 +18,7 @@ bool lovrMathInit() {
 
 void lovrMathDestroy() {
   if (!state.initialized) return;
-  lovrRelease(state.generator);
+  lovrRelease(RandomGenerator, state.generator);
   memset(&state, 0, sizeof(MathState));
 }
 

--- a/src/math/randomGenerator.c
+++ b/src/math/randomGenerator.c
@@ -29,6 +29,10 @@ RandomGenerator* lovrRandomGeneratorInit(RandomGenerator* generator) {
   return generator;
 }
 
+void lovrRandomGeneratorDestroy(void* ref) {
+  //
+}
+
 Seed lovrRandomGeneratorGetSeed(RandomGenerator* generator) {
   return generator->seed;
 }

--- a/src/math/randomGenerator.h
+++ b/src/math/randomGenerator.h
@@ -22,7 +22,7 @@ typedef struct {
 
 RandomGenerator* lovrRandomGeneratorInit(RandomGenerator* generator);
 #define lovrRandomGeneratorCreate() lovrRandomGeneratorInit(lovrAlloc(RandomGenerator))
-#define lovrRandomGeneratorDestroy NULL
+void lovrRandomGeneratorDestroy(void* ref);
 Seed lovrRandomGeneratorGetSeed(RandomGenerator* generator);
 void lovrRandomGeneratorSetSeed(RandomGenerator* generator, Seed seed);
 void lovrRandomGeneratorGetState(RandomGenerator* generator, char* state, size_t length);

--- a/src/physics/physics.c
+++ b/src/physics/physics.c
@@ -316,7 +316,7 @@ void lovrColliderDestroyData(Collider* collider) {
   vec_void_t* joints = lovrColliderGetJoints(collider);
   Joint* joint; int j;
   vec_foreach(joints, joint, j) {
-    lovrRelease(joint);
+    lovrRelease(Joint, joint);
   }
 
   dBodyDestroy(collider->body);
@@ -328,7 +328,7 @@ void lovrColliderDestroyData(Collider* collider) {
   collider->next = collider->prev = NULL;
 
   // If the Collider is destroyed, the world lets go of its reference to this Collider
-  lovrRelease(collider);
+  lovrRelease(Collider, collider);
 }
 
 World* lovrColliderGetWorld(Collider* collider) {
@@ -353,7 +353,7 @@ void lovrColliderRemoveShape(Collider* collider, Shape* shape) {
     dSpaceRemove(collider->world->space, shape->id);
     dGeomSetBody(shape->id, 0);
     shape->collider = NULL;
-    lovrRelease(shape);
+    lovrRelease(Shape, shape);
   }
 }
 

--- a/src/thread/channel.c
+++ b/src/thread/channel.c
@@ -61,7 +61,7 @@ bool lovrChannelPop(Channel* channel, Variant* variant, double timeout) {
     if (channel->messages.length > 0) {
       *variant = vec_pop(&channel->messages);
       if (channel->messages.length == 0) {
-        lovrRelease(channel);
+        lovrRelease(Channel, channel);
       }
       channel->received++;
       cnd_broadcast(&channel->cond);
@@ -110,7 +110,7 @@ void lovrChannelClear(Channel* channel) {
     if (variant.type == TYPE_STRING) {
       free(variant.value.string);
     } else if (variant.type == TYPE_OBJECT) {
-      lovrRelease(variant.value.ref);
+      //lovrRelease(variant.value.ref);
     }
   }
   channel->received = channel->sent;

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -16,7 +16,7 @@ void lovrThreadModuleDestroy() {
   map_iter_t iter = map_iter(&state.channels);
   while ((key = map_next(&state.channels, &iter)) != NULL) {
     Channel* channel = *(Channel**) map_get(&state.channels, key);
-    lovrRelease(channel);
+    lovrRelease(Channel, channel);
   }
   map_deinit(&state.channels);
   state.initialized = false;

--- a/src/types.c
+++ b/src/types.c
@@ -1,0 +1,22 @@
+#include "types.h"
+#include "util.h"
+
+const Type lovrSupertypes[] = {
+  [T_BallJoint] = T_Joint,
+  [T_BoxShape] = T_Shape,
+  [T_CapsuleShape] = T_Shape,
+  [T_CylinderShape] = T_Shape,
+  [T_DistanceJoint] = T_Joint,
+  [T_HingeJoint] = T_Joint,
+  [T_SliderJoint] = T_Joint,
+  [T_SoundData] = T_Blob,
+  [T_SphereShape] = T_Shape,
+  [T_TextureData] = T_Blob
+};
+
+Ref* _lovrAlloc(size_t size) {
+  Ref* ref = calloc(1, size);
+  lovrAssert(ref, "Out of memory");
+  ref->count = 1;
+  return ref;
+}

--- a/src/types.h
+++ b/src/types.h
@@ -1,0 +1,58 @@
+#include <stdlib.h>
+#include <stdint.h>
+
+#pragma once
+
+typedef enum {
+  T_NONE = 0,
+  T_vec3,
+  T_quat,
+  T_mat4,
+  T_Animator,
+  T_AudioStream,
+  T_BallJoint,
+  T_Blob,
+  T_BoxShape,
+  T_Buffer,
+  T_Canvas,
+  T_CapsuleShape,
+  T_Channel,
+  T_Collider,
+  T_Controller,
+  T_Curve,
+  T_CylinderShape,
+  T_DistanceJoint,
+  T_Font,
+  T_HingeJoint,
+  T_Joint,
+  T_Material,
+  T_Mesh,
+  T_Microphone,
+  T_Model,
+  T_ModelData,
+  T_Pool,
+  T_RandomGenerator,
+  T_Rasterizer,
+  T_Shader,
+  T_ShaderBlock,
+  T_Shape,
+  T_SliderJoint,
+  T_SoundData,
+  T_Source,
+  T_SphereShape,
+  T_Texture,
+  T_TextureData,
+  T_Thread,
+  T_World,
+  T_MAX
+} Type;
+
+typedef struct { uint8_t count; } Ref;
+typedef void lovrDestructor(void*);
+
+extern const Type lovrSupertypes[T_MAX];
+
+Ref* _lovrAlloc(size_t size);
+#define lovrAlloc(T) (T*) _lovrAlloc(sizeof(T))
+#define lovrRetain(R) if (R && ++(((Ref*) R)->count) >= 0xff) lovrThrow("Ref count overflow")
+#define lovrRelease(T, R) if (R && --(((Ref*) R)->count) == 0) lovr ## T ## Destroy(R), free(R)

--- a/src/util.c
+++ b/src/util.c
@@ -28,27 +28,6 @@ void lovrThrow(const char* format, ...) {
   }
 }
 
-void* _lovrAlloc(const char* type, size_t size, void (*destructor)(void*)) {
-  Ref* ref = calloc(1, size);
-  lovrAssert(ref, "Out of memory");
-  ref->destructor = destructor;
-  ref->type = type;
-  ref->count = 1;
-  return ref;
-}
-
-void lovrRetain(void* object) {
-  if (object) ((Ref*) object)->count++;
-}
-
-void lovrRelease(void* object) {
-  Ref* ref = object;
-  if (ref && --ref->count == 0) {
-    if (ref->destructor) ref->destructor(object);
-    free(object);
-  }
-}
-
 // https://github.com/starwing/luautf8
 size_t utf8_decode(const char *s, const char *e, unsigned *pch) {
   unsigned ch;

--- a/src/util.h
+++ b/src/util.h
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdarg.h>
+#include "types.h"
 
 #pragma once
 
@@ -29,18 +30,11 @@
 #define CHECK_SIZEOF(T) int(*_o)[sizeof(T)]=1
 
 #define lovrAssert(c, ...) if (!(c)) { lovrThrow(__VA_ARGS__); }
-#define lovrAlloc(T) (T*) _lovrAlloc(#T, sizeof(T), lovr ## T ## Destroy)
 
 #define MAX(a, b) (a > b ? a : b)
 #define MIN(a, b) (a < b ? a : b)
 #define CLAMP(x, min, max) MAX(min, MIN(max, x))
 #define ALIGN(p, n) ((uintptr_t) p & -n)
-
-typedef struct ref {
-  void (*destructor)(void*);
-  const char* type;
-  int count;
-} Ref;
 
 typedef struct { float r, g, b, a; } Color;
 
@@ -50,8 +44,5 @@ extern _Thread_local void* lovrErrorUserdata;
 
 void lovrSetErrorCallback(lovrErrorHandler callback, void* context);
 void _Noreturn lovrThrow(const char* format, ...);
-void* _lovrAlloc(const char* type, size_t size, void (*destructor)(void*));
-void lovrRetain(void* object);
-void lovrRelease(void* object);
 size_t utf8_decode(const char *s, const char *e, unsigned *pch);
 uint32_t nextPo2(uint32_t x);


### PR DESCRIPTION
This is an update to the type system.  It's meant to reduce the size of the "Ref" object header and improve the speed of Lua/C interop.  Summary of changes:

- Ref only stores a refcount now, instead of a destructor and a type name.
  - The struct goes from 24 bytes to 1 byte.
  - In most places where Refs are used, we already know their type, don't need to store it.
- lovrRelease takes a destructor to use to destroy the object.
  - Lua stores the destructor as an upvalue on the __gc metamethod.
- Userdata allocated by Lua store the type as an enum along with the object pointer.
  - This is where type information is actually needed.
  - Using an enum is faster than doing a string comparison.
  - Creating new userdata requires an explicit type since we can't look it up on the Ref.
- Variants become a little more complicated.  They are the only place where we truly have a generic reference.  So for this case specifically, we store the type in the Variant now.
  - Still working on this.
- Use a macro to simplify luax_registertype and luax_extendtype.
- Correctly error when refcounts overflow/underflow.

Stuff I'm still thinking about:

- Is this actually good.
- Our macro game is getting a bit too strong, especially in luax.
- Should type stuff go in a separate types.h or still be in util.h?
- Try to standardize more on terminology between Ref, Object, Type, Proxy.
- Maybe lovrSupertypes can go away, we only use it for 3 types...could just be a switch.