### PR TITLE
Real-time raw AudioStreams

### DIFF
--- a/src/api/l_data.c
+++ b/src/api/l_data.c
@@ -39,11 +39,19 @@ static int l_lovrDataNewBlob(lua_State* L) {
 }
 
 static int l_lovrDataNewAudioStream(lua_State* L) {
-  Blob* blob = luax_readblob(L, 1, "AudioStream");
-  int bufferSize = luaL_optinteger(L, 2, 4096);
-  AudioStream* stream = lovrAudioStreamCreate(blob, bufferSize);
+  AudioStream* stream = NULL;
+  if (lua_type(L, 1) == LUA_TNUMBER && lua_type(L, 2) == LUA_TNUMBER) {
+    int channelCount = lua_tonumber(L, 1);
+    int sampleRate = lua_tonumber(L, 2);
+    int bufferSize = luaL_optinteger(L, 3, 4096);
+    stream = lovrAudioStreamCreateRaw(channelCount, sampleRate, bufferSize);
+  } else {
+    Blob* blob = luax_readblob(L, 1, "AudioStream");
+    int bufferSize = luaL_optinteger(L, 2, 4096);
+    stream = lovrAudioStreamCreate(blob, bufferSize);
+    lovrRelease(Blob, blob);
+  }
   luax_pushtype(L, AudioStream, stream);
-  lovrRelease(Blob, blob);
   lovrRelease(AudioStream, stream);
   return 1;
 }

