### PR TITLE
Fix -DLOVR_ENABLE_THREAD=OFF compile

### DIFF
--- a/src/api/l_event.c
+++ b/src/api/l_event.c
@@ -9,7 +9,9 @@
 const char* EventTypes[] = {
   [EVENT_QUIT] = "quit",
   [EVENT_FOCUS] = "focus",
+#ifdef LOVR_ENABLE_THREAD
   [EVENT_THREAD_ERROR] = "threaderror",
+#endif
 };
 
 static LOVR_THREAD_LOCAL int pollRef;
@@ -103,11 +105,13 @@ static int nextEvent(lua_State* L) {
       lua_pushboolean(L, event.data.boolean.value);
       return 2;
 
+#ifdef LOVR_ENABLE_THREAD
     case EVENT_THREAD_ERROR:
       luax_pushtype(L, Thread, event.data.thread.thread);
       lua_pushstring(L, event.data.thread.error);
       lovrRelease(Thread, event.data.thread.thread);
       return 3;
+#endif
 
     case EVENT_CUSTOM:
       for (uint32_t i = 0; i < event.data.custom.count; i++) {

--- a/src/modules/event/event.c
+++ b/src/modules/event/event.c
@@ -37,9 +37,11 @@ void lovrEventPump() {
 }
 
 void lovrEventPush(Event event) {
+#ifdef LOVR_ENABLE_THREAD
   if (event.type == EVENT_THREAD_ERROR) {
     lovrRetain(event.data.thread.thread);
   }
+#endif
 
   arr_push(&state.events, event);
 }

--- a/src/modules/event/event.h
+++ b/src/modules/event/event.h
@@ -10,8 +10,10 @@ struct Thread;
 typedef enum {
   EVENT_QUIT,
   EVENT_FOCUS,
+  EVENT_CUSTOM,
+#ifdef LOVR_ENABLE_THREAD
   EVENT_THREAD_ERROR,
-  EVENT_CUSTOM
+#endif
 } EventType;
 
 typedef enum {


### PR DESCRIPTION
Note: I **DO NOT KNOW** if this is the correct fix, bjorn would know better.

l_event.c was processing a thread-related event and in the process using a thread struct, even when LOVR_ENABLE_THREAD is undefined and threads do not exist. I instead made receiving that event an assert failure.