### PR TITLE
lovr.headset.getStatus; lovr.headset.glob;

### DIFF
--- a/src/modules/headset/headset.h
+++ b/src/modules/headset/headset.h
@@ -53,6 +53,22 @@ typedef enum {
   MAX_AXES
 } DeviceAxis;
 
+// TODO separate pose and velocity into linear/angular components, maybe keep composite ones though
+typedef enum {
+  TRACKING_POSE,
+  TRACKING_VELOCITY,
+  TRACKING_BUTTON,
+  TRACKING_TOUCH,
+  TRACKING_AXIS,
+  TRACKING_SKELETON
+} TrackingType;
+
+typedef enum {
+  STATUS_UNAVAILABLE,
+  STATUS_ESTIMATED,
+  STATUS_TRACKED
+} TrackingStatus;
+
 // Notes:
 // - getDisplayFrequency may return 0.f if the information is unavailable.
 // - For isDown, changed can be set to false if change information is unavailable or inconvenient.


### PR DESCRIPTION
- rm the Device variant of `lovr.headset.getDriver`.  Now it only takes zero arguments and always returns the display driver.
- Rename `lovr.headset.isTracked` to `lovr.headset.getStatus`.
- `lovr.headset.getStatus` takes a Device and an optional TrackingType (`pose`, `velocity`, `button`, `touch`, `axis`, `skeleton`, defaults to pose).
- It returns a TrackingStatus (`unavailable`, `estimated`, `tracked`), and a driver.
- Add `lovr.headset.glob` as a more general version of `lovr.headset.getHands`.  It is equivalent to the following Lua code:

```lua
function lovr.headset.glob(filter, ...)
  local devices = { 'head', 'hand/left', 'hand/right' } -- (i.e. all the devices)
  local result = {}
  for i, device in ipairs(devices) do
    local matched = not filter or device:match(filter)
    local available = ... == nil or lovr.headset.getStatus(device, ...) ~= 'unavailable'
    if matched and available then
      result[#result + 1] = device
    end
  end
  return result
end
-- lovr.headset.glob() --> all devices
-- lovr.headset.glob('hand') --> all hands
-- lovr.headset.glob('hand/', 'pose') --> all hands with a pose
-- lovr.headset.glob(nil, 'button', trigger') --> all devices with a trigger
```

- `lovr.headset.getHands` is sorta unofficially deprecated now, since if `lovr.headset.glob` turns out to be good you can just do `lovr.headset.glob('hand', 'pose')` to get the same behavior.
  - EDIT: It might still be nice to have getHands because you can't do `lovr.headset.glob('hand')` once there are more hand sub-devices like pointer, palm, fingers, etc., it would need to be `lovr.headset.glob('hand/%w+$')`

This enables a lot of cool device querying but it still sucks right now:

- We don't separate pose and velocity into linear and angular components, so we can't detect 3DOF vs. 6DOF.  This sort of thing is important for eye tracking.  I figure we can add the separated components later (it complicates the internal getPose interface) and keep the fused "pose" / "velocity" enums to be a boolean and/or of the other two.
- We still can't detect connectedness, which creates awkward situations and is kinda a bummer.  Connectedness is complicated, and I'm not sure it's even possible in OpenVR and OpenXR anymore.  It needs more thought, we don't want those drivers to always report connected/disconnected, maybe pose could be used as a proxy but that breaks gamepads too so, idk.
- There is a weird conflation between "unknown/disconnected" and "not tracked".  Ideally these are separate concepts, but separating them right now would require a lot of work.  I think it would be a good change to make so we can do better status queries.
- Related: It would be good to have a concept of "device capabilities" instead of always making decisions based on instantaneous tracking status.