### PR TITLE
filesystem.append didn't append in Unix

### DIFF
--- a/src/core/fs.c
+++ b/src/core/fs.c
@@ -179,7 +179,7 @@ bool fs_open(const char* path, OpenMode mode, fs_handle* file) {
   switch (mode) {
     case OPEN_READ: flags = O_RDONLY; break;
     case OPEN_WRITE: flags = O_WRONLY | O_CREAT | O_TRUNC; break;
-    case OPEN_APPEND: flags = O_WRONLY | O_CREAT; break;
+    case OPEN_APPEND: flags = O_APPEND | O_WRONLY | O_CREAT; break;
     default: return false;
   }
   file->fd = open(path, flags, S_IRUSR | S_IWUSR);


### PR DESCRIPTION
At least on my Linux system it'd overwrite the contents of the file each time.