--- a/src/api/l_data.c
+++ b/src/api/l_data.c
@@ -44,7 +44,8 @@ static int l_lovrDataNewAudioStream(lua_State* L) {
     int channelCount = lua_tonumber(L, 1);
     int sampleRate = lua_tonumber(L, 2);
     int bufferSize = luaL_optinteger(L, 3, 4096);
-    stream = lovrAudioStreamCreateRaw(channelCount, sampleRate, bufferSize);
+    int queueLimit = luaL_optinteger(L, 4, sampleRate*0.5);
+    stream = lovrAudioStreamCreateRaw(channelCount, sampleRate, bufferSize, queueLimit);
   } else {
     Blob* blob = luax_readblob(L, 1, "AudioStream");
     int bufferSize = luaL_optinteger(L, 2, 4096);

--- a/src/api/l_data_audioStream.c
+++ b/src/api/l_data_audioStream.c
@@ -58,13 +58,6 @@ static int l_lovrAudioStreamAppend(lua_State* L) {
   return 1;
 }
 
-static int l_lovrAudioStreamGetQueueLength(lua_State* L) {
-  AudioStream* stream = luax_checktype(L, 1, AudioStream);
-  size_t length = lovrAudioStreamGetQueueLength(stream);
-  lua_pushnumber(L, length);
-  return 1;
-}
-
 const luaL_Reg lovrAudioStream[] = {
   { "decode", l_lovrAudioStreamDecode },
   { "getBitDepth", l_lovrAudioStreamGetBitDepth },
@@ -72,6 +65,5 @@ const luaL_Reg lovrAudioStream[] = {
   { "getDuration", l_lovrAudioStreamGetDuration },
   { "getSampleRate", l_lovrAudioStreamGetSampleRate },
   { "append", l_lovrAudioStreamAppend},
-  { "getQueueLength", l_lovrAudioStreamGetQueueLength},
   { NULL, NULL }
 };

--- a/src/api/l_data_audioStream.c
+++ b/src/api/l_data_audioStream.c
@@ -58,6 +58,13 @@ static int l_lovrAudioStreamAppend(lua_State* L) {
   return 1;
 }
 
+static int l_lovrAudioStreamGetQueueLength(lua_State* L) {
+  AudioStream* stream = luax_checktype(L, 1, AudioStream);
+  size_t length = lovrAudioStreamGetQueueLength(stream);
+  lua_pushnumber(L, length);
+  return 1;
+}
+
 const luaL_Reg lovrAudioStream[] = {
   { "decode", l_lovrAudioStreamDecode },
   { "getBitDepth", l_lovrAudioStreamGetBitDepth },
@@ -65,5 +72,6 @@ const luaL_Reg lovrAudioStream[] = {
   { "getDuration", l_lovrAudioStreamGetDuration },
   { "getSampleRate", l_lovrAudioStreamGetSampleRate },
   { "append", l_lovrAudioStreamAppend},
+  { "getQueueLength", l_lovrAudioStreamGetQueueLength},
   { NULL, NULL }
 };

--- a/src/api/l_data_audioStream.c
+++ b/src/api/l_data_audioStream.c
@@ -43,11 +43,27 @@ static int l_lovrAudioStreamGetSampleRate(lua_State* L) {
   return 1;
 }
 
+static int l_lovrAudioStreamAppend(lua_State* L) {
+  AudioStream* stream = luax_checktype(L, 1, AudioStream);
+  Blob* blob = luax_totype(L, 2, Blob);
+  SoundData* sound = luax_totype(L, 2, SoundData);
+  lovrAssert(blob || sound, "Invalid blob appended");
+  bool success = false;
+  if (sound) {
+    success = lovrAudioStreamAppendRawSound(stream, sound);
+  } else if (blob) {
+    success = lovrAudioStreamAppendRawBlob(stream, blob);
+  }
+  lua_pushboolean(L, success);
+  return 1;
+}
+
 const luaL_Reg lovrAudioStream[] = {
   { "decode", l_lovrAudioStreamDecode },
   { "getBitDepth", l_lovrAudioStreamGetBitDepth },
   { "getChannelCount", l_lovrAudioStreamGetChannelCount },
   { "getDuration", l_lovrAudioStreamGetDuration },
   { "getSampleRate", l_lovrAudioStreamGetSampleRate },
+  { "append", l_lovrAudioStreamAppend},
   { NULL, NULL }
 };

--- a/src/api/l_data_audioStream.c
+++ b/src/api/l_data_audioStream.c
@@ -33,7 +33,7 @@ static int l_lovrAudioStreamGetChannelCount(lua_State* L) {
 
 static int l_lovrAudioStreamGetDuration(lua_State* L) {
   AudioStream* stream = luax_checktype(L, 1, AudioStream);
-  lua_pushnumber(L, (float) stream->samples / stream->sampleRate);
+  lua_pushnumber(L, (float)lovrAudioStreamGetDurationInSeconds(stream));
   return 1;
 }
 

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -95,7 +95,6 @@ void lovrAudioUpdate() {
         alSourcePlay(id);
       }
     } else if (isStopped) {
-      lovrAudioStreamRewind(lovrSourceGetStream(source));
       arr_splice(&state.sources, i, 1);
       lovrRelease(Source, source);
     }

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -95,6 +95,9 @@ void lovrAudioUpdate() {
         alSourcePlay(id);
       }
     } else if (isStopped) {
+      // in case we'll play this source in the future, rewind it now. This also frees up queued raw buffers.
+      lovrAudioStreamRewind(lovrSourceGetStream(source));
+
       arr_splice(&state.sources, i, 1);
       lovrRelease(Source, source);
     }

--- a/src/modules/audio/source.c
+++ b/src/modules/audio/source.c
@@ -165,11 +165,6 @@ void lovrSourcePlay(Source* source) {
     return;
   }
 
-  // in case we're replaying an already-used stream, make sure to rewind it if applicable
-  if (!lovrAudioStreamIsRaw(source->stream)) {
-    lovrAudioStreamRewind(source->stream);
-  }
-
   // in case we have some queued buffers, make sure to unqueue them before streaming more data into them.
   ALint processed;
   alGetSourcei(lovrSourceGetId(source), AL_BUFFERS_PROCESSED, &processed);

--- a/src/modules/audio/source.c
+++ b/src/modules/audio/source.c
@@ -165,6 +165,11 @@ void lovrSourcePlay(Source* source) {
     return;
   }
 
+  // in case we're replaying an already-used stream, make sure to rewind it if applicable
+  if (!lovrAudioStreamIsRaw(source->stream)) {
+    lovrAudioStreamRewind(source->stream);
+  }
+
   lovrSourceStream(source, source->buffers, SOURCE_BUFFERS);
   alSourcePlay(source->id);
 }
@@ -285,7 +290,9 @@ void lovrSourceStop(Source* source) {
       alSourcei(source->id, AL_BUFFER, AL_NONE);
 
       // Rewind the decoder
-      lovrAudioStreamRewind(source->stream);
+      if (!lovrAudioStreamIsRaw(source->stream)) {
+        lovrAudioStreamRewind(source->stream);
+      }
       break;
     }
   }

