### PR TITLE
Potential for drawing "visibly" while populating the stencil buffer

### DIFF
--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -950,8 +950,14 @@ static int l_lovrGraphicsStencil(lua_State* L) {
     lovrGraphicsClear(NULL, NULL, &clearTo);
   }
   bool drawVisible = lua_toboolean(L, 5);
+  CompareMode stencilMode;
+  if (lua_isnoneornil(L, 6)) {
+    stencilMode = COMPARE_NONE;
+  } else {
+    stencilMode = luaL_checkoption(L, 6, NULL, CompareModes);
+  }
   lua_settop(L, 1);
-  lovrGraphicsStencil(action, replaceValue, drawVisible, stencilCallback, L);
+  lovrGraphicsStencil(action, replaceValue, drawVisible, stencilMode, stencilCallback, L);
   return 0;
 }
 

--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -949,8 +949,9 @@ static int l_lovrGraphicsStencil(lua_State* L) {
     int clearTo = lua_isnumber(L, 4) ? lua_tonumber(L, 4) : 0;
     lovrGraphicsClear(NULL, NULL, &clearTo);
   }
+  bool drawVisible = lua_toboolean(L, 5);
   lua_settop(L, 1);
-  lovrGraphicsStencil(action, replaceValue, stencilCallback, L);
+  lovrGraphicsStencil(action, replaceValue, drawVisible, stencilCallback, L);
   return 0;
 }
 

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -217,7 +217,7 @@ void lovrGpuClear(struct Canvas* canvas, Color* color, float* depth, int* stenci
 void lovrGpuCompute(struct Shader* shader, int x, int y, int z);
 void lovrGpuDiscard(struct Canvas* canvas, bool color, bool depth, bool stencil);
 void lovrGpuDraw(DrawCommand* draw);
-void lovrGpuStencil(StencilAction action, int replaceValue, StencilCallback callback, void* userdata);
+void lovrGpuStencil(StencilAction action, int replaceValue, bool drawVisible, StencilCallback callback, void* userdata);
 void lovrGpuPresent(void);
 void lovrGpuDirtyTexture(void);
 void lovrGpuTick(const char* label);

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -217,7 +217,7 @@ void lovrGpuClear(struct Canvas* canvas, Color* color, float* depth, int* stenci
 void lovrGpuCompute(struct Shader* shader, int x, int y, int z);
 void lovrGpuDiscard(struct Canvas* canvas, bool color, bool depth, bool stencil);
 void lovrGpuDraw(DrawCommand* draw);
-void lovrGpuStencil(StencilAction action, int replaceValue, bool drawVisible, StencilCallback callback, void* userdata);
+void lovrGpuStencil(StencilAction action, int replaceValue, bool drawVisible, CompareMode stencilMode, StencilCallback callback, void* userdata);
 void lovrGpuPresent(void);
 void lovrGpuDirtyTexture(void);
 void lovrGpuTick(const char* label);

--- a/src/modules/graphics/opengl.c
+++ b/src/modules/graphics/opengl.c
@@ -820,16 +820,7 @@ static void lovrGpuBindPipeline(Pipeline* pipeline) {
         glEnable(GL_STENCIL_TEST);
       }
 
-      GLenum glMode = GL_ALWAYS;
-      switch (state.stencilMode) {
-        case COMPARE_EQUAL: glMode = GL_EQUAL; break;
-        case COMPARE_NEQUAL: glMode = GL_NOTEQUAL; break;
-        case COMPARE_LESS: glMode = GL_GREATER; break;
-        case COMPARE_LEQUAL: glMode = GL_GEQUAL; break;
-        case COMPARE_GREATER: glMode = GL_LESS; break;
-        case COMPARE_GEQUAL: glMode = GL_LEQUAL; break;
-        default: break;
-      }
+      GLenum glMode = convertCompareMode(state.stencilMode);
 
       glStencilFunc(glMode, state.stencilValue, 0xff);
       glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
@@ -1225,7 +1216,7 @@ void lovrGpuPresent() {
   memset(&state.stats, 0, sizeof(state.stats));
 }
 
-void lovrGpuStencil(StencilAction action, int replaceValue, bool visibleDraw, StencilCallback callback, void* userdata) {
+void lovrGpuStencil(StencilAction action, int replaceValue, bool visibleDraw, CompareMode stencilMode, StencilCallback callback, void* userdata) {
   lovrGraphicsFlush();
   if (!visibleDraw)
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
@@ -1246,7 +1237,9 @@ void lovrGpuStencil(StencilAction action, int replaceValue, bool visibleDraw, St
     default: lovrThrow("Unreachable");
   }
 
-  glStencilFunc(GL_ALWAYS, replaceValue, 0xff);
+  GLenum glMode = convertCompareMode(stencilMode); // Should usually be COMPARE_NONE
+
+  glStencilFunc(glMode, replaceValue, 0xff);
   glStencilOp(GL_KEEP, GL_KEEP, glAction);
 
   state.stencilWriting = true;

--- a/src/modules/graphics/opengl.c
+++ b/src/modules/graphics/opengl.c
@@ -1225,9 +1225,10 @@ void lovrGpuPresent() {
   memset(&state.stats, 0, sizeof(state.stats));
 }
 
-void lovrGpuStencil(StencilAction action, int replaceValue, StencilCallback callback, void* userdata) {
+void lovrGpuStencil(StencilAction action, int replaceValue, bool visibleDraw, StencilCallback callback, void* userdata) {
   lovrGraphicsFlush();
-  glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+  if (!visibleDraw)
+    glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 
   if (!state.stencilEnabled) {
     state.stencilEnabled = true;
@@ -1253,7 +1254,8 @@ void lovrGpuStencil(StencilAction action, int replaceValue, StencilCallback call
   lovrGraphicsFlush();
   state.stencilWriting = false;
 
-  glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+  if (!visibleDraw)
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
   state.stencilMode = ~0; // Dirty
 }
 


### PR DESCRIPTION
Add one more argument to lovr.graphics.stencil(); set true and the colors in the stencil draw will be allowed to draw (instead of being masked out and only the stencil buffer being drawn to)

Will need to be documented at some point