### PR TITLE
oculus_mobile: Expose bounds dimensions;

### DIFF
--- a/src/modules/headset/oculus_mobile.c
+++ b/src/modules/headset/oculus_mobile.c
@@ -104,8 +104,8 @@ static void vrapi_setClipDistance(float clipNear, float clipFar) {
 }
 
 static void vrapi_getBoundsDimensions(float* width, float* depth) {
-  *width = 0.f;
-  *depth = 0.f;
+  *width = bridgeLovrMobileData.updateData.boundsWidth;
+  *depth = bridgeLovrMobileData.updateData.boundsDepth;
 }
 
 static const float* vrapi_getBoundsGeometry(uint32_t* count) {

--- a/src/modules/headset/oculus_mobile_bridge.h
+++ b/src/modules/headset/oculus_mobile_bridge.h
@@ -112,6 +112,9 @@ typedef struct {
   float eyeViewMatrix[2][16];
   float projectionMatrix[2][16];
 
+  float boundsWidth;
+  float boundsDepth;
+
   int controllerCount;
   BridgeLovrController controllers[BRIDGE_LOVR_CONTROLLERMAX];
 } BridgeLovrUpdateData;


### PR DESCRIPTION
Implements `lovr.headset.getBoundsDimensions` (and individual width/depth accessors) for oculus_mobile.