### PR TITLE
Add lovr.graphics.getTransforms(kind) and lovr.graphics.getViewports()

### DIFF
--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -143,6 +143,14 @@ StringEntry MaterialTextures[] = {
   { 0 }
 };
 
+StringEntry MatrixRequests[] = {
+  [MATRIX_REQUEST_MODEL] = ENTRY("model"),
+  [MATRIX_REQUEST_VIEW] = ENTRY("view"),
+  [MATRIX_REQUEST_PROJECTION] = ENTRY("projection"),
+  [MATRIX_REQUEST_MVP] = ENTRY("mvp"),
+  { 0 }
+};
+
 StringEntry ShaderTypes[] = {
   [SHADER_GRAPHICS] = ENTRY("graphics"),
   [SHADER_COMPUTE] = ENTRY("compute"),
@@ -676,6 +684,35 @@ static int l_lovrGraphicsSetStencilTest(lua_State* L) {
     lovrGraphicsSetStencilTest(mode, value);
   }
   return 0;
+}
+
+static int l_lovrGraphicsGetTransforms(lua_State* L) {
+  MatrixRequest request = luax_checkenum(L, 1, MatrixRequests, "mvp", "MatrixRequest");
+  float transforms[32];
+  int count;
+  lovrGraphicsMatrixGetTransform(transforms, &count, request);
+  for(int tidx = 0; tidx < count; tidx++) {
+    lua_createtable(L, 16, 0);
+    for(int idx = 0; idx < 16; idx++) {
+      lua_pushnumber(L, transforms[tidx*4 + idx]);
+      lua_rawseti(L, -2, idx+1);
+    }
+  }
+  return count;
+}
+
+static int l_lovrGraphicsGetViewports(lua_State* L) {
+  float viewport[8];
+  int count;
+  lovrGraphicsGetViewport(viewport, &count);
+  for(int vidx = 0; vidx < count; vidx++) {
+    lua_createtable(L, 4, 0);
+    for(int idx = 0; idx < 4; idx++) {
+      lua_pushnumber(L, viewport[vidx*4 + idx]);
+      lua_rawseti(L, -2, idx+1);
+    }
+  }
+  return count;
 }
 
 static int l_lovrGraphicsGetWinding(lua_State* L) {
@@ -1678,6 +1715,8 @@ static const luaL_Reg lovrGraphics[] = {
   { "setShader", l_lovrGraphicsSetShader },
   { "getStencilTest", l_lovrGraphicsGetStencilTest },
   { "setStencilTest", l_lovrGraphicsSetStencilTest },
+  { "getTransforms", l_lovrGraphicsGetTransforms },
+  { "getViewports", l_lovrGraphicsGetViewports },
   { "getWinding", l_lovrGraphicsGetWinding },
   { "setWinding", l_lovrGraphicsSetWinding },
   { "isWireframe", l_lovrGraphicsIsWireframe },

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -69,6 +69,13 @@ typedef enum {
   WINDING_COUNTERCLOCKWISE
 } Winding;
 
+typedef enum {
+  MATRIX_REQUEST_MODEL,
+  MATRIX_REQUEST_VIEW,
+  MATRIX_REQUEST_PROJECTION,
+  MATRIX_REQUEST_MVP, // Combined
+} MatrixRequest;
+
 typedef struct {
   bool stereo;
   struct Canvas* canvas;
@@ -152,6 +159,9 @@ void lovrGraphicsRotate(quat rotation);
 void lovrGraphicsScale(vec3 scale);
 void lovrGraphicsMatrixTransform(mat4 transform);
 void lovrGraphicsSetProjection(mat4 projection);
+bool lovrGraphicsGetIsStereo();
+void lovrGraphicsMatrixGetTransform(mat4 dst, int* count, MatrixRequest request); // dst must be an array of 32 values
+void lovrGraphicsGetViewport(float* viewport, int* count); // Viewport should be 8 values, x y width height per-eye.
 
 // Rendering
 void lovrGraphicsFlush(void);


### PR DESCRIPTION
This makes it possible to reverse a lovr-mouse click on the mirror window into worldspace in pure Lua. Some C functions got added to graphics.h to support this.

`lovr.graphics.getTransforms()` takes one of "projection", "view", "model" and "mvp" and returns either one or two tables containing matrix coefficients (bjorn says we can't return matrices right now…)
`lovr.graphics.getViewports()` returns either one or two tables containing (x,y,width,height) rectangles for the eyes

Test code (this can go into lovr-docs, though I worry it's not as readable as it could be-- it's long and the "important" math is a bit down)
(Demo requires [lovr-mouse.lua](http://github.com/bjornbytes/lovr-mouse) in the same directory)
(A really absurd, funny version of this demo would be tic-tac-toe with player 1 using the VR controllers and player 2 clicking on the screen, but that would be even longer)

```
-- "Second screen experience" Raycast demo
-- Click grid on desktop screen to alter scene visible in VR space
--
-- Sample contributed by andi mcc

-- In order for lovr.mouse to work, and therefore for this example to work,
-- we must be using LuaJIT and we must be using GLFW (ie: we can't be on Oculus Mobile)
if type(jit) == 'table' and lovr.headset.getDriver() ~= "oculusmobile" then
	lovr.mouse = require 'lovr-mouse'
end

local mirror = lovr.mirror              -- Backup lovr.mirror before it is overwritten

-- Constants
local pixwidth = lovr.graphics.getWidth()   -- Window pixel width and height
local pixheight = lovr.graphics.getHeight()
local cells = 7                             -- Number of cells in grid (per side)
local gridheight = 1.75                     -- Height of grid in worldspace

-- Derived constants
local gridspan = gridheight/2               -- Half height of grid in worldspace
local cellheight = gridheight/cells         -- Height of one grid cell in worldspace

-- State: We will store the blocks to draw as a 2D array of heights (nil for no block)
local grid = {}
for x=1,cells do grid[x] = {} end

-- Clicks to be processed
local clicks

function lovr.load()
	lovr.handlers['mousepressed'] = function(x,y)
		if not clicks then clicks = {} end
		table.insert(clicks, {x,y})
	end
end

local function drawGrid()
	-- Draw cell backgrounds (where present)
	for _x=1,cells do for _y=1,cells do
		local gray = grid[_x][_y]
		if gray then
			local x = _x - 0.5 -- Center of cell
			local y = _y - 0.5

			lovr.graphics.setColor(1,1,1, gray)
			lovr.graphics.plane('fill', x, y, 0, 1, 1)
		end
	end end

	-- Draw grid lines
	lovr.graphics.setColor(1,1,1,1)
	for c=0,cells do
		local x = c
		local y = c
		lovr.graphics.line(0, y, 0, cells, y, 0)
		lovr.graphics.line(x, 0, 0, x, cells, 0)
	end
end

local function invert(x,y)
	if grid[x][y] then
		grid[x][y] = nil
	else
		grid[x][y] = 0.5
	end
end

-- Draw 3D scene
function lovr.draw()
	-- First, draw a floor
	lovr.graphics.setColor(0.25,0.25,0.25)
	lovr.graphics.plane('fill', 0,0,0, 5,5, math.pi/2,1,0,0)

	-- Grid:
	lovr.graphics.push()
	lovr.graphics.translate(-gridspan,0.5,-1)
	lovr.graphics.scale(cellheight)
	-- Because getTransforms() is based on the current transform, we have to wait to process clicks until the draw function.
	if clicks then
		local viewports = {lovr.graphics.getViewports()}
		local matrices = {lovr.graphics.getTransforms()}
		for _,click in ipairs(clicks) do
			local x,y = unpack(click)
			local viewport
			for v,rect in ipairs(viewports) do
				local rx,ry,rwidth,rheight = unpack(rect)
				if x >= rx and x < rx+rwidth and y >= ry and y < ry+rheight then
					-- Unproject from world space
					local matrix = lovr.math.mat4(unpack(matrices[v])):invert()
					local ndcX = -1 + (x - rx)/rwidth * 2 -- Normalized Device Coordinates
					local ndcY = 1 - (y - ry)/rheight * 2 -- Note: Mouse coordinates have y+ down but OpenGL NDCs are y+ up
					local near = matrix:mul( lovr.math.vec3(ndcX, ndcY, 0) ) -- Where you clicked, touching the screen
					local far  = matrix:mul( lovr.math.vec3(ndcX, ndcY, 1) ) -- Where you clicked, touching the clip plane

					-- Project onto z-plane
					-- (Because we call this inside the push..pop the drawing grid IS the z-plane, and the math is easier)
					local ray = (far-near):normalize()
					local normal = lovr.math.vec3(0,0,1) -- Normal to z plane
					local distanceDenominator = ray:dot(normal)
					if distanceDenominator ~= 0 then
						local origin = lovr.math.vec3(0,0,0) -- Origin of z plane
						local distance = (origin - near):dot(normal)/distanceDenominator -- How far from near to z-plane?
						local pointAt = near + ray*distance  -- Where click ray intersects z plane

						-- In object space the grid squares are each 1x1 so we can floor to get the grid cells
						local cellX = math.floor(pointAt.x)
						local cellY = math.floor(pointAt.y)
						if cellX >= 0 and cellX < cells and cellY >= 0 and cellY < cells then
							invert(cellX + 1, cellY + 1)
						end
					end
				end
			end
		end
		clicks = nil
	end
	-- Finally draw the grid
	drawGrid()
	lovr.graphics.pop()

	if not lovr.mouse then -- If you can't click, you can't create any blocks
		lovr.graphics.print('This example only works on a desktop computer.', 0, 1.7, -3, .2)
	end
end
```

Looks like:

<img width="1192" alt="Screen Shot 2020-04-09 at 1 26 07 AM" src="https://user-images.githubusercontent.com/277318/78861234-48e96500-7a02-11ea-93bb-ec6920c50d58.png">
