### PR TITLE
Remove physfs from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "deps/openvr"]
 	path = deps/openvr
 	url = https://github.com/ValveSoftware/openvr
-[submodule "deps/physfs"]
-	path = deps/physfs
-	url = https://github.com/Didstopia/physfs.git
 [submodule "deps/luajit"]
 	path = deps/luajit
 	url = https://github.com/WohlSoft/LuaJIT


### PR DESCRIPTION
The Physfs dep has been removed, but it is still listed in .gitmodules. This is confusing my third party git client very badly.