### PR TITLE
fix crash in lovrGraphicsGetPixelDensity

### DIFF
--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -279,9 +279,9 @@ int lovrGraphicsGetHeight() {
 }
 
 float lovrGraphicsGetPixelDensity() {
-  int width, framebufferWidth;
-  lovrPlatformGetWindowSize(&width, NULL);
-  lovrPlatformGetFramebufferSize(&framebufferWidth, NULL);
+  int width, height, framebufferWidth, framebufferHeight;
+  lovrPlatformGetWindowSize(&width, &height);
+  lovrPlatformGetFramebufferSize(&framebufferWidth, &framebufferHeight);
   if (width == 0 || framebufferWidth == 0) {
     return 0.f;
   } else {


### PR DESCRIPTION
Neither Quest nor Pico check for null on its out-params.
Better to send in dummy params to avoid nulls.