### PR TITLE
Initialize vec3 from mat4

### DIFF
--- a/src/api/l_math_vectors.c
+++ b/src/api/l_math_vectors.c
@@ -488,8 +488,15 @@ int l_lovrVec3Set(lua_State* L) {
     float x = luax_optfloat(L, 2, 0.f);
     vec3_set(v, x, luax_optfloat(L, 3, x), luax_optfloat(L, 4, x));
   } else {
-    vec3 u = luax_checkvector(L, 2, V_VEC3, "vec3 or number");
-    vec3_init(v, u);
+    VectorType t;
+    float* p = luax_tovector(L, 2, &t);
+    if (p && t == V_VEC3) {
+      vec3_init(v, p);
+    } else if (p && t == V_MAT4) {
+      vec3_set(v, p[12], p[13], p[14]);
+    } else{
+      luaL_typerror(L, 2, "vec3, mat4, or number");
+    }
   }
   lua_settop(L, 1);
   return 1;


### PR DESCRIPTION
Rotation and scaling is lost, only position is extracted from mat4.

Allows `vec3(mat4Obj)` instead of more verbose `vec3(mat4obj:mul(0,0,0))` and `vec3(mat4obj:unpack())`.
