### PR TITLE
Throw lua errors in the error handler

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -162,7 +162,8 @@ void luax_registerloader(lua_State* L, lua_CFunction loader, int index) {
   lua_pop(L, 1);
 }
 
-void luax_vthrow(lua_State* L, const char* format, va_list args) {
+void luax_vthrow(void* context, const char* format, va_list args) {
+  lua_State* L = (lua_State*) context;
   lua_pushvfstring(L, format, args);
   lua_error(L);
 }
@@ -172,17 +173,20 @@ void luax_traceback(lua_State* L, lua_State* T, const char* message, int level) 
   if (!lua_checkstack(L, 5)) {
     return;
   }
+
   lua_getglobal(L, "debug");
   if (!lua_istable(L, -1)) {
     lua_pop(L, 1);
     return;
   }
+
   lua_getfield(L, -1, "traceback");
   if (!lua_isfunction(L, -1)) {
     lua_pop(L, 2);
     return;
   }
-  lua_remove(L, -2); // Pop debug object
+
+  lua_remove(L, -2);
   lua_pushthread(T);
   lua_pushstring(L, message);
   lua_pushinteger(L, level);

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -129,7 +129,7 @@ void* _luax_totype(lua_State* L, int index, uint32_t hash);
 void* _luax_checktype(lua_State* L, int index, uint32_t hash, const char* debug);
 void _luax_pushtype(lua_State* L, const char* name, uint32_t hash, void* object);
 void luax_registerloader(lua_State* L, lua_CFunction loader, int index);
-void luax_vthrow(lua_State* L, const char* format, va_list args);
+void luax_vthrow(void* L, const char* format, va_list args);
 void luax_traceback(lua_State* L, lua_State* T, const char* message, int level);
 int luax_getstack(lua_State* L);
 void luax_pushconf(lua_State* L);

--- a/src/main.c
+++ b/src/main.c
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
       return 1;
     }
 
-    lovrSetErrorCallback((errorFn*) luax_vthrow, T);
+    lovrSetErrorCallback(luax_vthrow, T);
 
 #ifdef EMSCRIPTEN
     lovrEmscriptenContext context = { L, T, argc, argv };

--- a/src/modules/headset/oculus_mobile.c
+++ b/src/modules/headset/oculus_mobile.c
@@ -349,18 +349,8 @@ int luax_print(lua_State* L) {
   return 0;
 }
 
-static void android_vthrow(lua_State* L, const char* format, va_list args) {
-  #define MAX_ERROR_LENGTH 1024
-  char lovrErrorMessage[MAX_ERROR_LENGTH];
-  vsnprintf(lovrErrorMessage, MAX_ERROR_LENGTH, format, args);
-  WARN("Error: %s\n", lovrErrorMessage);
-  assert(0);
-}
-
 static int luax_custom_atpanic(lua_State *L) {
-  // This doesn't appear to get a sensible stack. Maybe Luajit would work better?
-  luax_traceback(L, L, lua_tostring(L, -1), 0); // Pushes the traceback onto the stack
-  lovrThrow("Lua panic: %s", lua_tostring(L, -1));
+  WARN("PANIC: unprotected error in call to Lua API (%s)\n", lua_tostring(L, -1));
   return 0;
 }
 
@@ -369,12 +359,10 @@ static void bridgeLovrInitState() {
   // Copypaste the init sequence from lovrRun:
   // Load libraries
   L = luaL_newstate(); // FIXME: Can this be handed off to main.c?
-  luax_setmainthread(L);
-  lua_atpanic(L, luax_custom_atpanic);
   luaL_openlibs(L);
   LOG("\n OPENED LIB\n");
-
-  lovrSetErrorCallback((errorFn*) android_vthrow, L);
+  lua_atpanic(L, luax_custom_atpanic);
+  luax_setmainthread(L);
 
   // Install custom print
   lua_pushcfunction(L, luax_print);
@@ -421,7 +409,7 @@ static void bridgeLovrInitState() {
 
   coroutineStartFunctionRef = luaL_ref(L, LUA_REGISTRYINDEX); // Value returned by boot.lua
   T = lua_newthread(L); // Leave L clear to be used by the draw function
-  lua_atpanic(T, luax_custom_atpanic);
+  lovrSetErrorCallback(luax_vthrow, T);
   coroutineRef = luaL_ref(L, LUA_REGISTRYINDEX); // Hold on to the Lua-side coroutine object so it isn't GC'd
 
   LOG("\n STATE INIT COMPLETE\n");


### PR DESCRIPTION
I discussed this with @bjornbytes offline, it should now show the lovr error screen and message on oculus mobile instead of crashing in the cases I was seeing.