### PR TITLE
Change default damping threshold to zero

### DIFF
--- a/src/api/l_physics_collider.c
+++ b/src/api/l_physics_collider.c
@@ -301,7 +301,7 @@ static int l_lovrColliderGetLinearDamping(lua_State* L) {
 static int l_lovrColliderSetLinearDamping(lua_State* L) {
   Collider* collider = luax_checktype(L, 1, Collider);
   float damping = luax_checkfloat(L, 2);
-  float threshold = luax_optfloat(L, 3, .01f);
+  float threshold = luax_optfloat(L, 3, 0.0f);
   lovrColliderSetLinearDamping(collider, damping, threshold);
   return 0;
 }
@@ -318,7 +318,7 @@ static int l_lovrColliderGetAngularDamping(lua_State* L) {
 static int l_lovrColliderSetAngularDamping(lua_State* L) {
   Collider* collider = luax_checktype(L, 1, Collider);
   float damping = luax_checkfloat(L, 2);
-  float threshold = luax_optfloat(L, 3, .01f);
+  float threshold = luax_optfloat(L, 3, 0.0f);
   lovrColliderSetAngularDamping(collider, damping, threshold);
   return 0;
 }

--- a/src/api/l_physics_world.c
+++ b/src/api/l_physics_world.c
@@ -267,7 +267,7 @@ static int l_lovrWorldGetLinearDamping(lua_State* L) {
 static int l_lovrWorldSetLinearDamping(lua_State* L) {
   World* world = luax_checktype(L, 1, World);
   float damping = luax_checkfloat(L, 2);
-  float threshold = luax_optfloat(L, 3, .01f);
+  float threshold = luax_optfloat(L, 3, 0.0f);
   lovrWorldSetLinearDamping(world, damping, threshold);
   return 0;
 }
@@ -284,7 +284,7 @@ static int l_lovrWorldGetAngularDamping(lua_State* L) {
 static int l_lovrWorldSetAngularDamping(lua_State* L) {
   World* world = luax_checktype(L, 1, World);
   float damping = luax_checkfloat(L, 2);
-  float threshold = luax_optfloat(L, 3, .01f);
+  float threshold = luax_optfloat(L, 3, 0.0f);
   lovrWorldSetAngularDamping(world, damping, threshold);
   return 0;
 }


### PR DESCRIPTION
Zero as default makes more sense. Colliders can come to full stop which
allows them to go to sleep for CPU optimization. Also in zero gravity
colliders crawling through air with 0.01 velocity are infuriating.