### PR TITLE
Include .vs in .gitignore (visual studio code)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ bin
 /data
 /*.lua
 .DS_Store
+.vs
 /test


### PR DESCRIPTION
Visual Studio Code creates .vs directories when you tell it to open a directory as a project.

Might as well put them in .gitignore?