### PR TITLE
ref.h compiles in C++

### DIFF
--- a/src/core/ref.h
+++ b/src/core/ref.h
@@ -3,25 +3,45 @@
 
 #pragma once
 
-#if defined(LOVR_ENABLE_THREAD) && defined(_WIN32)
+#ifndef LOVR_ENABLE_THREAD
+
+// Thread module is off, don't use atomics
+
+typedef uint32_t Ref;
+static inline uint32_t ref_inc(Ref* ref) { return ++*ref; }
+static inline uint32_t ref_dec(Ref* ref) { return --*ref; }
+
+#elif defined(_MSC_VER)
+
+// MSVC atomics
 
 #include <intrin.h>
 typedef uint32_t Ref;
 static inline uint32_t ref_inc(Ref* ref) { return _InterlockedIncrement(ref); }
 static inline uint32_t ref_dec(Ref* ref) { return _InterlockedDecrement(ref); }
 
-#elif defined(LOVR_ENABLE_THREAD)
+#elif (defined(__GNUC_MINOR__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7))) \
+   || (defined(__has_builtin) && __has_builtin(__atomic_add_fetch) && __has_builtin(__atomic_sub_fetch))
+
+// GCC/Clang atomics
+
+typedef uint32_t Ref;
+static inline uint32_t ref_inc(Ref* ref) { return __atomic_add_fetch(ref, 1, __ATOMIC_SEQ_CST); }
+static inline uint32_t ref_dec(Ref* ref) { return __atomic_add_fetch(ref, 1, __ATOMIC_SEQ_CST); }
+
+#else
+
+// No known compiler-specific atomics-- fall back to C11 atomics
+
+// stdatomic.h doesn't work in c++ (except on Android, where it is fine)
+#if !defined(__ANDROID__) && defined(__cplusplus)
+#error "The header core/ref.h cannot currently be included from C++ when threading is enabled with this compiler. Either remove your ref.h include from any C++ files, or rebuild LOVR with -DLOVR_ENABLE_THREAD=OFF"
+#endif
 
 #include <stdatomic.h>
 typedef _Atomic(uint32_t) Ref;
 static inline uint32_t ref_inc(Ref* ref) { return atomic_fetch_add(ref, 1) + 1; }
 static inline uint32_t ref_dec(Ref* ref) { return atomic_fetch_sub(ref, 1) - 1; }
-
-#else
-
-typedef uint32_t Ref;
-static inline uint32_t ref_inc(Ref* ref) { return ++*ref; }
-static inline uint32_t ref_dec(Ref* ref) { return --*ref; }
 
 #endif
 


### PR DESCRIPTION
This commit is pretty out there and if you want to deny it I'd be fine with that. This replaces the ref.h solution in my other PR.

It turns out there are a set of GCC atomics that are supported by every compiler I can find that supports C11 atomics, but which do not have the C++ incompatibility. This patch uses the GCC atomics where possible but keeps C11 as a fallback (with a helpful error message if the C11 header is illegally included in C++).

Check for GCC version >=4.7 [covers GCC or, theoretically, Intel C Compiler] or __has_builtin(__atomic_add_fetch) [covers Clang]. If either of these are found, use the GCC atomic builtins instead of the C11 builtins.

Also: Gates Microsoft atomics on _MSC_VER, not _WIN32, and defines one of LOVR_HAS_MSVC_ATOMICS, LOVR_HAS_GCC_ATOMICS or LOVR_HAS_C11_ATOMICS where appropriate.