### PR TITLE
OpenXR: Fixes for implementations that are more strict with validation

### DIFF
--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -376,7 +376,8 @@ static bool openxr_init(float supersample, float offset, uint32_t msaa) {
     XrActionSpaceCreateInfo leftHandSpaceInfo = {
       .type = XR_TYPE_ACTION_SPACE_CREATE_INFO,
       .action = state.actions[ACTION_HAND_POSE],
-      .subactionPath = state.actionFilters[0]
+      .subactionPath = state.actionFilters[0],
+      .poseInActionSpace = { .orientation = { 0.f, 0.f, 0.f, 1.f }, .position = { 0.f, 0.f, 0.f } }
     };
 
     XR_INIT(xrCreateActionSpace(state.session, &leftHandSpaceInfo, &state.spaces[DEVICE_HAND_LEFT]));
@@ -385,7 +386,8 @@ static bool openxr_init(float supersample, float offset, uint32_t msaa) {
     XrActionSpaceCreateInfo rightHandSpaceInfo = {
       .type = XR_TYPE_ACTION_SPACE_CREATE_INFO,
       .action = state.actions[ACTION_HAND_POSE],
-      .subactionPath = state.actionFilters[1]
+      .subactionPath = state.actionFilters[1],
+      .poseInActionSpace = { .orientation = { 0.f, 0.f, 0.f, 1.f }, .position = { 0.f, 0.f, 0.f } }
     };
 
     XR_INIT(xrCreateActionSpace(state.session, &rightHandSpaceInfo, &state.spaces[DEVICE_HAND_RIGHT]));
@@ -598,7 +600,7 @@ static bool openxr_getPose(Device device, vec3 position, quat orientation) {
     return false;
   }
 
-  XrSpaceLocation location = { .next = NULL };
+  XrSpaceLocation location = { .type = XR_TYPE_SPACE_LOCATION, .next = NULL };
   xrLocateSpace(state.spaces[device], state.referenceSpace, state.frameState.predictedDisplayTime, &location);
   memcpy(orientation, &location.pose.orientation, 4 * sizeof(float));
   memcpy(position, &location.pose.position, 3 * sizeof(float));
@@ -611,7 +613,7 @@ static bool openxr_getVelocity(Device device, vec3 linearVelocity, vec3 angularV
   }
 
   XrSpaceVelocity velocity = { .type = XR_TYPE_SPACE_VELOCITY };
-  XrSpaceLocation location = { .next = &velocity };
+  XrSpaceLocation location = { .type = XR_TYPE_SPACE_LOCATION, .next = &velocity };
   xrLocateSpace(state.spaces[device], state.referenceSpace, state.frameState.predictedDisplayTime, &location);
   memcpy(linearVelocity, &velocity.linearVelocity, 3 * sizeof(float));
   memcpy(angularVelocity, &velocity.angularVelocity, 3 * sizeof(float));


### PR DESCRIPTION
Monado requires that the .type field is always set, and that poses are completely valid including setting `w` to 1.0f.