### PR TITLE
Vibrate function for Oculus Quest

### DIFF
--- a/src/modules/headset/oculus_mobile.c
+++ b/src/modules/headset/oculus_mobile.c
@@ -18,6 +18,7 @@
 static struct {
   BridgeLovrDimensions displayDimensions;
   BridgeLovrDevice deviceType;
+  BridgeLovrVibrateFunctionPtr vibrateFunction;
   BridgeLovrUpdateData updateData;
 } bridgeLovrMobileData;
 
@@ -229,7 +230,15 @@ static bool vrapi_getAxis(Device device, DeviceAxis axis, float* value) {
 }
 
 static bool vrapi_vibrate(Device device, float strength, float duration, float frequency) {
-  return false;
+  int controller;
+  if (device == DEVICE_HAND_LEFT)
+    controller = 0;
+  else if (device == DEVICE_HAND_RIGHT)
+    controller = 1;
+  else
+    return false;
+  bridgeLovrMobileData.vibrateFunction(controller, strength, duration); // Frequency currently discarded
+  return true;
 }
 
 static ModelData* vrapi_newModelData(Device device) {
@@ -443,6 +452,7 @@ void bridgeLovrInit(BridgeLovrInitData *initData) {
   bridgeLovrMobileData.displayDimensions = initData->suggestedEyeTexture;
   bridgeLovrMobileData.updateData.displayTime = initData->zeroDisplayTime;
   bridgeLovrMobileData.deviceType = initData->deviceType;
+  bridgeLovrMobileData.vibrateFunction = initData->vibrateFunction;
 
   free(apkPath);
   size_t length = strlen(initData->apkPath);

--- a/src/modules/headset/oculus_mobile.c
+++ b/src/modules/headset/oculus_mobile.c
@@ -18,7 +18,7 @@
 static struct {
   BridgeLovrDimensions displayDimensions;
   BridgeLovrDevice deviceType;
-  BridgeLovrVibrateFunctionPtr vibrateFunction;
+  BridgeLovrVibrateFunction* vibrateFunction;
   BridgeLovrUpdateData updateData;
 } bridgeLovrMobileData;
 
@@ -237,8 +237,7 @@ static bool vrapi_vibrate(Device device, float strength, float duration, float f
     controller = 1;
   else
     return false;
-  bridgeLovrMobileData.vibrateFunction(controller, strength, duration); // Frequency currently discarded
-  return true;
+  return bridgeLovrMobileData.vibrateFunction(controller, strength, duration); // Frequency currently discarded
 }
 
 static ModelData* vrapi_newModelData(Device device) {

--- a/src/modules/headset/oculus_mobile_bridge.h
+++ b/src/modules/headset/oculus_mobile_bridge.h
@@ -116,7 +116,7 @@ typedef struct {
   BridgeLovrController controllers[BRIDGE_LOVR_CONTROLLERMAX];
 } BridgeLovrUpdateData;
 
-typedef void (*BridgeLovrVibrateFunctionPtr)(int controller, float strength, float duration);
+typedef bool BridgeLovrVibrateFunction(int controller, float strength, float duration);
 
 // Data passed from Lovr_NativeActivity to BridgeLovr at init time
 typedef struct {
@@ -125,7 +125,7 @@ typedef struct {
   BridgeLovrDimensions suggestedEyeTexture;
   double zeroDisplayTime;
   BridgeLovrDevice deviceType;
-  BridgeLovrVibrateFunctionPtr vibrateFunction;
+  BridgeLovrVibrateFunction* vibrateFunction; // Returns true on success
 } BridgeLovrInitData;
 
 LOVR_EXPORT void bridgeLovrInit(BridgeLovrInitData *initData);

--- a/src/modules/headset/oculus_mobile_bridge.h
+++ b/src/modules/headset/oculus_mobile_bridge.h
@@ -116,6 +116,8 @@ typedef struct {
   BridgeLovrController controllers[BRIDGE_LOVR_CONTROLLERMAX];
 } BridgeLovrUpdateData;
 
+typedef void (*BridgeLovrVibrateFunctionPtr)(int controller, float strength, float duration);
+
 // Data passed from Lovr_NativeActivity to BridgeLovr at init time
 typedef struct {
   const char *writablePath;
@@ -123,6 +125,7 @@ typedef struct {
   BridgeLovrDimensions suggestedEyeTexture;
   double zeroDisplayTime;
   BridgeLovrDevice deviceType;
+  BridgeLovrVibrateFunctionPtr vibrateFunction;
 } BridgeLovrInitData;
 
 LOVR_EXPORT void bridgeLovrInit(BridgeLovrInitData *initData);


### PR DESCRIPTION
This commit is a fist pass. It only does "simple" vibrate (hard on/off). It supports duration but not frequency. Supporting frequency will probably require Oculus to document their "haptic buffer" function, which currently is IMO not clear enough to work with. I have filed a bug about this: https://developer.oculus.com/bugs/bug/533528907451560/

However even this incomplete version of vibrate probably gives us feature parity with some other platforms.

This commit requires a corresponding commit in the lovr-oculus-mobile repo (see mobile-1.patch, attached:
[mobile-1.txt](https://github.com/bjornbytes/lovr/files/3660168/mobile-1.txt) )

See also attached my test program (as written requires lovr-ent) 
[vibrate.txt](https://github.com/bjornbytes/lovr/files/3660170/vibrate.txt)