--- a/src/modules/audio/source.c
+++ b/src/modules/audio/source.c
@@ -281,14 +281,14 @@ void lovrSourceStop(Source* source) {
 
     case SOURCE_STREAM: {
 
+      // Stop the source
+      alSourceStop(source->id);
+      alSourcei(source->id, AL_BUFFER, AL_NONE);
+
       // Empty the buffers
       int count = 0;
       alGetSourcei(source->id, AL_BUFFERS_QUEUED, &count);
       alSourceUnqueueBuffers(source->id, count, NULL);
-
-      // Stop the source
-      alSourceStop(source->id);
-      alSourcei(source->id, AL_BUFFER, AL_NONE);
 
       // Rewind the decoder
       if (!lovrAudioStreamIsRaw(source->stream)) {

--- a/src/modules/audio/source.c
+++ b/src/modules/audio/source.c
@@ -291,9 +291,7 @@ void lovrSourceStop(Source* source) {
       alSourceUnqueueBuffers(source->id, count, NULL);
 
       // Rewind the decoder
-      if (!lovrAudioStreamIsRaw(source->stream)) {
-        lovrAudioStreamRewind(source->stream);
-      }
+      lovrAudioStreamRewind(source->stream);
       break;
     }
   }

--- a/src/modules/audio/source.c
+++ b/src/modules/audio/source.c
@@ -230,6 +230,7 @@ void lovrSourceSetFalloff(Source* source, float reference, float max, float roll
 }
 
 void lovrSourceSetLooping(Source* source, bool isLooping) {
+  lovrAssert(!source->stream || lovrAudioStreamIsRaw(source->stream), "Can't loop a raw stream");
   source->isLooping = isLooping;
   if (source->type == SOURCE_STATIC) {
     alSourcei(source->id, AL_LOOPING, isLooping ? AL_TRUE : AL_FALSE);

--- a/src/modules/audio/source.c
+++ b/src/modules/audio/source.c
@@ -169,8 +169,9 @@ void lovrSourcePlay(Source* source) {
   // BEFORE user code calls source:play(). This means that some buffers may still be queued (but processed
   // and completely finished playing). These must be unqueued before we can start using the source again.
   ALint processed;
+  ALuint _unused[SOURCE_BUFFERS];
   alGetSourcei(lovrSourceGetId(source), AL_BUFFERS_PROCESSED, &processed);
-  alSourceUnqueueBuffers(source->id, processed, NULL);
+  alSourceUnqueueBuffers(source->id, processed, &_unused);
 
   lovrSourceStream(source, source->buffers, SOURCE_BUFFERS);
   alSourcePlay(source->id);

--- a/src/modules/audio/source.c
+++ b/src/modules/audio/source.c
@@ -165,11 +165,12 @@ void lovrSourcePlay(Source* source) {
     return;
   }
 
-  // in case we have some queued buffers, make sure to unqueue them before streaming more data into them.
+  // There is no guarantee that lovrAudioUpdate is called AFTER the state of source becomes STOPPED but
+  // BEFORE user code calls source:play(). This means that some buffers may still be queued (but processed
+  // and completely finished playing). These must be unqueued before we can start using the source again.
   ALint processed;
   alGetSourcei(lovrSourceGetId(source), AL_BUFFERS_PROCESSED, &processed);
-  ALuint buffers[SOURCE_BUFFERS];
-  alSourceUnqueueBuffers(source->id, processed, buffers);
+  alSourceUnqueueBuffers(source->id, processed, NULL);
 
   lovrSourceStream(source, source->buffers, SOURCE_BUFFERS);
   alSourcePlay(source->id);

--- a/src/modules/audio/source.c
+++ b/src/modules/audio/source.c
@@ -170,6 +170,12 @@ void lovrSourcePlay(Source* source) {
     lovrAudioStreamRewind(source->stream);
   }
 
+  // in case we have some queued buffers, make sure to unqueue them before streaming more data into them.
+  ALint processed;
+  alGetSourcei(lovrSourceGetId(source), AL_BUFFERS_PROCESSED, &processed);
+  ALuint buffers[SOURCE_BUFFERS];
+  alSourceUnqueueBuffers(source->id, processed, buffers);
+
   lovrSourceStream(source, source->buffers, SOURCE_BUFFERS);
   alSourcePlay(source->id);
 }

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -117,6 +117,12 @@ bool lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound)
   return true;
 }
 
+size_t lovrAudioStreamGetQueueLength(AudioStream* stream)
+{
+  lovrAssert(lovrAudioStreamIsRaw(stream), "Queue length is only available on raw streams");
+  return stream->queueLengthInSamples;
+}
+
 bool lovrAudioStreamIsRaw(AudioStream* stream)
 {
   return stream->decoder == NULL;

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -44,8 +44,15 @@ AudioStream* lovrAudioStreamInitRaw(AudioStream* stream, int channelCount, int s
 
 void lovrAudioStreamDestroy(void* ref) {
   AudioStream* stream = ref;
-  stb_vorbis_close(stream->decoder);
-  lovrRelease(Blob, stream->blob);
+  if (stream->decoder) {
+    stb_vorbis_close(stream->decoder);
+    lovrRelease(Blob, stream->blob);
+  } else {
+    for (int i = 0; i < stream->queuedRawBuffers.length; i++) {
+      lovrRelease(Blob, stream->queuedRawBuffers.data[i]);
+    }
+    arr_free(&stream->queuedRawBuffers);
+  }
   free(stream->buffer);
 }
 

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -55,8 +55,7 @@ void lovrAudioStreamDestroy(void* ref) {
   free(stream->buffer);
 }
 
-static size_t dequeue_raw(AudioStream* stream, int16_t* destination, size_t sampleCount)
-{
+static size_t dequeue_raw(AudioStream* stream, int16_t* destination, size_t sampleCount) {
   if (stream->queuedRawBuffers.length == 0) {
     return 0;
   }
@@ -104,8 +103,7 @@ size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t s
   return samples;
 }
 
-bool lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob)
-{
+bool lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob) {
   lovrAssert(lovrAudioStreamIsRaw(stream), "Raw PCM data can only be appended to a raw AudioStream (see constructor that takes channel count and sample rate)")
   if (stream->queueLimitInSamples != 0 && stream->samples + blob->size/sizeof(int16_t) >= stream->queueLimitInSamples) {
     return false;
@@ -116,20 +114,16 @@ bool lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob)
   return true;
 }
 
-bool lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound)
-{
+bool lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound) {
   lovrAssert(sound->channelCount == stream->channelCount && sound->bitDepth == stream->bitDepth && sound->sampleRate == stream->sampleRate, "SoundData and AudioStream formats must match");
-  lovrAudioStreamAppendRawBlob(stream, &sound->blob);
-  return true;
+  return lovrAudioStreamAppendRawBlob(stream, &sound->blob);
 }
 
-bool lovrAudioStreamIsRaw(AudioStream* stream)
-{
+bool lovrAudioStreamIsRaw(AudioStream* stream) {
   return stream->decoder == NULL;
 }
 
-double lovrAudioStreamGetDurationInSeconds(AudioStream* stream)
-{
+double lovrAudioStreamGetDurationInSeconds(AudioStream* stream) {
   return stream->samples / stream->channelCount / stream->sampleRate;
 }
 

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -58,14 +58,17 @@ static size_t dequeue_raw(AudioStream* stream, int16_t* destination, size_t size
     memcpy(destination, blob->data, blob->size);
     lovrRelease(Blob, blob);
     arr_splice(&stream->queuedRawBuffers, 0, 1);
-    return size;
+    return blob->size;
   } else {
     // blob is too big. copy all that fits, and put remainder in a new blob in its place.
     memcpy(destination, blob->data, size);
     void* oldData = blob->data;
-    lovrBlobInit(blob, (char*)blob->data + size, blob->size - size, "raw audiostream remainder");
+    size_t remainingLength = blob->size - size;
+    void* copiedRemainder = malloc(remainingLength);
+    memcpy(copiedRemainder, (char*)blob->data + size, remainingLength);
+    lovrBlobInit(blob, copiedRemainder, remainingLength, "raw audiostream remainder");
     free(oldData);
-    return blob->size;
+    return size;
   }
 }
 

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -5,7 +5,7 @@
 #include "core/util.h"
 #include "lib/stb/stb_vorbis.h"
 #include <stdlib.h>
-#include <memory.h>
+#include <string.h>
 
 AudioStream* lovrAudioStreamInit(AudioStream* stream, Blob* blob, size_t bufferSize) {
   stb_vorbis* decoder = stb_vorbis_open_memory(blob->data, (int) blob->size, NULL, NULL);

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -54,11 +54,12 @@ static size_t dequeue_raw(AudioStream* stream, int16_t* destination, size_t size
   }
   Blob* blob = stream->queuedRawBuffers.data[0];
   if (blob->size <= size) {
+    size_t blobSize = blob->size;
     // blob fits in destination in its entirety. Copy over, free it and remove from start of array.
-    memcpy(destination, blob->data, blob->size);
+    memcpy(destination, blob->data, blobSize);
     lovrRelease(Blob, blob);
     arr_splice(&stream->queuedRawBuffers, 0, 1);
-    return blob->size;
+    return blobSize;
   } else {
     // blob is too big. copy all that fits, and put remainder in a new blob in its place.
     memcpy(destination, blob->data, size);

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -1,5 +1,6 @@
 #include "data/audioStream.h"
 #include "data/blob.h"
+#include "data/soundData.h"
 #include "core/ref.h"
 #include "core/util.h"
 #include "lib/stb/stb_vorbis.h"
@@ -24,11 +25,47 @@ AudioStream* lovrAudioStreamInit(AudioStream* stream, Blob* blob, size_t bufferS
   return stream;
 }
 
+AudioStream* lovrAudioStreamInitRaw(AudioStream* stream, size_t bufferSize, int channelCount, int sampleRate) {
+  stream->bitDepth = 16;
+  stream->channelCount = channelCount;
+  stream->sampleRate = sampleRate;
+  stream->samples = SIZE_MAX;
+  stream->decoder = NULL;
+  stream->bufferSize = stream->channelCount * bufferSize * sizeof(int16_t);
+  stream->buffer = malloc(stream->bufferSize);
+  lovrAssert(stream->buffer, "Out of memory");
+  stream->blob = NULL;
+  arr_init(&stream->queuedRawBuffers);
+  return stream;
+}
+
 void lovrAudioStreamDestroy(void* ref) {
   AudioStream* stream = ref;
   stb_vorbis_close(stream->decoder);
   lovrRelease(Blob, stream->blob);
   free(stream->buffer);
+}
+
+static size_t dequeue_raw(AudioStream* stream, int16_t* destination, size_t size)
+{
+  if (stream->queuedRawBuffers.length == 0) {
+    return 0;
+  }
+  Blob* blob = stream->queuedRawBuffers.data[0];
+  if (blob->size <= size) {
+    // blob fits in destination in its entirety. Copy over, free it and remove from start of array.
+    memcpy(destination, blob->data, blob->size);
+    lovrRelease(Blob, blob);
+    arr_splice(&stream->queuedRawBuffers, 0, 1);
+    return size;
+  } else {
+    // blob is too big. copy all that fits, and put remainder in a new blob in its place.
+    memcpy(destination, blob->data, size);
+    void* oldData = blob->data;
+    lovrBlobInit(blob, (char*)blob->data + size, blob->size - size, "raw audiostream remainder");
+    free(oldData);
+    return blob->size;
+  }
 }
 
 size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t size) {
@@ -39,7 +76,12 @@ size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t s
   size_t samples = 0;
 
   while (samples < capacity) {
-    int count = stb_vorbis_get_samples_short_interleaved(decoder, channelCount, buffer + samples, (int) (capacity - samples));
+    int count = 0;
+    if (decoder) {
+      count = stb_vorbis_get_samples_short_interleaved(decoder, channelCount, buffer + samples, (int)(capacity - samples));
+    } else {
+      count = dequeue_raw(stream, buffer + samples, (int)(capacity - samples));
+    }
     if (count == 0) break;
     samples += count * channelCount;
   }
@@ -47,17 +89,32 @@ size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t s
   return samples;
 }
 
+void lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob)
+{
+  lovrRetain(blob);
+  arr_push(&stream->queuedRawBuffers, blob);
+}
+
+void lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound)
+{
+  lovrAssert(sound->channelCount == stream->channelCount && sound->bitDepth == stream->bitDepth && sound->sampleRate == stream->sampleRate, "SoundData and AudioStream formats must match");
+  lovrAudioStreamAppendRawBlob(stream, &sound->blob);
+}
+
 void lovrAudioStreamRewind(AudioStream* stream) {
+  lovrAssert(stream->decoder, "Can't rewind raw stream");
   stb_vorbis* decoder = (stb_vorbis*) stream->decoder;
   stb_vorbis_seek_start(decoder);
 }
 
 void lovrAudioStreamSeek(AudioStream* stream, size_t sample) {
+  lovrAssert(stream->decoder, "Can't seek raw stream");
   stb_vorbis* decoder = (stb_vorbis*) stream->decoder;
   stb_vorbis_seek(decoder, (int) sample);
 }
 
 size_t lovrAudioStreamTell(AudioStream* stream) {
+  lovrAssert(stream->decoder, "No position available in raw stream");
   stb_vorbis* decoder = (stb_vorbis*) stream->decoder;
   return stb_vorbis_get_sample_offset(decoder);
 }

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -16,7 +16,7 @@ AudioStream* lovrAudioStreamInit(AudioStream* stream, Blob* blob, size_t bufferS
   stream->bitDepth = 16;
   stream->channelCount = info.channels;
   stream->sampleRate = info.sample_rate;
-  stream->samples = stb_vorbis_stream_length_in_samples(decoder);
+  stream->samples = stb_vorbis_stream_length_in_samples(decoder) * info.channels;
   stream->decoder = decoder;
   stream->bufferSize = stream->channelCount * bufferSize * sizeof(int16_t);
   stream->buffer = malloc(stream->bufferSize);
@@ -126,6 +126,11 @@ bool lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound)
 bool lovrAudioStreamIsRaw(AudioStream* stream)
 {
   return stream->decoder == NULL;
+}
+
+double lovrAudioStreamGetDurationInSeconds(AudioStream* stream)
+{
+  return stream->samples / stream->channelCount / stream->sampleRate;
 }
 
 void lovrAudioStreamRewind(AudioStream* stream) {

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -92,7 +92,7 @@ size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t s
 
 bool lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob)
 {
-  lovrAssert(stream->decoder == NULL, "Raw PCM data can only be appended to a raw AudioStream (see constructor that takes channel count and sample rate)")
+  lovrAssert(lovrAudioStreamIsRaw(stream), "Raw PCM data can only be appended to a raw AudioStream (see constructor that takes channel count and sample rate)")
   lovrRetain(blob);
   arr_push(&stream->queuedRawBuffers, blob);
   return true;
@@ -105,20 +105,25 @@ bool lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound)
   return true;
 }
 
+bool lovrAudioStreamIsRaw(AudioStream* stream)
+{
+  return stream->decoder == NULL;
+}
+
 void lovrAudioStreamRewind(AudioStream* stream) {
-  lovrAssert(stream->decoder, "Can't rewind raw stream");
+  lovrAssert(!lovrAudioStreamIsRaw(stream), "Can't rewind raw stream");
   stb_vorbis* decoder = (stb_vorbis*) stream->decoder;
   stb_vorbis_seek_start(decoder);
 }
 
 void lovrAudioStreamSeek(AudioStream* stream, size_t sample) {
-  lovrAssert(stream->decoder, "Can't seek raw stream");
+  lovrAssert(!lovrAudioStreamIsRaw(stream), "Can't seek raw stream");
   stb_vorbis* decoder = (stb_vorbis*) stream->decoder;
   stb_vorbis_seek(decoder, (int) sample);
 }
 
 size_t lovrAudioStreamTell(AudioStream* stream) {
-  lovrAssert(stream->decoder, "No position available in raw stream");
+  lovrAssert(!lovrAudioStreamIsRaw(stream), "No position available in raw stream");
   stb_vorbis* decoder = (stb_vorbis*) stream->decoder;
   return stb_vorbis_get_sample_offset(decoder);
 }

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -129,9 +129,16 @@ bool lovrAudioStreamIsRaw(AudioStream* stream)
 }
 
 void lovrAudioStreamRewind(AudioStream* stream) {
-  lovrAssert(!lovrAudioStreamIsRaw(stream), "Can't rewind raw stream");
   stb_vorbis* decoder = (stb_vorbis*) stream->decoder;
-  stb_vorbis_seek_start(decoder);
+  if (decoder) {
+    stb_vorbis_seek_start(decoder);
+  } else {
+    stream->queueLengthInSamples = 0;
+    for (int i = 0; i < stream->queuedRawBuffers.length; i++) {
+      lovrRelease(Blob, stream->queuedRawBuffers.data[i]);
+    }
+    arr_clear(&stream->queuedRawBuffers);
+  }
 }
 
 void lovrAudioStreamSeek(AudioStream* stream, size_t sample) {

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -122,7 +122,7 @@ bool lovrAudioStreamIsRaw(AudioStream* stream) {
 }
 
 double lovrAudioStreamGetDurationInSeconds(AudioStream* stream) {
-  return stream->samples / stream->channelCount / stream->sampleRate;
+  return (double)stream->samples / stream->channelCount / stream->sampleRate;
 }
 
 void lovrAudioStreamRewind(AudioStream* stream) {

--- a/src/modules/data/audioStream.h
+++ b/src/modules/data/audioStream.h
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 #include "core/arr.h"
 
 #pragma once
@@ -21,12 +22,12 @@ typedef struct AudioStream {
 
 AudioStream* lovrAudioStreamInit(AudioStream* stream, struct Blob* blob, size_t bufferSize);
 #define lovrAudioStreamCreate(...) lovrAudioStreamInit(lovrAlloc(AudioStream), __VA_ARGS__)
-AudioStream* lovrAudioStreamInitRaw(AudioStream* stream, size_t bufferSize, int channelCount, int sampleRate);
+AudioStream* lovrAudioStreamInitRaw(AudioStream* stream, int channelCount, int sampleRate, size_t bufferSize);
 #define lovrAudioStreamCreateRaw(...) lovrAudioStreamInitRaw(lovrAlloc(AudioStream), __VA_ARGS__)
 void lovrAudioStreamDestroy(void* ref);
 size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t size);
-void lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob);
-void lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound);
+bool lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob);
+bool lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound);
 void lovrAudioStreamRewind(AudioStream* stream);
 void lovrAudioStreamSeek(AudioStream* stream, size_t sample);
 size_t lovrAudioStreamTell(AudioStream* stream);

