### PR TITLE
Fix C++ compilation

### DIFF
--- a/src/core/hash.h
+++ b/src/core/hash.h
@@ -3,7 +3,7 @@
 
 // FNV1a
 static LOVR_INLINE uint64_t hash64(const void* data, size_t length) {
-  const uint8_t* bytes = data;
+  const uint8_t* bytes = (uint8_t *)data;
   uint64_t hash = 0xcbf29ce484222325;
   for (size_t i = 0; i < length; i++) {
     hash = (hash ^ bytes[i]) * 0x100000001b3;


### PR DESCRIPTION
Minor one-line fix to make lovr headers compatible with C++. No functional difference