### PR TITLE
Don't reset camera position of desktop driver on reset

### DIFF
--- a/src/modules/headset/desktop.c
+++ b/src/modules/headset/desktop.c
@@ -8,6 +8,8 @@
 #include <stdbool.h>
 
 static struct {
+  bool initialized;
+
   float LOVR_ALIGN(16) position[4];
   float LOVR_ALIGN(16) velocity[4];
   float LOVR_ALIGN(16) localVelocity[4];
@@ -28,12 +30,15 @@ static bool desktop_init(float offset, uint32_t msaa) {
   state.offset = offset;
   state.clipNear = 0.1f;
   state.clipFar = 100.f;
-  mat4_identity(state.transform);
+
+  if (!state.initialized) {
+    mat4_identity(state.transform);
+    state.initialized = true;
+  }
   return true;
 }
 
 static void desktop_destroy(void) {
-  memset(&state, 0, sizeof(state));
 }
 
 static bool desktop_getName(char* name, size_t length) {


### PR DESCRIPTION
This doesn't have to be merged, but: This makes it so when you reset, for example using F5 or lovr-lodr, the fake camera in "desktop" does not reset positions. This is IMO more convenient because the fake camera isn't an "in-game" thing, rather it's a simulation of a vr headset. VR headsets don't reset their positions when the game does…