### PR TITLE
Physics world accepts both vec3 and number coords

### DIFF
--- a/src/api/l_physics_world.c
+++ b/src/api/l_physics_world.c
@@ -40,10 +40,9 @@ static void raycastCallback(Shape* shape, float x, float y, float z, float nx, f
 
 static int l_lovrWorldNewCollider(lua_State* L) {
   World* world = luax_checktype(L, 1, World);
-  float x = luax_optfloat(L, 2, 0.f);
-  float y = luax_optfloat(L, 3, 0.f);
-  float z = luax_optfloat(L, 4, 0.f);
-  Collider* collider = lovrColliderCreate(world, x, y, z);
+  float position[4];
+  luax_readvec3(L, 2, position, NULL);
+  Collider* collider = lovrColliderCreate(world, position[0], position[1], position[2]);
   luax_pushtype(L, Collider, collider);
   lovrRelease(Collider, collider);
   return 1;
@@ -51,14 +50,11 @@ static int l_lovrWorldNewCollider(lua_State* L) {
 
 static int l_lovrWorldNewBoxCollider(lua_State* L) {
   World* world = luax_checktype(L, 1, World);
-  float x = luax_optfloat(L, 2, 0.f);
-  float y = luax_optfloat(L, 3, 0.f);
-  float z = luax_optfloat(L, 4, 0.f);
-  float sx = luax_optfloat(L, 5, 1.f);
-  float sy = luax_optfloat(L, 6, sx);
-  float sz = luax_optfloat(L, 7, sx);
-  Collider* collider = lovrColliderCreate(world, x, y, z);
-  BoxShape* shape = lovrBoxShapeCreate(sx, sy, sz);
+  float position[4], size[4];
+  int index = luax_readvec3(L, 2, position, NULL);
+  luax_readscale(L, index, size, 3, NULL);
+  Collider* collider = lovrColliderCreate(world, position[0], position[1], position[2]);
+  BoxShape* shape = lovrBoxShapeCreate(size[0], size[1], size[2]);
   lovrColliderAddShape(collider, shape);
   lovrColliderInitInertia(collider, shape);
   luax_pushtype(L, Collider, collider);
@@ -69,12 +65,11 @@ static int l_lovrWorldNewBoxCollider(lua_State* L) {
 
 static int l_lovrWorldNewCapsuleCollider(lua_State* L) {
   World* world = luax_checktype(L, 1, World);
-  float x = luax_optfloat(L, 2, 0.f);
-  float y = luax_optfloat(L, 3, 0.f);
-  float z = luax_optfloat(L, 4, 0.f);
-  float radius = luax_optfloat(L, 5, 1.f);
-  float length = luax_optfloat(L, 6, 1.f);
-  Collider* collider = lovrColliderCreate(world, x, y, z);
+  float position[4];
+  int index = luax_readvec3(L, 2, position, NULL);
+  float radius = luax_optfloat(L, index++, 1.f);
+  float length = luax_optfloat(L, index, 1.f);
+  Collider* collider = lovrColliderCreate(world, position[0], position[1], position[2]);
   CapsuleShape* shape = lovrCapsuleShapeCreate(radius, length);
   lovrColliderAddShape(collider, shape);
   lovrColliderInitInertia(collider, shape);
@@ -86,12 +81,11 @@ static int l_lovrWorldNewCapsuleCollider(lua_State* L) {
 
 static int l_lovrWorldNewCylinderCollider(lua_State* L) {
   World* world = luax_checktype(L, 1, World);
-  float x = luax_optfloat(L, 2, 0.f);
-  float y = luax_optfloat(L, 3, 0.f);
-  float z = luax_optfloat(L, 4, 0.f);
-  float radius = luax_optfloat(L, 5, 1.f);
-  float length = luax_optfloat(L, 6, 1.f);
-  Collider* collider = lovrColliderCreate(world, x, y, z);
+  float position[4];
+  int index = luax_readvec3(L, 2, position, NULL);
+  float radius = luax_optfloat(L, index++, 1.f);
+  float length = luax_optfloat(L, index, 1.f);
+  Collider* collider = lovrColliderCreate(world, position[0], position[1], position[2]);
   CylinderShape* shape = lovrCylinderShapeCreate(radius, length);
   lovrColliderAddShape(collider, shape);
   lovrColliderInitInertia(collider, shape);
@@ -103,11 +97,10 @@ static int l_lovrWorldNewCylinderCollider(lua_State* L) {
 
 static int l_lovrWorldNewSphereCollider(lua_State* L) {
   World* world = luax_checktype(L, 1, World);
-  float x = luax_optfloat(L, 2, 0.f);
-  float y = luax_optfloat(L, 3, 0.f);
-  float z = luax_optfloat(L, 4, 0.f);
-  float radius = luax_optfloat(L, 5, 1.f);
-  Collider* collider = lovrColliderCreate(world, x, y, z);
+  float position[4];
+  int index = luax_readvec3(L, 2, position, NULL);
+  float radius = luax_optfloat(L, index, 1.f);
+  Collider* collider = lovrColliderCreate(world, position[0], position[1], position[2]);
   SphereShape* shape = lovrSphereShapeCreate(radius);
   lovrColliderAddShape(collider, shape);
   lovrColliderInitInertia(collider, shape);
@@ -167,10 +160,9 @@ static int l_lovrWorldGetGravity(lua_State* L) {
 
 static int l_lovrWorldSetGravity(lua_State* L) {
   World* world = luax_checktype(L, 1, World);
-  float x = luax_checkfloat(L, 2);
-  float y = luax_checkfloat(L, 3);
-  float z = luax_checkfloat(L, 4);
-  lovrWorldSetGravity(world, x, y, z);
+  float gravity[4];
+  luax_readvec3(L, 2, gravity, NULL);
+  lovrWorldSetGravity(world, gravity[0], gravity[1], gravity[2]);
   return 0;
 }
 
@@ -223,15 +215,13 @@ static int l_lovrWorldSetSleepingAllowed(lua_State* L) {
 
 static int l_lovrWorldRaycast(lua_State* L) {
   World* world = luax_checktype(L, 1, World);
-  float x1 = luax_checkfloat(L, 2);
-  float y1 = luax_checkfloat(L, 3);
-  float z1 = luax_checkfloat(L, 4);
-  float x2 = luax_checkfloat(L, 5);
-  float y2 = luax_checkfloat(L, 6);
-  float z2 = luax_checkfloat(L, 7);
-  luaL_checktype(L, 8, LUA_TFUNCTION);
-  lua_settop(L, 8);
-  lovrWorldRaycast(world, x1, y1, z1, x2, y2, z2, raycastCallback, L);
+  float start[4], end[4];
+  int index;
+  index = luax_readvec3(L, 2, start, NULL);
+  index = luax_readvec3(L, index, end, NULL);
+  luaL_checktype(L, index, LUA_TFUNCTION);
+  lua_settop(L, index);
+  lovrWorldRaycast(world, start[0], start[1], start[2], end[0], end[1], end[2], raycastCallback, L);
   return 0;
 }
 


### PR DESCRIPTION
When creating colliders, setting gravity or casting rays on world,
arguments accept either coordinate numbers as before, or vec3 objects.
For functions that receive more than one set of coordinates, any
combination of coordinates and vectors is accepted.

Work towards solving #219, only World API is included here.