### PR TITLE
Fix lovr.filesystem.append()

### DIFF
--- a/src/modules/filesystem/file.c
+++ b/src/modules/filesystem/file.c
@@ -41,7 +41,7 @@ size_t lovrFileRead(File* file, void* data, size_t bytes) {
 }
 
 size_t lovrFileWrite(File* file, const void* data, size_t bytes) {
-  lovrAssert(file->handle && (file->mode == OPEN_READ || file->mode == OPEN_WRITE), "File must be open for writing");
+  lovrAssert(file->handle && (file->mode == OPEN_WRITE || file->mode == OPEN_APPEND), "File must be open for writing");
   return PHYSFS_writeBytes(file->handle, data, bytes);
 }
 


### PR DESCRIPTION
Previously, this program
```
function lovr.update(dt) lovr.filesystem.append("/test123", lovr.timer.getTime()) end
```
would fail in lovr because lovrFileWrite required the file to be in write mode (not append)

The `src/modules/filesystem/filesystem.c` change has no effect. I only changed it because I **assume** this was done by mistake, and it was confusing me.