### PR TITLE
implement haptics on oculus desktop

### DIFF
--- a/src/modules/headset/oculus.c
+++ b/src/modules/headset/oculus.c
@@ -27,6 +27,10 @@ static struct {
   Canvas* canvas;
   ovrTextureSwapChain chain;
   ovrMirrorTexture mirror;
+  float hapticFrequency[2];
+  float hapticStrength[2];
+  float hapticDuration[2];
+  double hapticLastTime;
   arr_t(Texture*) textures;
   map_t textureLookup;
 } state;
@@ -44,6 +48,10 @@ static Texture* lookupTexture(uint32_t handle) {
   return state.textures.data[index];
 }
 
+static double oculus_getDisplayTime(void) {
+  return ovr_GetPredictedDisplayTime(state.session, state.frameIndex);
+}
+
 static ovrTrackingState *refreshTracking(void) {
   static ovrTrackingState ts;
   if (!state.needRefreshTracking) {
@@ -59,7 +67,7 @@ static ovrTrackingState *refreshTracking(void) {
 
   // get the state head and controllers are predicted to be in at display time,
   // per the manual (frame timing section).
-  double predicted = ovr_GetPredictedDisplayTime(state.session, state.frameIndex);
+  double predicted = oculus_getDisplayTime();
   ts = ovr_GetTrackingState(state.session, predicted, true);
   state.needRefreshTracking = false;
   return &ts;
@@ -142,10 +150,6 @@ static void oculus_getDisplayDimensions(uint32_t* width, uint32_t* height) {
 static const float* oculus_getDisplayMask(uint32_t* count) {
   *count = 0;
   return NULL;
-}
-
-static double oculus_getDisplayTime(void) {
-  return ovr_GetPredictedDisplayTime(state.session, state.frameIndex);
 }
 
 static void getEyePoses(ovrPosef poses[2], double* sensorSampleTime) {
@@ -308,7 +312,18 @@ static bool oculus_getAxis(Device device, DeviceAxis axis, vec3 value) {
 }
 
 static bool oculus_vibrate(Device device, float strength, float duration, float frequency) {
-  return false; // TODO
+  int idx = device == DEVICE_HAND_LEFT ? 0 : 1;
+  state.hapticStrength[idx] = strength > 0.0f ? (strength <= 1.0f ? strength : 1.0f) : 0.0f;
+  state.hapticDuration[idx] = duration > 0.0f ? duration : 0.0f;
+  float freq = frequency / 320.0f; // 1.0 = 320hz, limit on Rift CV1 touch controllers.
+  if (freq < 0.0f) {
+    freq = 0.0f;
+  }
+  if (freq > 1.0f) {
+    freq = 1.0f;
+  }
+  state.hapticFrequency[idx] = freq;
+  return true;
 }
 
 static ModelData* oculus_newModelData(Device device) {
@@ -348,6 +363,16 @@ static void oculus_renderTo(void (*callback)(void*), void* userdata) {
   ovrPosef EyeRenderPose[2];
   double sensorSampleTime;
   getEyePoses(EyeRenderPose, &sensorSampleTime);
+
+  float delta = (float)(state.hapticLastTime - sensorSampleTime);
+  state.hapticLastTime = sensorSampleTime;
+  for (int i = 0; i < 2; ++i) {
+    ovr_SetControllerVibration(state.session, ovrControllerType_LTouch + i, state.hapticFrequency[i], state.hapticStrength[i]);
+    state.hapticDuration[i] -= delta;
+    if (state.hapticDuration[i] <= 0.0f) {
+      state.hapticStrength[i] = 0.0f;
+    }
+  }
 
   Camera camera = { .canvas = state.canvas };
 

--- a/src/modules/headset/oculus.c
+++ b/src/modules/headset/oculus.c
@@ -316,15 +316,9 @@ static bool oculus_vibrate(Device device, float strength, float duration, float 
     return false;
   }
   int idx = device == DEVICE_HAND_LEFT ? 0 : 1;
-  state.hapticStrength[idx] = strength > 0.0f ? (strength <= 1.0f ? strength : 1.0f) : 0.0f;
-  state.hapticDuration[idx] = duration > 0.0f ? duration : 0.0f;
-  float freq = frequency / 320.0f; // 1.0 = 320hz, limit on Rift CV1 touch controllers.
-  if (freq < 0.0f) {
-    freq = 0.0f;
-  }
-  if (freq > 1.0f) {
-    freq = 1.0f;
-  }
+  state.hapticStrength[idx] = CLAMP(strength, 0.0f, 1.0f);
+  state.hapticDuration[idx] = MAX(duration, 0.0f);
+  float freq = CLAMP(frequency / 320.0f, 0.0f, 1.0f); // 1.0 = 320hz, limit on Rift CV1 touch controllers.
   state.hapticFrequency[idx] = freq;
   return true;
 }

--- a/src/modules/headset/oculus.c
+++ b/src/modules/headset/oculus.c
@@ -312,6 +312,9 @@ static bool oculus_getAxis(Device device, DeviceAxis axis, vec3 value) {
 }
 
 static bool oculus_vibrate(Device device, float strength, float duration, float frequency) {
+  if (device != DEVICE_HAND_LEFT && device != DEVICE_HAND_RIGHT) {
+    return false;
+  }
   int idx = device == DEVICE_HAND_LEFT ? 0 : 1;
   state.hapticStrength[idx] = strength > 0.0f ? (strength <= 1.0f ? strength : 1.0f) : 0.0f;
   state.hapticDuration[idx] = duration > 0.0f ? duration : 0.0f;


### PR DESCRIPTION
fixes the todo. implemented with a timer so that durations should work, tested working with the following:

```lua
function lovr.draw()
	for i, hand in ipairs(lovr.headset.getHands()) do
		lovr.headset.vibrate(hand, lovr.headset.getAxis(hand, 'trigger'), 0, 0)

		local x, y, z = lovr.headset.getPosition(hand)
		lovr.graphics.sphere(x, y, z, .1)
	end
end
```

it updates the controller haptics state every frame, but I have no reason to believe this is a problem from the docs or test.