### PR TITLE
Sound adjustments: SoundData has-a blob, and mic sample size getter

### DIFF
--- a/src/api/l_audio_microphone.c
+++ b/src/api/l_audio_microphone.c
@@ -18,7 +18,8 @@ static int l_lovrMicrophoneGetChannelCount(lua_State* L) {
 
 static int l_lovrMicrophoneGetData(lua_State* L) {
   Microphone* microphone = luax_checktype(L, 1, Microphone);
-  SoundData* soundData = lovrMicrophoneGetData(microphone);
+  size_t samples = luax_optfloat(L, 2, 0);
+  SoundData* soundData = lovrMicrophoneGetData(microphone, samples);
   luax_pushtype(L, SoundData, soundData);
   lovrRelease(SoundData, soundData);
   return 1;

--- a/src/api/l_audio_microphone.c
+++ b/src/api/l_audio_microphone.c
@@ -18,7 +18,7 @@ static int l_lovrMicrophoneGetChannelCount(lua_State* L) {
 
 static int l_lovrMicrophoneGetData(lua_State* L) {
   Microphone* microphone = luax_checktype(L, 1, Microphone);
-  size_t samples = luax_optfloat(L, 2, 0);
+  size_t samples = luaL_optinteger(L, 2, 0);
   SoundData* soundData = lovrMicrophoneGetData(microphone, samples);
   luax_pushtype(L, SoundData, soundData);
   lovrRelease(SoundData, soundData);

--- a/src/api/l_data_audioStream.c
+++ b/src/api/l_data_audioStream.c
@@ -10,7 +10,7 @@ static int l_lovrAudioStreamDecode(lua_State* L) {
   size_t samples = lovrAudioStreamDecode(stream, NULL, 0);
   if (samples > 0) {
     SoundData* soundData = lovrSoundDataCreate(samples / stream->channelCount, stream->sampleRate, stream->bitDepth, stream->channelCount);
-    memcpy(soundData->blob.data, stream->buffer, samples * (stream->bitDepth / 8));
+    memcpy(soundData->blob->data, stream->buffer, samples * (stream->bitDepth / 8));
     luax_pushtype(L, SoundData, soundData);
     lovrRelease(SoundData, soundData);
   } else {

--- a/src/api/l_data_soundData.c
+++ b/src/api/l_data_soundData.c
@@ -51,7 +51,6 @@ static int l_lovrSoundDataGetBlob(lua_State* L) {
   SoundData* soundData = luax_checktype(L, 1, SoundData);
   Blob* blob = soundData->blob;
   luax_pushtype(L, Blob, blob);
-  lovrRelease(Blob, blob);
   return 1;
 }
 

--- a/src/api/l_data_soundData.c
+++ b/src/api/l_data_soundData.c
@@ -47,12 +47,6 @@ static int l_lovrSoundDataSetSample(lua_State* L) {
   return 0;
 }
 
-static int l_lovrSoundDataGetPointer(lua_State* L) {
-  SoundData* soundData = luax_checktype(L, 1, SoundData);
-  lua_pushlightuserdata(L, soundData->blob->data);
-  return 1;
-}
-
 static int l_lovrSoundDataGetBlob(lua_State* L) {
   SoundData* soundData = luax_checktype(L, 1, SoundData);
   Blob* blob = soundData->blob;
@@ -69,7 +63,6 @@ const luaL_Reg lovrSoundData[] = {
   { "getSampleCount", l_lovrSoundDataGetSampleCount },
   { "getSampleRate", l_lovrSoundDataGetSampleRate },
   { "setSample", l_lovrSoundDataSetSample },
-  { "getPointer", l_lovrSoundDataGetPointer },
   { "getBlob", l_lovrSoundDataGetBlob },
   { NULL, NULL }
 };

--- a/src/api/l_data_soundData.c
+++ b/src/api/l_data_soundData.c
@@ -1,5 +1,6 @@
 #include "api.h"
 #include "data/soundData.h"
+#include "core/ref.h"
 
 static int l_lovrSoundDataGetBitDepth(lua_State* L) {
   SoundData* soundData = luax_checktype(L, 1, SoundData);
@@ -56,6 +57,7 @@ static int l_lovrSoundDataGetBlob(lua_State* L) {
   SoundData* soundData = luax_checktype(L, 1, SoundData);
   Blob* blob = soundData->blob;
   luax_pushtype(L, Blob, blob);
+  lovrRelease(Blob, blob);
   return 1;
 }
 

--- a/src/api/l_data_soundData.c
+++ b/src/api/l_data_soundData.c
@@ -52,6 +52,13 @@ static int l_lovrSoundDataGetPointer(lua_State* L) {
   return 1;
 }
 
+static int l_lovrSoundDataGetBlob(lua_State* L) {
+  SoundData* soundData = luax_checktype(L, 1, SoundData);
+  Blob* blob = soundData->blob;
+  luax_pushtype(L, Blob, blob);
+  return 1;
+}
+
 const luaL_Reg lovrSoundData[] = {
   { "getBitDepth", l_lovrSoundDataGetBitDepth },
   { "getChannelCount", l_lovrSoundDataGetChannelCount },
@@ -61,5 +68,6 @@ const luaL_Reg lovrSoundData[] = {
   { "getSampleRate", l_lovrSoundDataGetSampleRate },
   { "setSample", l_lovrSoundDataSetSample },
   { "getPointer", l_lovrSoundDataGetPointer },
+  { "getBlob", l_lovrSoundDataGetBlob },
   { NULL, NULL }
 };

--- a/src/api/l_data_soundData.c
+++ b/src/api/l_data_soundData.c
@@ -48,7 +48,7 @@ static int l_lovrSoundDataSetSample(lua_State* L) {
 
 static int l_lovrSoundDataGetPointer(lua_State* L) {
   SoundData* soundData = luax_checktype(L, 1, SoundData);
-  lua_pushlightuserdata(L, soundData->blob.data);
+  lua_pushlightuserdata(L, soundData->blob->data);
   return 1;
 }
 

--- a/src/api/l_data_textureData.c
+++ b/src/api/l_data_textureData.c
@@ -78,7 +78,6 @@ static int l_lovrTextureDataGetBlob(lua_State* L) {
   TextureData* textureData = luax_checktype(L, 1, TextureData);
   Blob* blob = textureData->blob;
   luax_pushtype(L, Blob, blob);
-  lovrRelease(Blob, blob);
   return 1;
 }
 

--- a/src/api/l_data_textureData.c
+++ b/src/api/l_data_textureData.c
@@ -1,5 +1,6 @@
 #include "api.h"
 #include "data/textureData.h"
+#include "core/ref.h"
 
 static int l_lovrTextureDataEncode(lua_State* L) {
   TextureData* textureData = luax_checktype(L, 1, TextureData);
@@ -73,9 +74,11 @@ static int l_lovrTextureDataSetPixel(lua_State* L) {
   return 0;
 }
 
-static int l_lovrTextureDataGetPointer(lua_State* L) {
+static int l_lovrTextureDataGetBlob(lua_State* L) {
   TextureData* textureData = luax_checktype(L, 1, TextureData);
-  lua_pushlightuserdata(L, textureData->blob.data);
+  Blob* blob = textureData->blob;
+  luax_pushtype(L, Blob, blob);
+  lovrRelease(Blob, blob);
   return 1;
 }
 
@@ -88,6 +91,6 @@ const luaL_Reg lovrTextureData[] = {
   { "paste", l_lovrTextureDataPaste },
   { "getPixel", l_lovrTextureDataGetPixel },
   { "setPixel", l_lovrTextureDataSetPixel },
-  { "getPointer", l_lovrTextureDataGetPointer },
+  { "getBlob", l_lovrTextureDataGetBlob },
   { NULL, NULL }
 };

--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -358,7 +358,7 @@ static int l_lovrGraphicsCreateWindow(lua_State* L) {
   TextureData* textureData = NULL;
   if (!lua_isnil(L, -1)) {
     textureData = luax_checktexturedata(L, -1, true);
-    flags.icon.data = textureData->blob.data;
+    flags.icon.data = textureData->blob->data;
     flags.icon.width = textureData->width;
     flags.icon.height = textureData->height;
     lovrRelease(TextureData, textureData);

--- a/src/modules/audio/microphone.c
+++ b/src/modules/audio/microphone.c
@@ -56,7 +56,7 @@ SoundData* lovrMicrophoneGetData(Microphone* microphone, size_t samples) {
   }
 
   SoundData* soundData = lovrSoundDataCreate(samples, microphone->sampleRate, microphone->bitDepth, microphone->channelCount);
-  alcCaptureSamples(microphone->device, soundData->blob.data, (ALCsizei) samples);
+  alcCaptureSamples(microphone->device, soundData->blob->data, (ALCsizei) samples);
   return soundData;
 }
 

--- a/src/modules/audio/microphone.c
+++ b/src/modules/audio/microphone.c
@@ -46,13 +46,12 @@ SoundData* lovrMicrophoneGetData(Microphone* microphone, size_t samples) {
     return NULL;
   }
 
-  size_t maxSamples = lovrMicrophoneGetSampleCount(microphone);
-  if (maxSamples == 0) {
+  size_t availableSamples = lovrMicrophoneGetSampleCount(microphone);
+  if (availableSamples == 0) {
     return NULL;
   }
-  lovrAssert(samples <= maxSamples, "Requested more audio data than is buffered by the microphone");
-  if (samples == 0) {
-    samples = maxSamples;
+  if (samples == 0 || samples > availableSamples) {
+    samples = availableSamples;
   }
 
   SoundData* soundData = lovrSoundDataCreate(samples, microphone->sampleRate, microphone->bitDepth, microphone->channelCount);

--- a/src/modules/audio/microphone.c
+++ b/src/modules/audio/microphone.c
@@ -41,14 +41,18 @@ uint32_t lovrMicrophoneGetChannelCount(Microphone* microphone) {
   return microphone->channelCount;
 }
 
-SoundData* lovrMicrophoneGetData(Microphone* microphone) {
+SoundData* lovrMicrophoneGetData(Microphone* microphone, size_t samples) {
   if (!microphone->isRecording) {
     return NULL;
   }
 
-  size_t samples = lovrMicrophoneGetSampleCount(microphone);
-  if (samples == 0) {
+  size_t maxSamples = lovrMicrophoneGetSampleCount(microphone);
+  if (maxSamples == 0) {
     return NULL;
+  }
+  lovrAssert(samples <= maxSamples, "Requested more audio data than is buffered by the microphone");
+  if (samples == 0) {
+    samples = maxSamples;
   }
 
   SoundData* soundData = lovrSoundDataCreate(samples, microphone->sampleRate, microphone->bitDepth, microphone->channelCount);

--- a/src/modules/audio/microphone.h
+++ b/src/modules/audio/microphone.h
@@ -11,7 +11,7 @@ Microphone* lovrMicrophoneCreate(const char* name, size_t samples, uint32_t samp
 void lovrMicrophoneDestroy(void* ref);
 uint32_t lovrMicrophoneGetBitDepth(Microphone* microphone);
 uint32_t lovrMicrophoneGetChannelCount(Microphone* microphone);
-struct SoundData* lovrMicrophoneGetData(Microphone* microphone);
+struct SoundData* lovrMicrophoneGetData(Microphone* microphone, size_t samples);
 const char* lovrMicrophoneGetName(Microphone* microphone);
 size_t lovrMicrophoneGetSampleCount(Microphone* microphone);
 uint32_t lovrMicrophoneGetSampleRate(Microphone* microphone);

--- a/src/modules/audio/source.c
+++ b/src/modules/audio/source.c
@@ -34,7 +34,7 @@ Source* lovrSourceCreateStatic(SoundData* soundData) {
   source->soundData = soundData;
   alGenSources(1, &source->id);
   alGenBuffers(1, source->buffers);
-  alBufferData(source->buffers[0], format, soundData->blob.data, (ALsizei) soundData->blob.size, soundData->sampleRate);
+  alBufferData(source->buffers[0], format, soundData->blob->data, (ALsizei) soundData->blob->size, soundData->sampleRate);
   alSourcei(source->id, AL_BUFFER, source->buffers[0]);
   lovrRetain(soundData);
   return source;

--- a/src/modules/data/audioStream.c
+++ b/src/modules/data/audioStream.c
@@ -114,7 +114,7 @@ bool lovrAudioStreamAppendRawBlob(AudioStream* stream, struct Blob* blob) {
 
 bool lovrAudioStreamAppendRawSound(AudioStream* stream, struct SoundData* sound) {
   lovrAssert(sound->channelCount == stream->channelCount && sound->bitDepth == stream->bitDepth && sound->sampleRate == stream->sampleRate, "SoundData and AudioStream formats must match");
-  return lovrAudioStreamAppendRawBlob(stream, &sound->blob);
+  return lovrAudioStreamAppendRawBlob(stream, sound->blob);
 }
 
 bool lovrAudioStreamIsRaw(AudioStream* stream) {

--- a/src/modules/data/rasterizer.c
+++ b/src/modules/data/rasterizer.c
@@ -132,7 +132,7 @@ void lovrRasterizerLoadGlyph(Rasterizer* rasterizer, uint32_t character, Glyph* 
   float ty = GLYPH_PADDING + (float) glyph->h - glyph->dy;
   msShapeNormalize(shape);
   msEdgeColoringSimple(shape, 3., 0);
-  msGenerateMSDF(glyph->data->blob.data, glyph->tw, glyph->th, shape, 4.f, 1.f, 1.f, tx, ty);
+  msGenerateMSDF(glyph->data->blob->data, glyph->tw, glyph->th, shape, 4.f, 1.f, 1.f, tx, ty);
   msShapeDestroy(shape);
 }
 

--- a/src/modules/data/soundData.c
+++ b/src/modules/data/soundData.c
@@ -1,6 +1,7 @@
 #include "data/soundData.h"
 #include "data/audioStream.h"
 #include "core/util.h"
+#include "core/ref.h"
 #include "lib/stb/stb_vorbis.h"
 #include <limits.h>
 #include <stdlib.h>
@@ -11,9 +12,11 @@ SoundData* lovrSoundDataInit(SoundData* soundData, size_t samples, uint32_t samp
   soundData->sampleRate = sampleRate;
   soundData->bitDepth = bitDepth;
   soundData->channelCount = channelCount;
-  soundData->blob.size = samples * channelCount * (bitDepth / 8);
-  soundData->blob.data = calloc(1, soundData->blob.size);
-  lovrAssert(soundData->blob.data, "Out of memory");
+  size_t byteCount = samples * channelCount * (bitDepth / 8);
+  void *bytes = calloc(1, byteCount);
+  lovrAssert(bytes != NULL, "Out of memory");
+  soundData->blob = lovrBlobCreate(bytes, byteCount, "SoundData basic");
+
   return soundData;
 }
 
@@ -22,15 +25,16 @@ SoundData* lovrSoundDataInitFromAudioStream(SoundData* soundData, AudioStream* a
   soundData->sampleRate = audioStream->sampleRate;
   soundData->bitDepth = audioStream->bitDepth;
   soundData->channelCount = audioStream->channelCount;
-  soundData->blob.size = audioStream->samples * audioStream->channelCount * (audioStream->bitDepth / 8);
-  soundData->blob.data = calloc(1, soundData->blob.size);
-  lovrAssert(soundData->blob.data, "Out of memory");
+  size_t byteCount = audioStream->samples * audioStream->channelCount * (audioStream->bitDepth / 8);
+  void* bytes = calloc(1, byteCount);
+  lovrAssert(bytes != NULL, "Out of memory");
+  soundData->blob = lovrBlobCreate(bytes, byteCount, "SoundData from AudioStream");
 
   size_t samples;
-  int16_t* buffer = soundData->blob.data;
+  int16_t* buffer = soundData->blob->data;
   size_t offset = 0;
   lovrAudioStreamRewind(audioStream);
-  while ((samples = lovrAudioStreamDecode(audioStream, buffer + offset, soundData->blob.size - (offset * sizeof(int16_t)))) != 0) {
+  while ((samples = lovrAudioStreamDecode(audioStream, buffer + offset, soundData->blob->size - (offset * sizeof(int16_t)))) != 0) {
     offset += samples;
   }
 
@@ -40,31 +44,33 @@ SoundData* lovrSoundDataInitFromAudioStream(SoundData* soundData, AudioStream* a
 SoundData* lovrSoundDataInitFromBlob(SoundData* soundData, Blob* blob) {
   int sampleRate, channels;
   soundData->bitDepth = 16;
-  soundData->samples = stb_vorbis_decode_memory(blob->data, (int) blob->size, &channels, &sampleRate, (int16_t**) &soundData->blob.data);
+  soundData->blob = lovrAlloc(Blob);
+  soundData->samples = stb_vorbis_decode_memory(blob->data, (int) blob->size, &channels, &sampleRate, (int16_t**) &soundData->blob->data);
   soundData->sampleRate = sampleRate;
   soundData->channelCount = channels;
-  soundData->blob.size = soundData->samples * soundData->channelCount * (soundData->bitDepth / 8);
+  soundData->blob->size = soundData->samples * soundData->channelCount * (soundData->bitDepth / 8);
   return soundData;
 }
 
 float lovrSoundDataGetSample(SoundData* soundData, size_t index) {
-  lovrAssert(index < soundData->blob.size / (soundData->bitDepth / 8), "Sample index out of range");
+  lovrAssert(index < soundData->blob->size / (soundData->bitDepth / 8), "Sample index out of range");
   switch (soundData->bitDepth) {
-    case 8: return ((int8_t*) soundData->blob.data)[index] / (float) CHAR_MAX;
-    case 16: return ((int16_t*) soundData->blob.data)[index] / (float) SHRT_MAX;
+    case 8: return ((int8_t*) soundData->blob->data)[index] / (float) CHAR_MAX;
+    case 16: return ((int16_t*) soundData->blob->data)[index] / (float) SHRT_MAX;
     default: lovrThrow("Unsupported SoundData bit depth %d\n", soundData->bitDepth); return 0;
   }
 }
 
 void lovrSoundDataSetSample(SoundData* soundData, size_t index, float value) {
-  lovrAssert(index < soundData->blob.size / (soundData->bitDepth / 8), "Sample index out of range");
+  lovrAssert(index < soundData->blob->size / (soundData->bitDepth / 8), "Sample index out of range");
   switch (soundData->bitDepth) {
-    case 8: ((int8_t*) soundData->blob.data)[index] = value * CHAR_MAX; break;
-    case 16: ((int16_t*) soundData->blob.data)[index] = value * SHRT_MAX; break;
+    case 8: ((int8_t*) soundData->blob->data)[index] = value * CHAR_MAX; break;
+    case 16: ((int16_t*) soundData->blob->data)[index] = value * SHRT_MAX; break;
     default: lovrThrow("Unsupported SoundData bit depth %d\n", soundData->bitDepth); break;
   }
 }
 
 void lovrSoundDataDestroy(void* ref) {
-  lovrBlobDestroy(ref);
+  SoundData* sd = (SoundData*)ref;
+  lovrRelease(Blob, sd->blob);
 }

--- a/src/modules/data/soundData.h
+++ b/src/modules/data/soundData.h
@@ -6,7 +6,7 @@
 struct AudioStream;
 
 typedef struct SoundData {
-  Blob blob;
+  Blob *blob;
   uint32_t channelCount;
   uint32_t sampleRate;
   size_t samples;

--- a/src/modules/data/textureData.h
+++ b/src/modules/data/textureData.h
@@ -48,7 +48,7 @@ typedef struct {
 } Mipmap;
 
 typedef struct TextureData {
-  Blob blob;
+  Blob *blob;
   uint32_t width;
   uint32_t height;
   Blob* source;

--- a/src/modules/graphics/opengl.c
+++ b/src/modules/graphics/opengl.c
@@ -1559,17 +1559,17 @@ void lovrTextureReplacePixels(Texture* texture, TextureData* textureData, uint32
       }
     }
   } else {
-    lovrAssert(textureData->blob.data, "Trying to replace Texture pixels with empty pixel data");
+    lovrAssert(textureData->blob->data, "Trying to replace Texture pixels with empty pixel data");
     GLenum glType = convertTextureFormatType(textureData->format);
 
     switch (texture->type) {
       case TEXTURE_2D:
       case TEXTURE_CUBE:
-        glTexSubImage2D(binding, mipmap, x, y, width, height, glFormat, glType, textureData->blob.data);
+        glTexSubImage2D(binding, mipmap, x, y, width, height, glFormat, glType, textureData->blob->data);
         break;
       case TEXTURE_ARRAY:
       case TEXTURE_VOLUME:
-        glTexSubImage3D(binding, mipmap, x, y, slice, width, height, 1, glFormat, glType, textureData->blob.data);
+        glTexSubImage3D(binding, mipmap, x, y, slice, width, height, 1, glFormat, glType, textureData->blob->data);
         break;
     }
 
@@ -1782,7 +1782,7 @@ TextureData* lovrCanvasNewTextureData(Canvas* canvas, uint32_t index) {
   }
 
   TextureData* textureData = lovrTextureDataCreate(canvas->width, canvas->height, 0x0, FORMAT_RGBA);
-  glReadPixels(0, 0, canvas->width, canvas->height, GL_RGBA, GL_UNSIGNED_BYTE, textureData->blob.data);
+  glReadPixels(0, 0, canvas->width, canvas->height, GL_RGBA, GL_UNSIGNED_BYTE, textureData->blob->data);
 
   if (index != 0) {
     glReadBuffer(0);

--- a/src/modules/headset/openvr.c
+++ b/src/modules/headset/openvr.c
@@ -426,7 +426,7 @@ static ModelData* openvr_newModelData(Device device) {
 
   RenderModel_TextureMap_t* vrTexture = state.deviceTextures[index];
   model->textures[0] = lovrTextureDataCreate(vrTexture->unWidth, vrTexture->unHeight, 0, FORMAT_RGBA);
-  memcpy(model->textures[0]->blob.data, vrTexture->rubTextureMapData, vrTexture->unWidth * vrTexture->unHeight * 4);
+  memcpy(model->textures[0]->blob->data, vrTexture->rubTextureMapData, vrTexture->unWidth * vrTexture->unHeight * 4);
 
   model->materials[0] = (ModelMaterial) {
     .colors[COLOR_DIFFUSE] = { 1.f, 1.f, 1.f, 1.f },


### PR DESCRIPTION
Just some small fixes that ease the handling of audio:

* `SoundData` gets a `Blob*` ivar instead of `Blob`. This means the blob can be accessed as a proper child object.
* In that vein, `SoundData` gets `SoundData:getBlob()`. This way, you can `getString` etc on the blob in the `SoundData`, and use the data with other APIs more easily
* Slightly related, `Microphone:getData()` gets a buffer size parameter. I was originally going to implement a ring buffer class, but I only need it to buffer microphone data before it's ready to be sent off to the network. Turns out OpenAL already has a ringbuffer internally, and by adding a parameter to say how much data you want to chop of NOW, we can utilize that ringbuffer downstream. This makes my code much easier.

The last one there is going to make it much easier to use `SoundDataPool` from the microphone class, once I implement it. That's my next step, to reduce the `SoundData` malloc churn.