### PR TITLE
lovr.headset.getSkeleton("local")

### DIFF
--- a/src/modules/headset/headset_vrapi.c
+++ b/src/modules/headset/headset_vrapi.c
@@ -347,26 +347,29 @@ static bool vrapi_getSkeleton(Device device, float* poses) {
   }
 
   float LOVR_ALIGN(16) globalPoses[ovrHandBone_Max * 8];
-  float identity[8] = {0,0,0,1, 0,0,0,1};
-  for (uint32_t i = 0; i < ovrHandBone_Max; i++) {
-    float* pose = &globalPoses[i * 8];
+  if(space == SPACE_GLOBAL) {
+    for (uint32_t i = 0; i < ovrHandBone_Max; i++) {
+      float* pose = &globalPoses[i * 8];
 
-    if(space == SPACE_GLOBAL) {
       if (skeleton->BoneParentIndices[i] >= 0) {
         memcpy(pose, &globalPoses[skeleton->BoneParentIndices[i] * 8], 8 * sizeof(float));
       } else {
         memcpy(pose + 0, &handPose->RootPose.Position.x, 3 * sizeof(float));
         memcpy(pose + 4, &handPose->RootPose.Orientation.x, 4 * sizeof(float));
       }
-    } else {
-      memcpy(pose, identity, 8*sizeof(float));
-    }
 
-    float LOVR_ALIGN(16) translation[4];
-    memcpy(translation, &skeleton->BonePoses[i].Position.x, 3 * sizeof(float));
-    quat_rotate(pose + 4, translation);
-    vec3_add(pose + 0, translation);
-    quat_mul(pose + 4, pose + 4, &handPose->BoneRotations[i].x);
+      float LOVR_ALIGN(16) translation[4];
+      memcpy(translation, &skeleton->BonePoses[i].Position.x, 3 * sizeof(float));
+      quat_rotate(pose + 4, translation);
+      vec3_add(pose + 0, translation);
+      quat_mul(pose + 4, pose + 4, &handPose->BoneRotations[i].x);
+    }
+  } else {
+    for (uint32_t i = 0; i < ovrHandBone_Max; i++) {
+      float* pose = &globalPoses[i * 8];
+      memcpy(pose + 0, &skeleton->BonePoses[i].Position.x, 3 * sizeof(float));
+      memcpy(pose + 4, &handPose->BoneRotations[i].x, 4 * sizeof(float));
+    }
   }
 
   // We try our best, okay?


### PR DESCRIPTION
API to get the hand's skeleton poses in each node's local coordinate system, so that they can be applied/animated onto a hand model with the same node skeleton hierarchy as the hand tracking data.

This is WIP:

- [ ] BUG For some reason all the poses seem to be at 180 degrees rotation when my hand is at neutral pose. am I missing something oculus specific, or do I have a bug, or what's going on...
- [ ] FEATURE Change C API for getSkeleton to take coordinate space param
- [ ] FEATURE Change Lua API for getSkeleton to take coordinate space param
- [ ] Figure out what to do for the extra coordinate space param for all the headsets I can't test myself...