--- a/src/modules/data/audioStream.h
+++ b/src/modules/data/audioStream.h
@@ -19,6 +19,7 @@ typedef struct AudioStream {
   struct Blob* blob;
   arr_t(struct Blob*) queuedRawBuffers;
   size_t queueLimitInSamples;
+  size_t firstBlobCursor; // bytes into queuedRawBuffers.data[0] at which to do the next read
 } AudioStream;
 
 AudioStream* lovrAudioStreamInit(AudioStream* stream, struct Blob* blob, size_t bufferSize);

--- a/src/modules/data/audioStream.h
+++ b/src/modules/data/audioStream.h
@@ -30,6 +30,7 @@ void lovrAudioStreamDestroy(void* ref);
 size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t size);
 bool lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob);
 bool lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound);
+size_t lovrAudioStreamGetQueueLength(AudioStream* stream);
 bool lovrAudioStreamIsRaw(AudioStream* stream);
 void lovrAudioStreamRewind(AudioStream* stream);
 void lovrAudioStreamSeek(AudioStream* stream, size_t sample);

--- a/src/modules/data/audioStream.h
+++ b/src/modules/data/audioStream.h
@@ -12,13 +12,12 @@ typedef struct AudioStream {
   uint32_t bitDepth;
   uint32_t channelCount;
   uint32_t sampleRate;
-  size_t samples;
+  size_t samples; // if raw: count of samples queued in queuedRawBuffers
   size_t bufferSize;
   void* buffer;
   void* decoder; // null if stream is raw
   struct Blob* blob;
   arr_t(struct Blob*) queuedRawBuffers;
-  size_t queueLengthInSamples;
   size_t queueLimitInSamples;
 } AudioStream;
 
