### PR TITLE
Fix collider setOrientation() and setPose()

### DIFF
--- a/src/api/l_physics_collider.c
+++ b/src/api/l_physics_collider.c
@@ -222,7 +222,7 @@ static int l_lovrColliderSetOrientation(lua_State* L) {
   Collider* collider = luax_checktype(L, 1, Collider);
   float orientation[4];
   luax_readquat(L, 2, orientation, NULL);
-  lovrColliderSetOrientation(collider, orientation[0], orientation[1], orientation[2], orientation[3]);
+  lovrColliderSetOrientation(collider, orientation);
   return 0;
 }
 
@@ -247,7 +247,7 @@ static int l_lovrColliderSetPose(lua_State* L) {
   int index = luax_readvec3(L, 2, position, NULL);
   luax_readquat(L, index, orientation, NULL);
   lovrColliderSetPosition(collider, position[0], position[1], position[2]);
-  lovrColliderSetOrientation(collider, orientation[0], orientation[1], orientation[2], orientation[3]);
+  lovrColliderSetOrientation(collider, orientation);
   return 0;
 }
 

--- a/src/modules/physics/physics.c
+++ b/src/modules/physics/physics.c
@@ -517,9 +517,7 @@ void lovrColliderGetOrientation(Collider* collider, float* angle, float* x, floa
   quat_getAngleAxis(quaternion, angle, x, y, z);
 }
 
-void lovrColliderSetOrientation(Collider* collider, float angle, float x, float y, float z) {
-  float quaternion[4];
-  quat_fromAngleAxis(quaternion, angle, x, y, z);
+void lovrColliderSetOrientation(Collider* collider, float* quaternion) {
   float q[4] = { quaternion[3], quaternion[0], quaternion[1], quaternion[2] };
   dBodySetQuaternion(collider->body, q);
 }

--- a/src/modules/physics/physics.h
+++ b/src/modules/physics/physics.h
@@ -139,7 +139,7 @@ void lovrColliderSetMassData(Collider* collider, float cx, float cy, float cz, f
 void lovrColliderGetPosition(Collider* collider, float* x, float* y, float* z);
 void lovrColliderSetPosition(Collider* collider, float x, float y, float z);
 void lovrColliderGetOrientation(Collider* collider, float* angle, float* x, float* y, float* z);
-void lovrColliderSetOrientation(Collider* collider, float angle, float x, float y, float z);
+void lovrColliderSetOrientation(Collider* collider, float* quaternion);
 void lovrColliderGetLinearVelocity(Collider* collider, float* x, float* y, float* z);
 void lovrColliderSetLinearVelocity(Collider* collider, float x, float y, float z);
 void lovrColliderGetAngularVelocity(Collider* collider, float* x, float* y, float* z);


### PR DESCRIPTION
The conversion from `angle,ax,ay,az` to quaternion is already done in physics module.