### PR TITLE
Reverting binding to base

### DIFF
--- a/src/resources/bindings_touch.json
+++ b/src/resources/bindings_touch.json
@@ -11,8 +11,6 @@
          "poses" : [
             { "output" : "/actions/lovr/in/leftHandPose", "path" : "/user/hand/left/pose/raw" },
             { "output" : "/actions/lovr/in/rightHandPose", "path" : "/user/hand/right/pose/raw" },
-            { "output" : "/actions/lovr/in/leftHandPose", "path" : "/user/hand/left/pose/base" },
-            { "output" : "/actions/lovr/in/rightHandPose", "path" : "/user/hand/right/pose/base" },
             { "output" : "/actions/lovr/in/leftHandPoint", "path" : "/user/hand/left/pose/tip" },
             { "output" : "/actions/lovr/in/rightHandPoint", "path" : "/user/hand/right/pose/tip" }
          ],


### PR DESCRIPTION
Now controllers work without https://github.com/bjornbytes/lovr/pull/336 Possibly the testing environment is unreliable. I revert the change, so there is no chance of breaking things for someone else.