### PR TITLE
on lodr restart, make sure lovr.headset is nil'd if none is available

### DIFF
--- a/src/api/l_headset.c
+++ b/src/api/l_headset.c
@@ -142,9 +142,8 @@ static int l_lovrHeadsetInit(lua_State* L) {
     lua_pop(L, 1);
   }
 
-  if (lovrHeadsetInit(drivers, driverCount, supersample, offset, msaa)) {
-    luax_atexit(L, lovrHeadsetDestroy);
-  }
+  luax_atexit(L, lovrHeadsetDestroy); // Always make sure the headset module gets cleaned up
+  lovrHeadsetInit(drivers, driverCount, supersample, offset, msaa);
 
   lua_pop(L, 2);
   return 0;


### PR DESCRIPTION
In boot.lua, it assumes that lovr.headset.init will assert if no driver
is available. This was previously only true on the first call to it,
since after it's initialized, it'll just return early and won't assert.
This will later crash since your lua code will now see a lovr.headset
being available, but calling anything in it will crash since
lovrHeadsetDisplayDriver is NULL