@@ -30,7 +29,6 @@ void lovrAudioStreamDestroy(void* ref);
 size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t size);
 bool lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob);
 bool lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound);
-size_t lovrAudioStreamGetQueueLength(AudioStream* stream);
 bool lovrAudioStreamIsRaw(AudioStream* stream);
 void lovrAudioStreamRewind(AudioStream* stream);
 void lovrAudioStreamSeek(AudioStream* stream, size_t sample);

--- a/src/modules/data/audioStream.h
+++ b/src/modules/data/audioStream.h
@@ -28,6 +28,7 @@ void lovrAudioStreamDestroy(void* ref);
 size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t size);
 bool lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob);
 bool lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound);
+bool lovrAudioStreamIsRaw(AudioStream* stream);
 void lovrAudioStreamRewind(AudioStream* stream);
 void lovrAudioStreamSeek(AudioStream* stream, size_t sample);
 size_t lovrAudioStreamTell(AudioStream* stream);

--- a/src/modules/data/audioStream.h
+++ b/src/modules/data/audioStream.h
@@ -29,6 +29,7 @@ void lovrAudioStreamDestroy(void* ref);
 size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t size);
 bool lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob);
 bool lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound);
+double lovrAudioStreamGetDurationInSeconds(AudioStream* stream);
 bool lovrAudioStreamIsRaw(AudioStream* stream);
 void lovrAudioStreamRewind(AudioStream* stream);
 void lovrAudioStreamSeek(AudioStream* stream, size_t sample);

