### PR TITLE
fix crash in error handler when running out of vectors

### DIFF
--- a/src/resources/boot.lua
+++ b/src/resources/boot.lua
@@ -277,6 +277,9 @@ function lovr.errhand(message, traceback)
       render()
     end
     lovr.graphics.present()
+    if lovr.math then
+      lovr.math.drain()
+    end
   end
 end
 


### PR DESCRIPTION
> 
Error occurred while trying to display another error: Temporary vector space exhausted. Try using lovr.math.drain to drain the vector pool periodically.

This would happen because the new error handler has fancy graphics and uses temprary vectors, but doesn't drain the temporary vector pool. Now it does :) 