### PR TITLE
don't free window icon before it's used

### DIFF
--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -362,11 +362,10 @@ static int l_lovrGraphicsCreateWindow(lua_State* L) {
   lua_getfield(L, 1, "icon");
   TextureData* textureData = NULL;
   if (!lua_isnil(L, -1)) {
-    textureData = luax_checktexturedata(L, -1, true);
+    textureData = luax_checktexturedata(L, -1, false);
     flags.icon.data = textureData->blob->data;
     flags.icon.width = textureData->width;
     flags.icon.height = textureData->height;
-    lovrRelease(TextureData, textureData);
   }
   lua_pop(L, 1);
 


### PR DESCRIPTION
It seems to me like that lovrRelease will delete textureData->blob immediately,
which means the windowing system later can't use it because it's already freed.
There's already a free on line 378 which looks more correct.

Also, icon appears flipped if 'flipped' is set to true here on Linux. Is GLFW
inconsistent between linux and windows, or should it indeed be false?