### PR TITLE
Make it possible to include lovr headers from C++

### DIFF
--- a/src/core/maf.h
+++ b/src/core/maf.h
@@ -510,12 +510,13 @@ MAF mat4 mat4_translate(mat4 m, float x, float y, float z) {
 
 MAF mat4 mat4_rotateQuat(mat4 m, quat q) {
   float x = q[0], y = q[1], z = q[2], w = q[3];
-  return mat4_multiply(m, (float[16]) {
+  float m2[16] = {
     1 - 2 * y * y - 2 * z * z, 2 * x * y + 2 * w * z, 2 * x * z - 2 * w * y, 0,
     2 * x * y - 2 * w * z, 1 - 2 * x * x - 2 * z * z, 2 * y * z + 2 * w * x, 0,
     2 * x * z + 2 * w * y, 2 * y * z - 2 * w * x, 1 - 2 * x * x - 2 * y * y, 0,
     0, 0, 0, 1
-  });
+  };
+  return mat4_multiply(m, m2);
 }
 
 MAF mat4 mat4_rotate(mat4 m, float angle, float x, float y, float z) {

--- a/src/lib/sds/sds.h
+++ b/src/lib/sds/sds.h
@@ -43,6 +43,12 @@ extern const char *SDS_NOINIT;
 
 typedef char *sds;
 
+#ifdef __cplusplus
+#define DUMMY_ELEMENT 1
+#else
+#define DUMMY_ELEMENT
+#endif
+
 #ifdef _MSC_VER
 #define PACK(decl) __pragma(pack(push, 1)) decl __pragma(pack(pop))
 
@@ -60,31 +66,31 @@ typedef long ssize_t;
  * However is here to document the layout of type 5 SDS strings. */
 PACK(struct sdshdr5 {
     unsigned char flags; /* 3 lsb of type, and 5 msb of string length */
-    char buf[];
+    char buf[DUMMY_ELEMENT];
 });
 PACK(struct sdshdr8 {
     uint8_t len; /* used */
     uint8_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
-    char buf[];
+    char buf[DUMMY_ELEMENT];
 });
 PACK(struct sdshdr16 {
     uint16_t len; /* used */
     uint16_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
-    char buf[];
+    char buf[DUMMY_ELEMENT];
 });
 PACK(struct sdshdr32 {
     uint32_t len; /* used */
     uint32_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
-    char buf[];
+    char buf[DUMMY_ELEMENT];
 });
 PACK(struct sdshdr64 {
     uint64_t len; /* used */
     uint64_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
-    char buf[];
+    char buf[DUMMY_ELEMENT];
 });
 
 #undef PACK


### PR DESCRIPTION
Although Lovr is pure C, users might fork Lovr or attempt to load binary Lua plugins that reference the header files. My own fork of Lovr contains a number of C++ files. I think it's worth making the Lovr headers C++-compatible as long as the changes do not create an inconvenience for mainline Lovr dev.

This PR contains three patches to make headers C++ friendly:
- Patch SDS to detect __cplusplus and not use empty arrays when present
- Patch a line in maf.h to use a variable instead of an inline array
- Put an #error in core/ref.h detecting __cplusplus and explaining that we are using C++-incompatible C11 atomics-- I have some ideas about how to "fix" this properly at some future point but for now I think a useful error message is good enough

See commit messages for more detail

All of these changes should be total noops for the normal C build