### PR TITLE
Fix definition of HOME key on Android

### DIFF
--- a/src/core/os_android.c
+++ b/src/core/os_android.c
@@ -90,7 +90,7 @@ static int32_t onInputEvent(struct android_app* app, AInputEvent* event) {
     case AKEYCODE_DPAD_DOWN: key = KEY_DOWN; break;
     case AKEYCODE_DPAD_LEFT: key = KEY_LEFT; break;
     case AKEYCODE_DPAD_RIGHT: key = KEY_RIGHT; break;
-    case AKEYCODE_HOME: key = KEY_HOME; break;
+    case AKEYCODE_MOVE_HOME: key = KEY_HOME; break;
     case AKEYCODE_MOVE_END: key = KEY_END; break;
     case AKEYCODE_PAGE_UP: key = KEY_PAGE_UP; break;
     case AKEYCODE_PAGE_DOWN: key = KEY_PAGE_DOWN; break;


### PR DESCRIPTION
There are two HOME keys defined in keycodes.h, the previously used
doesn't work and is labeled with the following comment: "This key
is handled by the framework and is never delivered to applications."