### PR TITLE
Use different compute #version with OpenGL ES

### DIFF
--- a/src/resources/shaders.c
+++ b/src/resources/shaders.c
@@ -125,9 +125,15 @@ const char* lovrShaderFragmentSuffix = ""
 "#endif \n"
 "}";
 
+#ifdef LOVR_GLES
+const char* lovrShaderComputePrefix = ""
+"#version 310 es \n"
+"#line 0 \n";
+#else
 const char* lovrShaderComputePrefix = ""
 "#version 430 \n"
 "#line 0 \n";
+#endif
 
 const char* lovrShaderComputeSuffix = ""
 "void main() { \n"


### PR DESCRIPTION
Yesterday I said:
> Also, I just tested out the compute shaders, works nicely on this end, thanks!

Turns out I spoke too soon, that was just the SSBOs working.

GLES doesn't like `#version 430` for compute, it wants `#version 310 es`. We can conditionally compile that!