### PR TITLE
Instead of showing post-distortion in Oculus mirror, show the left eye (no stereo)

### DIFF
--- a/src/modules/headset/oculus.c
+++ b/src/modules/headset/oculus.c
@@ -333,7 +333,7 @@ static void oculus_renderTo(void (*callback)(void*), void* userdata) {
       .Width = lovrGraphicsGetWidth(),
       .Height = lovrGraphicsGetHeight(),
       .Format = OVR_FORMAT_R8G8B8A8_UNORM_SRGB,
-      .MirrorOptions = ovrMirrorOption_PostDistortion
+      .MirrorOptions = ovrMirrorOption_LeftEyeOnly
     };
     lovrAssert(OVR_SUCCESS(ovr_CreateMirrorTextureWithOptionsGL(state.session, &mdesc, &state.mirror)), "Unable to create mirror texture");
 


### PR DESCRIPTION
Combine this with an upgrade to Oculus SDK 1.43 (which fixes the frame 3 glitch) and https://github.com/bjornbytes/lovr/pull/128 , and the Oculus mirror is now very nice. Now if only we could do something about rendering when the headset comes off…

I'm not sure if we should set this to LeftEye (which I did) or to 0 (would show the eyes "flat" but side-by-side, like OpenVR). Maybe it would make sense to have a conf.lua value at some point indicating whether people would rather have the mirror be stereo or mono.