### PR TITLE
Desktop driver: Move left controller with mouse

### DIFF
--- a/src/modules/headset/desktop.c
+++ b/src/modules/headset/desktop.c
@@ -14,7 +14,8 @@ static struct {
   float LOVR_ALIGN(16) velocity[4];
   float LOVR_ALIGN(16) localVelocity[4];
   float LOVR_ALIGN(16) angularVelocity[4];
-  float LOVR_ALIGN(16) transform[16];
+  float LOVR_ALIGN(16) headTransform[16];
+  float LOVR_ALIGN(16) leftHandTransform[16];
 
   double prevCursorX;
   double prevCursorY;
@@ -32,7 +33,8 @@ static bool desktop_init(float offset, uint32_t msaa) {
   state.clipFar = 100.f;
 
   if (!state.initialized) {
-    mat4_identity(state.transform);
+    mat4_identity(state.headTransform);
+    mat4_identity(state.leftHandTransform);
     state.initialized = true;
   }
   return true;
@@ -89,37 +91,12 @@ static const float* desktop_getBoundsGeometry(uint32_t* count) {
 static bool desktop_getPose(Device device, vec3 position, quat orientation) {
   if (device == DEVICE_HEAD) {
     vec3_set(position, 0.f, 0.f, 0.f);
-    mat4_transform(state.transform, position);
-    quat_fromMat4(orientation, state.transform);
+    mat4_transform(state.headTransform, position);
+    quat_fromMat4(orientation, state.headTransform);
     return true;
   } else if ( device == DEVICE_HAND_LEFT ) {
-    int w, h;
-    double x, y, aspect = 1;
-    lovrPlatformGetWindowSize(&w, &h);
-    lovrPlatformGetMousePosition(&x, &y);
-    if (w > 0 && h > 0) {
-      // change coordinate system to -1.0 to 1.0
-      x = (x / w)*2 - 1.0;
-      y = (y / h)*2 - 1.0;
-      aspect = h/(double)w;
-      
-      x +=  0.2; // neutral position = pointing towards center-ish
-      x *= 0.6; // fudged range to juuust cover pointing at the whole scene, but not outside it
-    }
-    
-    float leftHandTransform[16];
-    mat4_set(leftHandTransform, state.transform);
-    double xrange = M_PI*0.2;
-    double yrange = xrange * aspect;
-    mat4_translate(leftHandTransform, -.1f, -.1f, -0.10f);
-    mat4_rotate(leftHandTransform, -x * xrange, 0, 1, 0);
-    mat4_rotate(leftHandTransform, -y * yrange, 1, 0, 0);
-    mat4_translate(leftHandTransform, 0, 0, -.20f);
-    mat4_rotate(leftHandTransform, -x * xrange, 0, 1, 0);
-    mat4_rotate(leftHandTransform, -y * yrange, 1, 0, 0);
-    
-    mat4_getPosition(leftHandTransform, position);
-    quat_fromMat4(orientation, leftHandTransform);
+    mat4_getPosition(state.leftHandTransform, position);
+    quat_fromMat4(orientation, state.leftHandTransform);
     return true;
   }
   return false;
@@ -165,7 +142,7 @@ static void desktop_renderTo(void (*callback)(void*), void* userdata) {
   desktop_getDisplayDimensions(&width, &height);
   Camera camera = { .canvas = NULL, .viewMatrix = { MAT4_IDENTITY }, .stereo = true };
   mat4_perspective(camera.projection[0], state.clipNear, state.clipFar, 67.f * (float) M_PI / 180.f, (float) width / 2.f / height);
-  mat4_multiply(camera.viewMatrix[0], state.transform);
+  mat4_multiply(camera.viewMatrix[0], state.headTransform);
   mat4_invertPose(camera.viewMatrix[0]);
   mat4_set(camera.projection[1], camera.projection[0]);
   mat4_set(camera.viewMatrix[1], camera.viewMatrix[0]);
@@ -185,15 +162,15 @@ static void desktop_update(float dt) {
   float movespeed = 3.f * dt;
   float turnspeed = 3.f * dt;
   float damping = MAX(1.f - 20.f * dt, 0);
-
+  
+  int width, height;
+  double mx, my, aspect = 1;
+  lovrPlatformGetWindowSize(&width, &height);
+  lovrPlatformGetMousePosition(&mx, &my);
+  
+  // Mouse move
   if (lovrPlatformIsMouseDown(MOUSE_LEFT)) {
     lovrPlatformSetMouseMode(MOUSE_MODE_GRABBED);
-
-    int width, height;
-    lovrPlatformGetWindowSize(&width, &height);
-
-    double mx, my;
-    lovrPlatformGetMousePosition(&mx, &my);
 
     if (state.prevCursorX == -1 && state.prevCursorY == -1) {
       state.prevCursorX = mx;
@@ -219,7 +196,7 @@ static void desktop_update(float dt) {
   state.localVelocity[2] = front ? -movespeed : (back ? movespeed : state.localVelocity[2]);
   state.localVelocity[3] = 0.f;
   vec3_init(state.velocity, state.localVelocity);
-  mat4_transformDirection(state.transform, state.velocity);
+  mat4_transformDirection(state.headTransform, state.velocity);
   vec3_scale(state.localVelocity, damping);
 
   // Update position
@@ -229,12 +206,34 @@ static void desktop_update(float dt) {
   state.pitch = CLAMP(state.pitch - state.angularVelocity[0] * turnspeed, -(float) M_PI / 2.f, (float) M_PI / 2.f);
   state.yaw -= state.angularVelocity[1] * turnspeed;
 
-  // Update transform
-  mat4_identity(state.transform);
-  mat4_translate(state.transform, 0.f, state.offset, 0.f);
-  mat4_translate(state.transform, state.position[0], state.position[1], state.position[2]);
-  mat4_rotate(state.transform, state.yaw, 0.f, 1.f, 0.f);
-  mat4_rotate(state.transform, state.pitch, 1.f, 0.f, 0.f);
+  // Update head transform
+  mat4_identity(state.headTransform);
+  mat4_translate(state.headTransform, 0.f, state.offset, 0.f);
+  mat4_translate(state.headTransform, state.position[0], state.position[1], state.position[2]);
+  mat4_rotate(state.headTransform, state.yaw, 0.f, 1.f, 0.f);
+  mat4_rotate(state.headTransform, state.pitch, 1.f, 0.f, 0.f);
+  
+  // Update hand transform to follow cursor
+  double px = mx, py = my;
+  if (width > 0 && height > 0) {
+    // change coordinate system to -1.0 to 1.0
+    px = (px / width)*2 - 1.0;
+    py = (py / height)*2 - 1.0;
+    aspect = height/(double)width;
+    
+    px +=  0.2; // neutral position = pointing towards center-ish
+    px *= 0.6; // fudged range to juuust cover pointing at the whole scene, but not outside it
+  }
+
+  mat4_set(state.leftHandTransform, state.headTransform);
+  double xrange = M_PI*0.2;
+  double yrange = xrange * aspect;
+  mat4_translate(state.leftHandTransform, -.1f, -.1f, -0.10f);
+  mat4_rotate(state.leftHandTransform, -px * xrange, 0, 1, 0);
+  mat4_rotate(state.leftHandTransform, -py * yrange, 1, 0, 0);
+  mat4_translate(state.leftHandTransform, 0, 0, -.20f);
+  mat4_rotate(state.leftHandTransform, -px * xrange, 0, 1, 0);
+  mat4_rotate(state.leftHandTransform, -py * yrange, 1, 0, 0);
 }
 
 HeadsetInterface lovrHeadsetDesktopDriver = {


### PR DESCRIPTION
Looks like this:

![2019-10-14 10 05 10](https://user-images.githubusercontent.com/34791/66736909-d04a8700-ee6a-11e9-9d08-24cf99a8a373.gif)

Downside: Right-clicking no longer taps in the center of the scene. Upside: you can actually move the controller and emulate much  more advanced behaviors without having to launch into VR :) I think it's totally worth it.

I noticed a bit late that that some similar stuff is done in `desktop_update`. Should I refactor this to not be on demand, but instead populate a state.leftHandTransform in update instead?