### PR TITLE
Fix ref.h in recent MSVC when compiled as C++

### DIFF
--- a/src/core/ref.h
+++ b/src/core/ref.h
@@ -17,12 +17,18 @@ static inline uint32_t ref_dec(Ref* ref) { return --*ref; }
 
 #elif defined(_MSC_VER)
 
+#ifdef __cplusplus
+#define _LOVR_REF_H_CPP_CAST (volatile long *)
+#else
+#define _LOVR_REF_H_CPP_CAST
+#endif
+
 // MSVC atomics
 
 #include <intrin.h>
 typedef uint32_t Ref;
-static inline uint32_t ref_inc(Ref* ref) { return _InterlockedIncrement(ref); }
-static inline uint32_t ref_dec(Ref* ref) { return _InterlockedDecrement(ref); }
+static inline uint32_t ref_inc(Ref* ref) { return _InterlockedIncrement(_LOVR_REF_H_CPP_CAST ref); }
+static inline uint32_t ref_dec(Ref* ref) { return _InterlockedDecrement(_LOVR_REF_H_CPP_CAST ref); }
 
 #elif (defined(__GNUC_MINOR__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7))) \
    || (__has_builtin(__atomic_add_fetch) && __has_builtin(__atomic_sub_fetch))


### PR DESCRIPTION
Okay. This… one's… weird.

We pass ref directly to _InterlockedIncrement on Windows. However the argument to _InterlockedIncrement is declared volatile and Ref is not declared volatile. Apparently this is fine in C, and it is fine in C++ in both Clang and MSVC 2017. However if you compile Lovr in MSVC 2019, and you have added a .cpp file which #includes ref.h (which is something I have done in my private fork), this will fail. This patch adds a cast which only activates when ref.h is included into a C++ file.

I do not know if this is the best way to do this. It would be better to add a compile flag that tells MSVC 2019 it is okay to pass a `long *` to a `volatile long *` without a cast. But I don't know how to do that.