### PR TITLE
Check if shape can be positioned and oriented

### DIFF
--- a/src/api/l_physics_shapes.c
+++ b/src/api/l_physics_shapes.c
@@ -115,6 +115,7 @@ static int l_lovrShapeGetPosition(lua_State* L) {
 
 static int l_lovrShapeSetPosition(lua_State* L) {
   Shape* shape = luax_checkshape(L, 1);
+  lovrAssert(lovrShapeGetCollider(shape) != NULL, "Shape must be attached to collider");
   float position[4]; 
   luax_readvec3(L, 2, position, NULL);
   lovrShapeSetPosition(shape, position[0], position[1], position[2]);
@@ -135,6 +136,7 @@ static int l_lovrShapeGetOrientation(lua_State* L) {
 
 static int l_lovrShapeSetOrientation(lua_State* L) {
   Shape* shape = luax_checkshape(L, 1);
+  lovrAssert(lovrShapeGetCollider(shape) != NULL, "Shape must be attached to collider");
   float orientation[4];
   luax_readquat(L, 2, orientation, NULL);
   lovrShapeSetOrientation(shape, orientation);


### PR DESCRIPTION
Shape without attached collider cannot be positioned or oriented. Trying
to do so results in ODE crash. Better to throw a more descriptive error.