### PR TITLE
Allow lovr.headset.init to fail

### DIFF
--- a/src/resources/boot.lua
+++ b/src/resources/boot.lua
@@ -159,7 +159,11 @@ function lovr.boot()
   end
 
   if lovr.headset and lovr.graphics and conf.window then
-    lovr.headset.init()
+    local ok, result = pcall(lovr.headset.init)
+    if not ok then
+      print(string.format('Warning: Could not load module %q: %s', 'headset', result))
+      lovr.headset = nil
+    end
   end
 
   lovr.handlers = setmetatable({}, { __index = lovr })


### PR DESCRIPTION
with a pcall, like the requires above. so if there
is no matching headset driver, the module is just
turned off.