### PR TITLE
Oculus Mobile hand tracking [prototype]

### DIFF
--- a/src/modules/headset/oculus_mobile.c
+++ b/src/modules/headset/oculus_mobile.c
@@ -186,7 +186,11 @@ static bool vrapi_isDown(Device device, DeviceButton button, bool* down) {
   if (idx < 0)
     return false;
 
-  return buttonDown(bridgeLovrMobileData.updateData.controllers[idx].buttonDown, button, down);
+  BridgeLovrController *data = &bridgeLovrMobileData.updateData.controllers[idx];
+  if (data->hand & BRIDGE_LOVR_HAND_TRACKING)
+    return false;
+
+  return buttonDown(data->handset.buttonDown, button, down);
 }
 
 static bool vrapi_isTouched(Device device, DeviceButton button, bool* touched) {
@@ -194,7 +198,11 @@ static bool vrapi_isTouched(Device device, DeviceButton button, bool* touched) {
   if (idx < 0)
     return false;
 
-  return buttonTouch(bridgeLovrMobileData.updateData.controllers[idx].buttonTouch, button, touched);
+  BridgeLovrController *data = &bridgeLovrMobileData.updateData.controllers[idx];
+  if (data->hand & BRIDGE_LOVR_HAND_TRACKING)
+    return false;
+
+  return buttonTouch(data->handset.buttonTouch, button, touched);
 }
 
 static bool vrapi_getAxis(Device device, DeviceAxis axis, float* value) {
@@ -204,25 +212,27 @@ static bool vrapi_getAxis(Device device, DeviceAxis axis, float* value) {
 
   BridgeLovrController *data = &bridgeLovrMobileData.updateData.controllers[idx];
 
-  if (bridgeLovrMobileData.deviceType == BRIDGE_LOVR_DEVICE_QUEST) {
+  if (data->hand & BRIDGE_LOVR_HAND_TRACKING) {
+    return false;
+  } else if (data->hand & BRIDGE_LOVR_HAND_RIFTY) {
     switch (axis) {
       case AXIS_THUMBSTICK:
-        value[0] = data->trackpad.x;
-        value[1] = data->trackpad.y;
+        value[0] = data->handset.trackpad.x;
+        value[1] = data->handset.trackpad.y;
         break;
-      case AXIS_TRIGGER: value[0] = data->trigger; break;
-      case AXIS_GRIP: value[0] = data->grip; break;
+      case AXIS_TRIGGER: value[0] = data->handset.trigger; break;
+      case AXIS_GRIP: value[0] = data->handset.grip; break;
       default: return false;
     }
   } else {
     switch (axis) {
       case AXIS_TOUCHPAD:
-        value[0] = (data->trackpad.x - 160) / 160.f;
-        value[1] = (data->trackpad.y - 160) / 160.f;
+        value[0] = (data->handset.trackpad.x - 160) / 160.f;
+        value[1] = (data->handset.trackpad.y - 160) / 160.f;
         break;
       case AXIS_TRIGGER: {
         bool down;
-        if (!buttonDown(data->buttonDown, BUTTON_TRIGGER, &down))
+        if (!buttonDown(data->handset.buttonDown, BUTTON_TRIGGER, &down))
           return false;
         value[0] = down ? 1.f : 0.f;
         break;
@@ -456,6 +466,17 @@ void bridgeLovrInit(BridgeLovrInitData *initData) {
   LOG("\n BRIDGE INIT COMPLETE\n");
 }
 
+#define growAndCopyArray(OUT, IN, DATA, TYPE) \
+  { \
+      size_t arraySize = IN->members * sizeof(TYPE); \
+      if (IN->members > OUT.members) { \
+        free(OUT.DATA); \
+        OUT.DATA = malloc(arraySize); \
+      } \
+      OUT.members = IN->members; \
+      memcpy(OUT.DATA, IN->DATA, arraySize); \
+  }
+
 void bridgeLovrUpdate(BridgeLovrUpdateData *updateData) {
   // Unpack update data
   bridgeLovrMobileData.updateData = *updateData;
@@ -466,6 +487,23 @@ void bridgeLovrUpdate(BridgeLovrUpdateData *updateData) {
   } else if (pauseState == PAUSESTATE_RESUME) { // Resume frame-- adjust platform time to be equal to last good platform time
     lovrPlatformSetTime(lastPauseAt);
     pauseState = PAUSESTATE_NONE;
+  }
+
+  // Temporary hand handling
+  for(int c = 0; c < updateData->controllerCount; c++) {
+    BridgeLovrController *in = &updateData->controllers[c];
+    if (in->hand & BRIDGE_LOVR_HAND_TRACKING) {
+      bool right = in->hand & BRIDGE_LOVR_HAND_RIGHT;
+      LovrOculusMobileHands *out = &lovrOculusMobileHands[right];
+      out->live = true;
+      out->confidence = in->tracking.confidence;
+      out->handScale = in->tracking.handScale;
+      out->pose = in->pose;
+
+      growAndCopyArray(out->bones, in->tracking.bones, strings, char *);
+      growAndCopyArray(out->handPoses, in->tracking.poses, poses, BridgeLovrPose);
+      growAndCopyArray(out->fingerConfidence, in->tracking.fingerConfidence, numbers, float);
+    }
   }
 
   // Go

--- a/src/modules/headset/oculus_mobile.h
+++ b/src/modules/headset/oculus_mobile.h
@@ -1,3 +1,15 @@
 #pragma once
 
 extern char *lovrOculusMobileWritablePath;
+
+typedef struct {
+  bool live;
+  float confidence;
+  float handScale;
+  BridgeLovrPose pose;
+  BridgeLovrStringList bones;
+  BridgeLovrPoseList handPoses;
+  BridgeLovrFloatList fingerConfidence;
+} LovrOculusMobileHands;
+
+LovrOculusMobileHands lovrOculusMobileHands[2];

--- a/src/modules/headset/oculus_mobile_bridge.h
+++ b/src/modules/headset/oculus_mobile_bridge.h
@@ -75,10 +75,16 @@ typedef enum
   BRIDGE_LOVR_TOUCH_TRIGGER_ANTI  = 0x00000200, // "The finger is sufficiently far away from the trigger to not be considered in proximity to it."
 } BridgeLovrTouch;
 
-// Bit identical with VrApi_Input.h ovrControllerCapabilties
 typedef enum {
-  BRIDGE_LOVR_HAND_LEFT = 0x00000004,
-  BRIDGE_LOVR_HAND_RIGHT = 0x00000008,
+  BRIDGE_LOVR_HAND_LEFT =  0x00000001, // Bit identical with VrApi_Input.h ovrHandTrackingStatus
+  BRIDGE_LOVR_HAND_RIGHT = 0x00000002, // Bit identical with VrApi_Input.h ovrHandTrackingStatus
+
+  BRIDGE_LOVR_HAND_HANDMASK = BRIDGE_LOVR_HAND_LEFT | BRIDGE_LOVR_HAND_RIGHT, // Bits to mask a ovrHandTrackingStatus by
+  BRIDGE_LOVR_HAND_CAPSHIFT = 2, // Right shift a ovrControllerCapabilities by this many bits to let BRIDGE_LOVR_HAND_HANDMASK work
+
+  BRIDGE_LOVR_HAND_HANDSET   = 0x00000004, // If true, a tracked handset (as opposed to a "controller")
+  BRIDGE_LOVR_HAND_RIFTY     = 0x00000008, // If true, handset is "oculus quest style"
+  BRIDGE_LOVR_HAND_TRACKING  = 0x00000010, // If true, hand tracking
 } BridgeLovrHand;
 
 // Values identical with headset.h HeadsetType
@@ -90,15 +96,41 @@ typedef enum
   BRIDGE_LOVR_DEVICE_QUEST = 5,
 } BridgeLovrDevice;
 
+typedef struct { // Assumed constant
+  int members;
+  const char **strings;
+} BridgeLovrStringList;
+
+typedef struct { // Assumed constant
+  int members;
+  float *numbers;
+} BridgeLovrFloatList;
+
+typedef struct { // Assumed constant
+  int members;
+  BridgeLovrPose *poses;
+} BridgeLovrPoseList;
+
 typedef struct {
-  bool handset;
   BridgeLovrHand hand;
   BridgeLovrPose pose;
   BridgeLovrMovement movement;
-  BridgeLovrTrackpad trackpad;
-  float trigger, grip;
-  BridgeLovrButton buttonDown;
-  BridgeLovrTouch  buttonTouch;
+  union {
+    struct {
+      BridgeLovrTrackpad trackpad;
+      float trigger, grip;
+      BridgeLovrButton buttonDown;
+      BridgeLovrTouch  buttonTouch;
+    } handset;
+    struct {
+      bool live;
+      float confidence;
+      float handScale;
+      BridgeLovrStringList *bones;
+      BridgeLovrPoseList *poses;
+      BridgeLovrFloatList *fingerConfidence;
+    } tracking;
+  };
 } BridgeLovrController;
 
 #define BRIDGE_LOVR_CONTROLLERMAX 3


### PR DESCRIPTION
Values are passed in via some new lists in bridge.h and are returned via some very simplistic functions in a new table `lovr.headset.hand`.

This is the api used with [andi-hand](https://github.com/mcclure/lovr/tree/andi-hand) branch git:67f8a55063ae and is meant to be compiled paired with [lovr-oculus-mobile](https://github.com/mcclure/lovr-oculus-mobile/tree/lovr-oculus-mobile-hand/) git:d10d1e5199ff . The andi-hand branch is separate because that one contains the "finger guns"/"shoot the can" demo.

I think the bridge changes can possibly go in right now, but maybe we shouldn't merge this until we have a better API than the `lovr.headset.hand` table. More comments on this below.