### PR TITLE
Headset views;

### DIFF
--- a/src/api/l_headset.c
+++ b/src/api/l_headset.c
@@ -181,6 +181,44 @@ static int l_lovrHeadsetGetDisplayMask(lua_State* L) {
   return 1;
 }
 
+static int l_lovrHeadsetGetViewCount(lua_State* L) {
+  lua_pushinteger(L, lovrHeadsetDriver->getViewCount());
+  return 1;
+}
+
+static int l_lovrHeadsetGetViewPose(lua_State* L) {
+  float position[4], orientation[4];
+  uint32_t view = luaL_checkinteger(L, 1) - 1;
+  if (!lovrHeadsetDriver->getViewPose(view, position, orientation)) {
+    lua_pushnil(L);
+    return 1;
+  }
+  float angle, ax, ay, az;
+  quat_getAngleAxis(orientation, &angle, &ax, &ay, &az);
+  lua_pushnumber(L, position[0]);
+  lua_pushnumber(L, position[1]);
+  lua_pushnumber(L, position[2]);
+  lua_pushnumber(L, angle);
+  lua_pushnumber(L, ax);
+  lua_pushnumber(L, ay);
+  lua_pushnumber(L, az);
+  return 7;
+}
+
+static int l_lovrHeadsetGetViewAngles(lua_State* L) {
+  float left, right, up, down;
+  uint32_t view = luaL_checkinteger(L, 1) - 1;
+  if (!lovrHeadsetDriver->getViewAngles(view, &left, &right, &up, &down)) {
+    lua_pushnil(L);
+    return 1;
+  }
+  lua_pushnumber(L, left);
+  lua_pushnumber(L, right);
+  lua_pushnumber(L, up);
+  lua_pushnumber(L, down);
+  return 4;
+}
+
 static int l_lovrHeadsetGetClipDistance(lua_State* L) {
   float clipNear, clipFar;
   lovrHeadsetDriver->getClipDistance(&clipNear, &clipFar);
@@ -549,6 +587,9 @@ static const luaL_Reg lovrHeadset[] = {
   { "getDisplayDimensions", l_lovrHeadsetGetDisplayDimensions },
   { "getDisplayFrequency", l_lovrHeadsetGetDisplayFrequency },
   { "getDisplayMask", l_lovrHeadsetGetDisplayMask },
+  { "getViewCount", l_lovrHeadsetGetViewCount },
+  { "getViewPose", l_lovrHeadsetGetViewPose },
+  { "getViewAngles", l_lovrHeadsetGetViewAngles },
   { "getClipDistance", l_lovrHeadsetGetClipDistance },
   { "setClipDistance", l_lovrHeadsetSetClipDistance },
   { "getBoundsWidth", l_lovrHeadsetGetBoundsWidth },

--- a/src/core/maf.h
+++ b/src/core/maf.h
@@ -576,6 +576,10 @@ MAF mat4 mat4_fov(mat4 m, float left, float right, float up, float down, float c
   return m;
 }
 
+MAF void mat4_getFov(mat4 m, float* left, float* right, float* up, float* down) {
+  // TODO
+}
+
 MAF mat4 mat4_lookAt(mat4 m, vec3 from, vec3 to, vec3 up) {
   float x[4];
   float y[4];

--- a/src/core/maf.h
+++ b/src/core/maf.h
@@ -576,10 +576,6 @@ MAF mat4 mat4_fov(mat4 m, float left, float right, float up, float down, float c
   return m;
 }
 
-MAF void mat4_getFov(mat4 m, float* left, float* right, float* up, float* down) {
-  // TODO
-}
-
 MAF mat4 mat4_lookAt(mat4 m, vec3 from, vec3 to, vec3 up) {
   float x[4];
   float y[4];

--- a/src/modules/headset/desktop.c
+++ b/src/modules/headset/desktop.c
@@ -30,12 +30,14 @@ static struct {
   float clipFar;
   float pitch;
   float yaw;
+  float fov;
 } state;
 
 static bool desktop_init(float offset, uint32_t msaa) {
   state.offset = offset;
   state.clipNear = .1f;
   state.clipFar = 100.f;
+  state.fov = 67.f * (float) M_PI / 180.f;
 
   if (!state.initialized) {
     mat4_identity(state.headTransform);
@@ -76,6 +78,28 @@ static void desktop_getDisplayDimensions(uint32_t* width, uint32_t* height) {
 static const float* desktop_getDisplayMask(uint32_t* count) {
   *count = 0;
   return NULL;
+}
+
+static uint32_t desktop_getViewCount() {
+  return 2;
+}
+
+static bool desktop_getViewPose(uint32_t view, float* position, float* orientation) {
+  vec3_init(position, state.position);
+  quat_fromMat4(orientation, state.headTransform);
+  return view < 2;
+}
+
+static bool desktop_getViewAngles(uint32_t view, float* left, float* right, float* up, float* down) {
+  float aspect;
+  uint32_t width, height;
+  desktop_getDisplayDimensions(&width, &height);
+  aspect = (float) width / 2.f / height;
+  *left = state.fov * aspect;
+  *right = state.fov * aspect;
+  *up = state.fov;
+  *down = state.fov;
+  return view < 2;
 }
 
 static void desktop_getClipDistance(float* clipNear, float* clipFar) {
@@ -148,10 +172,10 @@ static ModelData* desktop_newModelData(Device device) {
 }
 
 static void desktop_renderTo(void (*callback)(void*), void* userdata) {
-  uint32_t width, height;
-  desktop_getDisplayDimensions(&width, &height);
+  float left, right, up, down;
+  desktop_getViewAngles(0, &left, &right, &up, &down);
   Camera camera = { .canvas = NULL, .viewMatrix = { MAT4_IDENTITY }, .stereo = true };
-  mat4_perspective(camera.projection[0], state.clipNear, state.clipFar, 67.f * (float) M_PI / 180.f, (float) width / 2.f / height);
+  mat4_fov(camera.projection[0], state.clipNear, state.clipFar, left, right, up, down);
   mat4_multiply(camera.viewMatrix[0], state.headTransform);
   mat4_invert(camera.viewMatrix[0]);
   mat4_set(camera.projection[1], camera.projection[0]);
@@ -255,6 +279,9 @@ HeadsetInterface lovrHeadsetDesktopDriver = {
   .getDisplayTime = desktop_getDisplayTime,
   .getDisplayDimensions = desktop_getDisplayDimensions,
   .getDisplayMask = desktop_getDisplayMask,
+  .getViewCount = desktop_getViewCount,
+  .getViewPose = desktop_getViewPose,
+  .getViewAngles = desktop_getViewAngles,
   .getClipDistance = desktop_getClipDistance,
   .setClipDistance = desktop_setClipDistance,
   .getBoundsDimensions = desktop_getBoundsDimensions,

--- a/src/modules/headset/headset.h
+++ b/src/modules/headset/headset.h
@@ -51,6 +51,12 @@ typedef enum {
   MAX_AXES
 } DeviceAxis;
 
+// Notes:
+// - getDisplayFrequency may return 0.f if the information is unavailable.
+// - For isDown, changed can be set to false if change information is unavailable or inconvenient.
+// - getAxis may write 4 floats to the output value.  The expected number is a constant (see axisCounts in l_headset).
+// - In general, most input results should be kept constant between calls to update.
+
 typedef struct HeadsetInterface {
   struct HeadsetInterface* next;
   HeadsetDriver driverType;
@@ -62,6 +68,9 @@ typedef struct HeadsetInterface {
   float (*getDisplayFrequency)(void);
   const float* (*getDisplayMask)(uint32_t* count);
   double (*getDisplayTime)(void);
+  uint32_t (*getViewCount)(void);
+  bool (*getViewPose)(uint32_t view, float* position, float* orientation);
+  bool (*getViewAngles)(uint32_t view, float* left, float* right, float* up, float* down);
   void (*getClipDistance)(float* clipNear, float* clipFar);
   void (*setClipDistance)(float clipNear, float clipFar);
   void (*getBoundsDimensions)(float* width, float* depth);

--- a/src/modules/headset/oculus.c
+++ b/src/modules/headset/oculus.c
@@ -12,10 +12,12 @@
 #include <OVR_CAPI_GL.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <math.h>
 
 static struct {
   bool needRefreshTracking;
   bool needRefreshButtons;
+  ovrHmdDesc desc;
   ovrSession session;
   ovrGraphicsLuid luid;
   float clipNear;
@@ -85,6 +87,8 @@ static bool oculus_init(float offset, uint32_t msaa) {
     return false;
   }
 
+  state.desc = ovr_GetHmdDesc(state.session);
+
   state.needRefreshTracking = true;
   state.needRefreshButtons = true;
   state.clipNear = .1f;
@@ -119,8 +123,7 @@ static void oculus_destroy(void) {
 }
 
 static bool oculus_getName(char* name, size_t length) {
-  ovrHmdDesc desc = ovr_GetHmdDesc(state.session);
-  strncpy(name, desc.ProductName, length - 1);
+  strncpy(name, state.desc.ProductName, length - 1);
   name[length - 1] = '\0';
   return true;
 }
@@ -130,9 +133,7 @@ static HeadsetOrigin oculus_getOriginType(void) {
 }
 
 static void oculus_getDisplayDimensions(uint32_t* width, uint32_t* height) {
-  ovrHmdDesc desc = ovr_GetHmdDesc(state.session);
-  ovrSizei size = ovr_GetFovTextureSize(state.session, ovrEye_Left, desc.DefaultEyeFov[0], 1.0f);
-
+  ovrSizei size = ovr_GetFovTextureSize(state.session, ovrEye_Left, state.desc.DefaultEyeFov[0], 1.0f);
   *width = size.w;
   *height = size.h;
 }
@@ -144,6 +145,44 @@ static const float* oculus_getDisplayMask(uint32_t* count) {
 
 static double oculus_getDisplayTime(void) {
   return ovr_GetPredictedDisplayTime(state.session, 0);
+}
+
+static void getEyePoses(ovrPosef poses[2], double* sensorSampleTime) {
+  ovrEyeRenderDesc eyeRenderDesc[2] = {
+    ovr_GetRenderDesc(state.session, ovrEye_Left, state.desc.DefaultEyeFov[0]),
+    ovr_GetRenderDesc(state.session, ovrEye_Right, state.desc.DefaultEyeFov[1])
+  };
+
+  ovrPosef offsets[2] = {
+    eyeRenderDesc[0].HmdToEyePose,
+    eyeRenderDesc[1].HmdToEyePose
+  };
+
+  ovr_GetEyePoses(state.session, 0, ovrFalse, offsets, poses, sensorSampleTime);
+}
+
+static uint32_t oculus_getViewCount(void) {
+  return 2;
+}
+
+static bool oculus_getViewPose(uint32_t view, float* position, float* orientation) {
+  if (view > 1) return false;
+  ovrPosef poses[2];
+  getEyePoses(poses, NULL);
+  ovrPosef* pose = &poses[view];
+  vec3_set(position, pose->Position.x, pose->Position.y, pose->Position.z);
+  quat_set(orientation, pose->Orientation.x, pose->Orientation.y, pose->Orientation.z, pose->Orientation.w);
+  return true;
+}
+
+static bool oculus_getViewAngles(uint32_t view, float* left, float* right, float* up, float* down) {
+  if (view > 1) return false;
+  ovrFovPort* fov = &state.desc.DefaultEyeFov[view];
+  *left = atanf(fov->LeftTan);
+  *right = atanf(fov->RightTan);
+  *up = atanf(fov->UpTan);
+  *down = atanf(fov->DownTan);
+  return true;
 }
 
 static void oculus_getClipDistance(float* clipNear, float* clipFar) {
@@ -275,9 +314,8 @@ static ModelData* oculus_newModelData(Device device) {
 }
 
 static void oculus_renderTo(void (*callback)(void*), void* userdata) {
-  ovrHmdDesc desc = ovr_GetHmdDesc(state.session);
   if (!state.canvas) {
-    state.size = ovr_GetFovTextureSize(state.session, ovrEye_Left, desc.DefaultEyeFov[ovrEye_Left], 1.0f);
+    state.size = ovr_GetFovTextureSize(state.session, ovrEye_Left, state.desc.DefaultEyeFov[ovrEye_Left], 1.0f);
 
     ovrTextureSwapChainDesc swdesc = {
       .Type = ovrTexture_2D,
@@ -305,16 +343,9 @@ static void oculus_renderTo(void (*callback)(void*), void* userdata) {
     lovrPlatformSetSwapInterval(0);
   }
 
-  ovrEyeRenderDesc eyeRenderDesc[2];
-  eyeRenderDesc[0] = ovr_GetRenderDesc(state.session, ovrEye_Left, desc.DefaultEyeFov[0]);
-  eyeRenderDesc[1] = ovr_GetRenderDesc(state.session, ovrEye_Right, desc.DefaultEyeFov[1]);
-  ovrPosef HmdToEyeOffset[2] = {
-    eyeRenderDesc[0].HmdToEyePose,
-    eyeRenderDesc[1].HmdToEyePose
-  };
   ovrPosef EyeRenderPose[2];
   double sensorSampleTime;
-  ovr_GetEyePoses(state.session, 0, ovrTrue, HmdToEyeOffset, EyeRenderPose, &sensorSampleTime);
+  getEyePoses(EyeRenderPose, &sensorSampleTime);
 
   Camera camera = { .canvas = state.canvas };
 
@@ -328,7 +359,7 @@ static void oculus_renderTo(void (*callback)(void*), void* userdata) {
     float pos[] = {
       EyeRenderPose[eye].Position.x,
       EyeRenderPose[eye].Position.y,
-      EyeRenderPose[eye].Position.z,
+      EyeRenderPose[eye].Position.z
     };
     mat4 transform = camera.viewMatrix[eye];
     mat4_identity(transform);
@@ -337,7 +368,7 @@ static void oculus_renderTo(void (*callback)(void*), void* userdata) {
     transform[13] = -(transform[1] * pos[0] + transform[5] * pos[1] + transform[9] * pos[2]);
     transform[14] = -(transform[2] * pos[0] + transform[6] * pos[1] + transform[10] * pos[2]);
 
-    ovrMatrix4f projection = ovrMatrix4f_Projection(desc.DefaultEyeFov[eye], state.clipNear, state.clipFar, ovrProjection_ClipRangeOpenGL);
+    ovrMatrix4f projection = ovrMatrix4f_Projection(state.desc.DefaultEyeFov[eye], state.clipNear, state.clipFar, ovrProjection_ClipRangeOpenGL);
     mat4_fromMat44(camera.projection[eye], projection.M);
   }
 
@@ -365,7 +396,7 @@ static void oculus_renderTo(void (*callback)(void*), void* userdata) {
     vp.Size.w = state.size.w;
     vp.Size.h = state.size.h;
     ld.Viewport[eye] = vp;
-    ld.Fov[eye] = desc.DefaultEyeFov[eye];
+    ld.Fov[eye] = state.desc.DefaultEyeFov[eye];
     ld.RenderPose[eye] = EyeRenderPose[eye];
     ld.SensorSampleTime = sensorSampleTime;
   }
@@ -404,6 +435,9 @@ HeadsetInterface lovrHeadsetOculusDriver = {
   .getDisplayDimensions = oculus_getDisplayDimensions,
   .getDisplayMask = oculus_getDisplayMask,
   .getDisplayTime = oculus_getDisplayTime,
+  .getViewCount = oculus_getViewCount,
+  .getViewPose = oculus_getViewPose,
+  .getViewAngles = oculus_getViewAngles,
   .getClipDistance = oculus_getClipDistance,
   .setClipDistance = oculus_setClipDistance,
   .getBoundsDimensions = oculus_getBoundsDimensions,

--- a/src/modules/headset/oculus_mobile.c
+++ b/src/modules/headset/oculus_mobile.c
@@ -77,6 +77,26 @@ static const float* vrapi_getDisplayMask(uint32_t* count) {
   return NULL;
 }
 
+static uint32_t vrapi_getViewCount(void) {
+  return 2;
+}
+
+static void vrapi_getViewPose(uint32_t view, float* position, float* orientation) {
+  if (view > 1) return false;
+  float transform[16];
+  mat4_init(transform, bridgeLovrMobileData.updateData.eyeViewMatrix[view]);
+  mat4_invert(transform); // :(
+  mat4_getPosition(transform, position);
+  mat4_getOrientation(transform, orientation);
+  return true;
+}
+
+static void vrapi_getViewAngles(uint32_t view, float* left, float* right, float* up, float* down) {
+  if (view > 1) return false;
+  mat4_getFov(bridgeLovrMobileData.updateData.projectionMatrix[view], left, right, up, down);
+  return true;
+}
+
 static void vrapi_getClipDistance(float* clipNear, float* clipFar) {
   // TODO
 }
@@ -264,6 +284,9 @@ HeadsetInterface lovrHeadsetOculusMobileDriver = {
   .getDisplayTime = vrapi_getDisplayTime,
   .getDisplayDimensions = vrapi_getDisplayDimensions,
   .getDisplayMask = vrapi_getDisplayMask,
+  .getViewCount = vrapi_getViewCount,
+  .getViewPose = vrapi_getViewPose,
+  .getViewAngles = vrapi_getViewAngles,
   .getClipDistance = vrapi_getClipDistance,
   .setClipDistance = vrapi_setClipDistance,
   .getBoundsDimensions = vrapi_getBoundsDimensions,

--- a/src/modules/headset/oculus_mobile.c
+++ b/src/modules/headset/oculus_mobile.c
@@ -92,9 +92,7 @@ static void vrapi_getViewPose(uint32_t view, float* position, float* orientation
 }
 
 static void vrapi_getViewAngles(uint32_t view, float* left, float* right, float* up, float* down) {
-  if (view > 1) return false;
-  mat4_getFov(bridgeLovrMobileData.updateData.projectionMatrix[view], left, right, up, down);
-  return true;
+  return false; // TODO decompose projection matrix into fov angles
 }
 
 static void vrapi_getClipDistance(float* clipNear, float* clipFar) {

--- a/src/modules/headset/webvr.c
+++ b/src/modules/headset/webvr.c
@@ -1,6 +1,7 @@
 #include "headset/headset.h"
 #include "graphics/graphics.h"
 #include <stdbool.h>
+#include <stdint.h>
 
 // Provided by resources/webvr.js
 extern bool webvr_init(float offset, uint32_t msaa);
@@ -10,6 +11,9 @@ extern HeadsetOrigin webvr_getOriginType(void);
 extern double webvr_getDisplayTime(void);
 extern void webvr_getDisplayDimensions(uint32_t* width, uint32_t* height);
 extern const float* webvr_getDisplayMask(uint32_t* count);
+extern uint32_t webvr_getViewCount(void);
+extern bool webvr_getViewPose(uint32_t view, float* position, float* orientation);
+extern bool webvr_getViewAngles(uint32_t view, float* left, float* right, float* up, float* down);
 extern void webvr_getClipDistance(float* near, float* far);
 extern void webvr_setClipDistance(float near, float far);
 extern void webvr_getBoundsDimensions(float* width, float* depth);
@@ -53,6 +57,9 @@ HeadsetInterface lovrHeadsetWebVRDriver = {
   .getDisplayTime = webvr_getDisplayTime,
   .getDisplayDimensions = webvr_getDisplayDimensions,
   .getDisplayMask = webvr_getDisplayMask,
+  .getViewCount = webvr_getViewCount,
+  .getViewPose = webvr_getViewPose,
+  .getViewAngles = webvr_getViewAngles,
   .getClipDistance = webvr_getClipDistance,
   .setClipDistance = webvr_setClipDistance,
   .getBoundsDimensions = webvr_getBoundsDimensions,

--- a/src/resources/webvr.js
+++ b/src/resources/webvr.js
@@ -140,6 +140,18 @@ var LibraryLOVR = {
     return 0;
   },
 
+  webvr_getViewCount: function() {
+    return 2;
+  },
+
+  webvr_getViewPose: function(view, position, orientation) {
+    return false; // TODO
+  },
+
+  webvr_getViewAngles: function(view, left, right, up, down) {
+    return false; // TODO
+  },
+
   webvr_getClipDistance: function(clipNear, clipFar) {
     HEAPF32[clipNear >> 2] = webvr.display.depthNear;
     HEAPF32[clipFar >> 2] = webvr.display.depthFar;


### PR DESCRIPTION
See #198 

- `lovr.headset.getViewCount`
- `lovr.headset.getViewPose`
- `lovr.headset.getViewAngles`

Todo

- [x] Finalize API:
  - Internal API: might be better off as `getViews(views[2], &count)`, for many reasons
  - External API: nil vs. errors, naming

Maybe

- [ ] Write `mat4_getFov` so we can extract fovs from projection matrices (oculus_mobile)
- [ ] Consider exposing `mat4_getFov` as `left, right, up, down = Mat4:fov(nil)`
- [ ] Consider making `mat4:fov` accept a `vec4` for the angles, so you can do `mat4:fov(vec4(lovr.headset.getViewAngles(i)), lovr.headset.getClipDistance())`.
- [ ] Consider exposing `getDisplayTime` and adding a timestamp as the second argument to the accessors, so you can get view/projection predictions for any timestamp.  Probably won't do this, at least right now.
- [ ] Change canvas/shader stereo flag to be a viewCount (but still support stereo and map to viewCount = 2, in a deprecated fashion).  This lets you create a Canvas for a headset render target based on the actual view count!
- [ ] Maybe WebVR but probably later
- [ ] Something else I'm forgetting