### PR TITLE
shaderblock:getOffset() crashes on nonexistent field

### DIFF
--- a/src/api/l_graphics_shaderBlock.c
+++ b/src/api/l_graphics_shaderBlock.c
@@ -19,8 +19,9 @@ static int l_lovrShaderBlockGetSize(lua_State* L) {
 
 static int l_lovrShaderBlockGetOffset(lua_State* L) {
   ShaderBlock* block = luax_checktype(L, 1, ShaderBlock);
-  const char* field = luaL_checkstring(L, 2);
-  const Uniform* uniform = lovrShaderBlockGetUniform(block, field);
+  const char* name = luaL_checkstring(L, 2);
+  const Uniform* uniform = lovrShaderBlockGetUniform(block, name);
+  lovrAssert(uniform, "Unknown uniform for ShaderBlock '%s'", name);
   lua_pushinteger(L, uniform->offset);
   return 1;
 }


### PR DESCRIPTION
Every method in shaderBlock() asserts that a uniform exists before reading its structure, except getOffset, which just hauls ahead and reads it, causing a segfault. Patch adds the assert in getOffset as well.

Here's my test code

```
function lovr.load()
  MONKEYS = 500

  -- Create a ShaderBlock to store positions for lots of models
  block = lovr.graphics.newShaderBlock('uniform', {
    modelTransforms = { 'mat4', MONKEYS }
  }, { usage = 'static' })
  block:getOffset("doesntExist")
end
```