### PR TITLE
Y-flip mirror texture on Oculus

### DIFF
--- a/src/resources/boot.lua
+++ b/src/resources/boot.lua
@@ -188,7 +188,11 @@ function lovr.mirror()
   if lovr.headset then -- On some systems, headset module will be disabled
     local texture = lovr.headset.getMirrorTexture()
     if texture then    -- On some drivers, texture is printed directly to the window
-      lovr.graphics.fill(texture)
+      if lovr.headset.getDriver() == 'oculus' then
+        lovr.graphics.fill(lovr.headset.getMirrorTexture(), 0, 1, 1, -1)
+      else
+        lovr.graphics.fill(lovr.headset.getMirrorTexture())
+      end
     end
   else
     lovr.graphics.clear()


### PR DESCRIPTION
Oculus gives us the mirror texture "upside down" compared to every other driver, so flip it rightside up before drawing in boot.lua.

**WARNING: I HAVEN'T TESTED THIS ON MASTER YET**. It worked a few months ago. I'll have time to test it next week. EDIT: I tested it, it worked as expected