### PR TITLE
Oculus mobile "restart cookie" support; lovr.event.restart() changes

### DIFF
--- a/src/api/l_event.c
+++ b/src/api/l_event.c
@@ -170,12 +170,7 @@ static int l_lovrEventPush(lua_State* L) {
 static int l_lovrEventQuit(lua_State* L) {
   EventData data;
 
-  int argType = lua_type(L, 1);
-  if (argType == LUA_TNUMBER || lua_isnoneornil(L, 1)) {
-    data.quit.exitCode = luaL_optint(L, 1, 0);
-  } else {
-    return luaL_argerror (L, 1, "number or nil expected");
-  }
+  data.quit.exitCode = luaL_optint(L, 1, 0);
 
   EventType type = EVENT_QUIT;
   Event event = { .type = type, .data = data };

--- a/src/api/l_event.c
+++ b/src/api/l_event.c
@@ -9,6 +9,7 @@
 
 StringEntry EventTypes[] = {
   [EVENT_QUIT] = ENTRY("quit"),
+  [EVENT_RESTART] = ENTRY("restart"),
   [EVENT_FOCUS] = ENTRY("focus"),
 #ifdef LOVR_ENABLE_THREAD
   [EVENT_THREAD_ERROR] = ENTRY("threaderror"),
@@ -98,14 +99,8 @@ static int nextEvent(lua_State* L) {
 
   switch (event.type) {
     case EVENT_QUIT:
-      if (event.data.quit.restart) {
-        lua_pushliteral(L, "restart");
-        luax_pushvariant(L, &event.data.quit.cookie);
-        return 3;
-      } else {
-        lua_pushnumber(L, event.data.quit.exitCode);
-        return 2;
-      }
+      lua_pushnumber(L, event.data.quit.exitCode);
+      return 2;
 
     case EVENT_FOCUS:
       lua_pushboolean(L, event.data.boolean.value);
@@ -138,9 +133,9 @@ static void hotkeyHandler(KeyCode key, ButtonAction action) {
   }
 
   if (key == KEY_ESCAPE) {
-    lovrEventPush((Event) { .type = EVENT_QUIT, .data.quit.restart = false, .data.quit.exitCode = 0 });
+    lovrEventPush((Event) { .type = EVENT_QUIT, .data.quit.exitCode = 0 });
   } else if (key == KEY_F5) {
-    lovrEventPush((Event) { .type = EVENT_QUIT, .data.quit.restart = true });
+    lovrEventPush((Event) { .type = EVENT_RESTART });
   }
 }
 
@@ -176,15 +171,10 @@ static int l_lovrEventQuit(lua_State* L) {
   EventData data;
 
   int argType = lua_type(L, 1);
-  if (argType == LUA_TSTRING && !strcmp("restart", lua_tostring(L, 1))) {
-    data.quit.restart = true;
-    data.quit.exitCode = 0;
-    luax_checkvariant(L, 2, &data.quit.cookie);
-  } else if (argType == LUA_TNUMBER || lua_isnoneornil(L, 1)) {
-    data.quit.restart = false;
+  if (argType == LUA_TNUMBER || lua_isnoneornil(L, 1)) {
     data.quit.exitCode = luaL_optint(L, 1, 0);
   } else {
-    return luaL_argerror (L, 1, "number, nil or the exact string 'restart' expected");
+    return luaL_argerror (L, 1, "number or nil expected");
   }
 
   EventType type = EVENT_QUIT;
@@ -194,12 +184,8 @@ static int l_lovrEventQuit(lua_State* L) {
 }
 
 static int l_lovrEventRestart(lua_State* L) {
-  EventData data;
-  data.quit.exitCode = 0;
-  data.quit.restart = true;
-  luax_checkvariant(L, 1, &data.quit.cookie);
-  EventType type = EVENT_QUIT;
-  Event event = { .type = type, .data = data };
+  EventType type = EVENT_RESTART;
+  Event event = { .type = type };
   lovrEventPush(event);
   return 0;
 }

--- a/src/modules/event/event.h
+++ b/src/modules/event/event.h
@@ -9,6 +9,7 @@ struct Thread;
 
 typedef enum {
   EVENT_QUIT,
+  EVENT_RESTART,
   EVENT_FOCUS,
   EVENT_CUSTOM,
 #ifdef LOVR_ENABLE_THREAD
@@ -41,9 +42,7 @@ typedef struct Variant {
 } Variant;
 
 typedef struct {
-  bool restart;
   int exitCode;
-  Variant cookie;
 } QuitEvent;
 
 typedef struct {

--- a/src/modules/headset/oculus_mobile.c
+++ b/src/modules/headset/oculus_mobile.c
@@ -511,7 +511,7 @@ void bridgeLovrUpdate(BridgeLovrUpdateData *updateData) {
   luax_clearerror(T);
   lovrSetErrorCallback(luax_vthrow, T);
   if (lua_resume(T, 1) != LUA_YIELD) {
-    if (lua_type(T, -1) == LUA_TSTRING && !strcmp(lua_tostring(T, -1), "restart")) {
+    if (lua_type(T, -2) == LUA_TSTRING && !strcmp(lua_tostring(T, -2), "restart")) {
       state.renderCallback = NULL;
       state.renderUserdata = NULL;
       lua_close(L);

--- a/src/resources/boot.lua
+++ b/src/resources/boot.lua
@@ -152,8 +152,7 @@ function lovr.run()
       if name == 'restart' then
         local cookie = lovr.restart and lovr.restart()
         return 'restart', cookie
-      end
-      if name == 'quit' and (not lovr.quit or not lovr.quit(a)) then
+      elseif name == 'quit' and (not lovr.quit or not lovr.quit(a)) then
         return a or 0
       end
       if lovr.handlers[name] then lovr.handlers[name](a, b, c, d) end

--- a/src/resources/boot.lua
+++ b/src/resources/boot.lua
@@ -149,8 +149,12 @@ function lovr.run()
   return function()
     lovr.event.pump()
     for name, a, b, c, d in lovr.event.poll() do
-      if name == 'quit' and (not lovr.quit or not lovr.quit()) then
-        return a or 0, b
+      if name == 'restart' then
+        local cookie = lovr.restart and lovr.restart()
+        return 'restart', cookie
+      end
+      if name == 'quit' and (not lovr.quit or not lovr.quit(a)) then
+        return a or 0
       end
       if lovr.handlers[name] then lovr.handlers[name](a, b, c, d) end
     end


### PR DESCRIPTION
After the changes to add a "cookie" to `lovr.event.quit("restart")`, restarting was broken on Oculus Mobile. This patches oculus mobile so restarting and the cookie work.

In addition, after a slack conversation, these changes were made to quit("restart") and the cookie:

- lovr.event.quit("restart") no longer supported
- lovr.event.quit no longer accepts restart "cookie"
- When lovr.event.restart() called, lovr.quit is not called, instead lovr.restart() is called
- Value returned from lovr.restart() becomes the cookie
- lovr.event.quit receives the lovr.event.quit() return code as an argument

(The return values from lovr.run() are not changed, but boot.lua picks the return values differently and the event code is simplified to remove the cookie plumbing.)

These changes mean that a cookie can be obtained if a restart is triggered by F5 or lodr (as long as lodr is patched so makeWrapper calls lovr.event.restart() instead of returning "restart").

My test program:

```
local count = arg.restart or 0

function lovr.load()
	print(string.format("%d boots", count))
end

local time = 0
function lovr.update(dt)
	time = time + dt
	if time > 20 then
		print("TIME OUT!")
		lovr.event.restart()
	end
end
   
function lovr.restart()
	print("restarting")
	return count + 1
end
```