--- a/src/modules/data/audioStream.h
+++ b/src/modules/data/audioStream.h
@@ -1,9 +1,11 @@
 #include <stdint.h>
 #include <stddef.h>
+#include "core/arr.h"
 
 #pragma once
 
 struct Blob;
+struct SoundData;
 
 typedef struct AudioStream {
   uint32_t bitDepth;
@@ -12,14 +14,19 @@ typedef struct AudioStream {
   size_t samples;
   size_t bufferSize;
   void* buffer;
-  void* decoder;
+  void* decoder; // null if stream is raw
   struct Blob* blob;
+  arr_t(struct Blob*) queuedRawBuffers;
 } AudioStream;
 
 AudioStream* lovrAudioStreamInit(AudioStream* stream, struct Blob* blob, size_t bufferSize);
 #define lovrAudioStreamCreate(...) lovrAudioStreamInit(lovrAlloc(AudioStream), __VA_ARGS__)
+AudioStream* lovrAudioStreamInitRaw(AudioStream* stream, size_t bufferSize, int channelCount, int sampleRate);
+#define lovrAudioStreamCreateRaw(...) lovrAudioStreamInitRaw(lovrAlloc(AudioStream), __VA_ARGS__)
 void lovrAudioStreamDestroy(void* ref);
 size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t size);
