### PR TITLE
lovr.headset.getDevices (straw proposal, don't merge)

### DIFF
--- a/src/api/l_headset.c
+++ b/src/api/l_headset.c
@@ -502,6 +502,28 @@ static int l_lovrHeadsetGetHands(lua_State* L) {
   return 1;
 }
 
+static int l_lovrHeadsetGetDevices(lua_State* L) {
+  if (lua_istable(L, 1)) {
+    lua_settop(L, 1);
+  } else {
+    lua_newtable(L);
+  }
+
+  int count = 0;
+  float position[4], orientation[4];
+  for (size_t i = 0; i < MAX_DEVICES; i++) {
+    FOREACH_TRACKING_DRIVER(driver) {
+      if (driver->getPose(i, position, orientation)) {
+        lua_pushstring(L, Devices[i]);
+        lua_rawseti(L, -2, ++count);
+      }
+    }
+  }
+  lua_pushnil(L);
+  lua_rawseti(L, -2, ++count);
+  return 1;
+}
+
 static const luaL_Reg lovrHeadset[] = {
   { "getDriver", l_lovrHeadsetGetDriver },
   { "getName", l_lovrHeadsetGetName },
@@ -531,6 +553,7 @@ static const luaL_Reg lovrHeadset[] = {
   { "update", l_lovrHeadsetUpdate },
   { "getMirrorTexture", l_lovrHeadsetGetMirrorTexture },
   { "getHands", l_lovrHeadsetGetHands },
+  { "getDevices", l_lovrHeadsetGetDevices },
   { NULL, NULL }
 };
 


### PR DESCRIPTION
This is something I did in my private branch; I'm PRing it as an example to propose something for the still-incoming isTracked() changes.

Whereas getHands() only returns hand/left and hand/right, getDevices() returns all devices Lovr knows about which could respond to any of getPose, isTracked, isDown or getAxis. This includes the head. It is useful for hypothetical controller support.

I would like to propose a version of this function go into the isTracked() change. I don't know the new isTracked() signature, but this function would have a similar signature. For example if `isTracked("responds","isDown","b")` is yes for an Oculus Touch controller, then `getDevices("responds","isDown","b")` would return all devices that are capable of responding to isDown("b"). This would make it easier to write simple programs that are agnostic to what kinds of devices they communicate with, as long as those devices fit how they will be using the device.