### PR TITLE
t.headset.fakeKbamBlock = true in conf.lua

### DIFF
--- a/src/api/l_headset.c
+++ b/src/api/l_headset.c
@@ -642,6 +642,15 @@ int luaopen_lovr_headset(lua_State* L) {
     lua_pop(L, 1);
   }
 
+#if LOVR_USE_DESKTOP_HEADSET
+  // Special conf only used by desktop driver
+  lua_getfield(L, LUA_REGISTRYINDEX, "_lovrconf");
+  lua_getfield(L, -1, "headset"); // FIXME: Could be nil?
+  lua_getfield(L, -1, "fakeKbamBlock");
+  lovrHeadsetFakeKbamBlock(lua_toboolean(L, -1));
+  lua_pop(L, 3);
+#endif
+
   if (lovrHeadsetInit(drivers.data, drivers.length, offset, msaa)) {
     luax_atexit(L, lovrHeadsetDestroy);
   }

--- a/src/modules/headset/desktop.c
+++ b/src/modules/headset/desktop.c
@@ -22,7 +22,16 @@ static struct {
   float clipFar;
   float pitch;
   float yaw;
+
+  bool kbamBlocked;
 } state;
+
+void lovrHeadsetFakeKbamBlock(bool block) {
+  if (block != state.kbamBlocked) {
+    lovrLog("%s fake headset keyboard/mouse controls\n", block?"Disabling":"Re-enabling");
+    state.kbamBlocked = block;
+  }
+}
 
 static bool desktop_init(float offset, uint32_t msaa) {
   state.offset = offset;
@@ -102,7 +111,7 @@ static bool desktop_getAcceleration(Device device, vec3 acceleration, vec3 angul
 }
 
 static bool desktop_isDown(Device device, DeviceButton button, bool* down) {
-  if (device != DEVICE_HAND_LEFT || (button != BUTTON_TRIGGER && button != BUTTON_PRIMARY)) {
+  if (state.kbamBlocked || device != DEVICE_HAND_LEFT || (button != BUTTON_TRIGGER && button != BUTTON_PRIMARY)) {
     return false;
   }
 
@@ -141,6 +150,8 @@ static void desktop_renderTo(void (*callback)(void*), void* userdata) {
 }
 
 static void desktop_update(float dt) {
+  if (state.kbamBlocked) return;
+
   bool front = lovrPlatformIsKeyDown(KEY_W) || lovrPlatformIsKeyDown(KEY_UP);
   bool back = lovrPlatformIsKeyDown(KEY_S) || lovrPlatformIsKeyDown(KEY_DOWN);
   bool left = lovrPlatformIsKeyDown(KEY_A) || lovrPlatformIsKeyDown(KEY_LEFT);

--- a/src/modules/headset/headset.h
+++ b/src/modules/headset/headset.h
@@ -129,3 +129,5 @@ extern HeadsetInterface* lovrHeadsetTrackingDrivers;
 
 bool lovrHeadsetInit(HeadsetDriver* drivers, uint32_t count, float offset, uint32_t msaa);
 void lovrHeadsetDestroy(void);
+
+void lovrHeadsetFakeKbamBlock(bool block);


### PR DESCRIPTION
Set this to disable ("block") the controls of the desktop driver. The desktop driver will still run, but the keyboard and mouse controls will not activate.

This is of pretty narrow usage, but has been useful to me. Situations you might want this:
- You are using lovr-mouse or lovr-keyboard, and don't want the act of typing to move the camera around. (My primary use)
- You are shipping a release build of an application and decide you don't want to leave in (effectively) "debug controls"