+void lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob);
+void lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound);
 void lovrAudioStreamRewind(AudioStream* stream);
 void lovrAudioStreamSeek(AudioStream* stream, size_t sample);
 size_t lovrAudioStreamTell(AudioStream* stream);

--- a/src/modules/data/audioStream.h
+++ b/src/modules/data/audioStream.h
@@ -18,11 +18,13 @@ typedef struct AudioStream {
   void* decoder; // null if stream is raw
   struct Blob* blob;
   arr_t(struct Blob*) queuedRawBuffers;
+  size_t queueLengthInSamples;
+  size_t queueLimitInSamples;
 } AudioStream;
 
 AudioStream* lovrAudioStreamInit(AudioStream* stream, struct Blob* blob, size_t bufferSize);
 #define lovrAudioStreamCreate(...) lovrAudioStreamInit(lovrAlloc(AudioStream), __VA_ARGS__)
-AudioStream* lovrAudioStreamInitRaw(AudioStream* stream, int channelCount, int sampleRate, size_t bufferSize);
+AudioStream* lovrAudioStreamInitRaw(AudioStream* stream, int channelCount, int sampleRate, size_t bufferSize, size_t queueLimitInSamples);
 #define lovrAudioStreamCreateRaw(...) lovrAudioStreamInitRaw(lovrAlloc(AudioStream), __VA_ARGS__)
 void lovrAudioStreamDestroy(void* ref);
 size_t lovrAudioStreamDecode(AudioStream* stream, int16_t* destination, size_t size);


### PR DESCRIPTION
Gives LÖVR the ability to play runtime-generated audio (in addition to playing audio from ogg files on disk). This will be used in Alloverse to play voip audio between multiplayer users, but could also be used to generate audio or music programmatically.

This PR adds two APIs:
* `lovr.audio.newAudioStream(bufferSize, channelCount, sampleRate)` creates a "raw" AudioStream which can only get audio from `AudioStream:append()` and not from decoding a file on disk
* `AudioStream:append(blob)` appends raw PCM sound data for playback ASAP.

Tasks remaining before PR is mergeable:

- [x] Implement Lua API
- [ ] Create a queue of blobs to reduce malloc churn (or use a ringbuffer)
- [x] add upper limit for queued buffers