### PR TITLE
New API for mic capture

### DIFF
--- a/src/api/l_audio.c
+++ b/src/api/l_audio.c
@@ -24,6 +24,13 @@ static int l_lovrAudioStop(lua_State* L) {
   return 0;
 }
 
+static int l_lovrAudioIsRunning(lua_State* L) {
+  AudioType type = luax_checkenum(L, 1, AudioType, "playback");
+  bool isRunning = lovrAudioIsRunning(type);
+  lua_pushboolean(L, isRunning);
+  return 1;
+}
+
 static int l_lovrAudioGetVolume(lua_State* L) {
   lua_pushnumber(L, lovrAudioGetVolume());
   return 1;
@@ -119,6 +126,7 @@ static int l_lovrAudioSetCaptureFormat(lua_State *L) {
 static const luaL_Reg lovrAudio[] = {
   { "start", l_lovrAudioStart },
   { "stop", l_lovrAudioStop },
+  { "isRunning", l_lovrAudioIsRunning },
   { "getVolume", l_lovrAudioGetVolume },
   { "setVolume", l_lovrAudioSetVolume },
   { "newSource", l_lovrAudioNewSource },

--- a/src/api/l_audio.c
+++ b/src/api/l_audio.c
@@ -11,12 +11,6 @@ StringEntry lovrAudioType[] = {
   { 0 }
 };
 
-StringEntry lovrTimeUnit[] = {
-  [UNIT_SECONDS] = ENTRY("seconds"),
-  [UNIT_SAMPLES] = ENTRY("samples"),
-  { 0 }
-};
-
 static int l_lovrAudioReset(lua_State* L) {
   lovrAudioReset();
   return 0;
@@ -85,37 +79,9 @@ static int l_lovrAudioSetListenerPose(lua_State *L) {
   return 0;
 }
 
-static int l_lovrAudioGetCaptureDuration(lua_State *L) {
-  TimeUnit units = luax_checkenum(L, 1, TimeUnit, "seconds");
-  size_t sampleCount = lovrAudioGetCaptureSampleCount();
-  
-  if (units == UNIT_SECONDS) {
-    lua_pushnumber(L, lovrAudioConvertToSeconds(sampleCount, AUDIO_CAPTURE));
-  } else {
-    lua_pushinteger(L, sampleCount);
-  }
-  return 1;
-}
-
-static int l_lovrAudioCapture(lua_State* L) {
-  int index = 1;
-  
-  size_t samples = lua_type(L, index) == LUA_TNUMBER ? lua_tointeger(L, index++) : lovrAudioGetCaptureSampleCount();
-
-  if (samples == 0) {
-    return 0;
-  }
-
-  SoundData* soundData = luax_totype(L, index++, SoundData);
-  size_t offset = soundData ? luaL_optinteger(L, index, 0) : 0;
-
-  if (soundData) {
-    lovrRetain(soundData);
-  }
-
-  soundData = lovrAudioCapture(samples, soundData, offset);
+static int l_lovrAudioGetCaptureStream(lua_State* L) {
+  SoundData* soundData = lovrAudioGetCaptureStream();
   luax_pushtype(L, SoundData, soundData);
-  lovrRelease(SoundData, soundData);
   return 1;
 }
 
@@ -164,8 +130,7 @@ static const luaL_Reg lovrAudio[] = {
   { "setVolume", l_lovrAudioSetVolume },
   { "newSource", l_lovrAudioNewSource },
   { "setListenerPose", l_lovrAudioSetListenerPose },
-  { "capture", l_lovrAudioCapture },
-  { "getCaptureDuration", l_lovrAudioGetCaptureDuration },
+  { "getCaptureStream", l_lovrAudioGetCaptureStream },
   { "getDevices", l_lovrAudioGetDevices },
   { "useDevice", l_lovrUseDevice },
   { NULL, NULL }

--- a/src/api/l_data_soundData.c
+++ b/src/api/l_data_soundData.c
@@ -39,6 +39,7 @@ static int l_lovrSoundDataRead(lua_State* L) {
   SoundData* source = luax_checktype(L, 1, SoundData);
   int index = 2;
   SoundData* dest = luax_totype(L, index, SoundData);
+  if (dest) index++;
   size_t frameCount = lua_type(L, index) == LUA_TNUMBER ? lua_tointeger(L, index++) : lovrSoundDataGetDuration(source);
   size_t offset = dest ? luaL_optinteger(L, index, 0) : 0;
   bool shouldRelease = false;

--- a/src/api/l_data_soundData.c
+++ b/src/api/l_data_soundData.c
@@ -1,11 +1,64 @@
 #include "api.h"
 #include "data/soundData.h"
 #include "data/blob.h"
+#include "core/ref.h"
+#include <stdlib.h>
+
+StringEntry lovrTimeUnit[] = {
+  [UNIT_SECONDS] = ENTRY("seconds"),
+  [UNIT_SAMPLES] = ENTRY("samples"),
+  { 0 }
+};
 
 static int l_lovrSoundDataGetBlob(lua_State* L) {
   SoundData* soundData = luax_checktype(L, 1, SoundData);
   Blob* blob = soundData->blob;
   luax_pushtype(L, Blob, blob);
+  return 1;
+}
+
+static int l_lovrSoundDataGetDuration(lua_State* L) {
+  SoundData* soundData = luax_checktype(L, 1, SoundData);
+  TimeUnit units = luax_checkenum(L, 2, TimeUnit, "seconds");
+  uint32_t frames = lovrSoundDataGetDuration(soundData);
+  if (units == UNIT_SECONDS) {
+    lua_pushnumber(L, (double) frames / soundData->sampleRate);
+  } else {
+    lua_pushinteger(L, frames);
+  }
+
+  return 1;
+}
+
+static const char *format2string(SampleFormat f) { return f == SAMPLE_I16 ? "i16" : "f32"; }
+
+// soundData:read(dest, {size}, {offset}) -> framesRead
+// soundData:read({size}) -> framesRead
+static int l_lovrSoundDataRead(lua_State* L) {
+  //struct SoundData* soundData, uint32_t offset, uint32_t count, void* data
+  SoundData* source = luax_checktype(L, 1, SoundData);
+  int index = 2;
+  SoundData* dest = luax_totype(L, index, SoundData);
+  size_t frameCount = lua_type(L, index) == LUA_TNUMBER ? lua_tointeger(L, index++) : lovrSoundDataGetDuration(source);
+  size_t offset = dest ? luaL_optinteger(L, index, 0) : 0;
+  bool shouldRelease = false;
+  if (dest == NULL) {
+    dest = lovrSoundDataCreateRaw(frameCount, source->channels, source->sampleRate, source->format, NULL);
+    shouldRelease = true;
+  } else {
+    lovrAssert(dest->channels == source->channels, "Source (%d) and destination (%d) channel counts must match", source->channels, dest->channels);
+    lovrAssert(dest->sampleRate == source->sampleRate, "Source (%d) and destination (%d) sample rates must match", source->sampleRate, dest->sampleRate);
+    lovrAssert(dest->format == source->format, "Source (%s) and destination (%s) formats must match", format2string(source->format), format2string(dest->format));
+    lovrAssert(offset + frameCount <= dest->frames, "Tried to write samples past the end of a SoundData buffer");
+    lovrAssert(dest->blob, "Can't read into a stream destination");
+  }
+
+  size_t outFrames = source->read(source, offset, frameCount, dest->blob->data);
+  dest->frames = outFrames;
+  dest->blob->size = outFrames * SampleFormatBytesPerFrame(dest->channels, dest->format);
+  luax_pushtype(L, SoundData, dest);
+  if (shouldRelease) lovrRelease(SoundData, dest);
+
   return 1;
 }
 
@@ -35,6 +88,8 @@ static int l_lovrSoundDataSetSample(lua_State* L) {
 
 const luaL_Reg lovrSoundData[] = {
   { "getBlob", l_lovrSoundDataGetBlob },
+  { "getDuration", l_lovrSoundDataGetDuration },
+  { "read", l_lovrSoundDataRead },
   { "append", l_lovrSoundDataAppend },
   { "setSample", l_lovrSoundDataSetSample },
   { NULL, NULL }

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -266,6 +266,11 @@ bool lovrAudioStop(AudioType type) {
   return stoppingResult == MA_SUCCESS;
 }
 
+bool lovrAudioIsRunning(AudioType type)
+{
+  return ma_device_get_state(&state.devices[type]) == MA_STATE_STARTED;
+}
+
 float lovrAudioGetVolume() {
   float volume = 0.f;
   ma_device_get_master_volume(&state.devices[AUDIO_PLAYBACK], &volume);

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -116,7 +116,7 @@ static void onPlayback(ma_device* device, void* output, const void* _, uint32_t 
 
 static void onCapture(ma_device* device, void* output, const void* input, uint32_t frames) {
   // note: uses ma_pcm_rb which is lockless
-  size_t bytesPerFrame = SampleFormatBytesPerFrame(CAPTURE_CHANNELS, OUTPUT_FORMAT);
+  size_t bytesPerFrame = SampleFormatBytesPerFrame(CAPTURE_CHANNELS, state.config[AUDIO_CAPTURE].format);
   lovrSoundDataStreamAppendBuffer(state.captureStream, input, frames*bytesPerFrame);
 }
 

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -212,7 +212,7 @@ bool lovrAudioInitDevice(AudioType type) {
     config.capture.format = miniAudioFormatFromLovr[state.config[AUDIO_CAPTURE].format];
     for(int i = 0; i < captureDeviceCount && state.config[AUDIO_CAPTURE].deviceName; i++) {
       if (strcmp(captureDevices[i].name, state.config[AUDIO_CAPTURE].deviceName) == 0) {
-        config.capture.pDeviceID = &playbackDevices[i].id;
+        config.capture.pDeviceID = &captureDevices[i].id;
       }
     }
     if (state.config[AUDIO_CAPTURE].deviceName && config.capture.pDeviceID == NULL) {

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -205,7 +205,7 @@ bool lovrAudioInitDevice(AudioType type) {
 
   if (type == AUDIO_CAPTURE) {
     lovrRelease(SoundData, state.captureStream);
-    state.captureStream = lovrSoundDataCreateStream(state.config[type].sampleRate * 1.0, CAPTURE_CHANNELS, state.config[type].sampleRate, OUTPUT_FORMAT);
+    state.captureStream = lovrSoundDataCreateStream(state.config[type].sampleRate * 1.0, CAPTURE_CHANNELS, state.config[type].sampleRate, state.config[type].format);
     if (!state.captureStream) {
       lovrLog(LOG_WARN, "audio", "Failed to init audio device %d\n", type);
       lovrAudioDestroy();

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -457,7 +457,15 @@ void lovrAudioSetCaptureFormat(SampleFormat format, int sampleRate)
 
 void lovrAudioUseDevice(AudioType type, const char *deviceName) {
   free(state.config[type].deviceName);
-  state.config[type].deviceName = strdup(deviceName);
+
+#ifdef ANDROID
+  // XX<nevyn> miniaudio doesn't seem to be happy to set a specific device an android (fails with
+  // error -2 on device init). Since there is only one playback and one capture device in OpenSL,
+  // we can just set this to NULL and make this call a no-op.
+  deviceName = NULL;
+#endif
+
+  state.config[type].deviceName = deviceName ? strdup(deviceName) : NULL;
 
   // restart device if needed
   ma_uint32 previousState = state.devices[type].state;

--- a/src/modules/audio/audio.h
+++ b/src/modules/audio/audio.h
@@ -33,6 +33,7 @@ bool lovrAudioInit();
 void lovrAudioDestroy(void);
 bool lovrAudioStart(AudioType type);
 bool lovrAudioStop(AudioType type);
+bool lovrAudioIsRunning(AudioType type);
 float lovrAudioGetVolume(void);
 void lovrAudioSetVolume(float volume);
 void lovrAudioSetListenerPose(float position[4], float orientation[4]);

--- a/src/modules/audio/audio.h
+++ b/src/modules/audio/audio.h
@@ -21,11 +21,6 @@ typedef enum {
   SOURCE_STREAM
 } SourceType;
 
-typedef enum {
-  UNIT_SECONDS,
-  UNIT_SAMPLES
-} TimeUnit;
-
 typedef void* AudioDeviceIdentifier;
 
 typedef struct {
@@ -70,8 +65,7 @@ uint32_t lovrSourceGetTime(Source* source);
 void lovrSourceSetTime(Source* source, uint32_t sample);
 struct SoundData* lovrSourceGetSoundData(Source* source);
 
-uint32_t lovrAudioGetCaptureSampleCount();
-struct SoundData* lovrAudioCapture(uint32_t sampleCount, struct SoundData *soundData, uint32_t offset);
+struct SoundData* lovrAudioGetCaptureStream();
 
 void lovrAudioGetDevices(AudioDevice **outDevices, size_t *outCount);
 void lovrAudioUseDevice(AudioDeviceIdentifier identifier, int sampleRate, SampleFormat format);

--- a/src/modules/audio/spatializers/dummy_spatializer.c
+++ b/src/modules/audio/spatializers/dummy_spatializer.c
@@ -39,7 +39,7 @@ void dummy_spatializer_apply(Source* source, mat4 transform, const float* input,
 void dummy_spatializer_setListenerPose(float position[4], float orientation[4]) {
   mat4_identity(state.listener);
   mat4_translate(state.listener, position[0], position[1], position[2]);
-  mat4_rotate(state.listener, orientation[0], orientation[1], orientation[2], orientation[3]);
+  mat4_rotateQuat(state.listener, orientation);
 }
 Spatializer dummySpatializer = {
   dummy_spatializer_init,

--- a/src/modules/data/soundData.c
+++ b/src/modules/data/soundData.c
@@ -66,6 +66,7 @@ static uint32_t lovrSoundDataReadMp3(SoundData* soundData, uint32_t offset, uint
 */
 
 static uint32_t lovrSoundDataReadRing(SoundData* soundData, uint32_t offset, uint32_t count, void* data) {
+  uint8_t *charData = (uint8_t*)data;
   size_t bytesPerFrame = SampleFormatBytesPerFrame(soundData->channels, soundData->format);
   size_t totalRead = 0;
   while(count > 0) {
@@ -73,7 +74,7 @@ static uint32_t lovrSoundDataReadRing(SoundData* soundData, uint32_t offset, uin
     void *store;
     ma_result acquire_status = ma_pcm_rb_acquire_read(soundData->ring, &availableFramesInRing, &store);
     if (acquire_status != MA_SUCCESS) return 0;
-    memcpy(data, store, availableFramesInRing * bytesPerFrame);
+    memcpy(charData, store, availableFramesInRing * bytesPerFrame);
     ma_result commit_status = ma_pcm_rb_commit_read(soundData->ring, availableFramesInRing, store);
     if (commit_status != MA_SUCCESS) return 0;
 
@@ -82,7 +83,7 @@ static uint32_t lovrSoundDataReadRing(SoundData* soundData, uint32_t offset, uin
     }
 
     count -= availableFramesInRing;
-    data += availableFramesInRing * bytesPerFrame;
+    charData += availableFramesInRing * bytesPerFrame;
     totalRead += availableFramesInRing;
   }
   return totalRead;

--- a/src/modules/data/soundData.c
+++ b/src/modules/data/soundData.c
@@ -158,7 +158,7 @@ SoundData* lovrSoundDataCreateFromFile(struct Blob* blob, bool decode) {
 }
 
 size_t lovrSoundDataStreamAppendBlob(SoundData *dest, struct Blob* blob) {
-  lovrSoundDataStreamAppendBuffer(dest, blob->data, blob->size);
+  return lovrSoundDataStreamAppendBuffer(dest, blob->data, blob->size);
 }
 
 size_t lovrSoundDataStreamAppendBuffer(SoundData *dest, const void *buf, size_t byteSize) {

--- a/src/modules/data/soundData.h
+++ b/src/modules/data/soundData.h
@@ -16,6 +16,11 @@ typedef enum {
   SAMPLE_INVALID
 } SampleFormat;
 
+typedef enum {
+  UNIT_SECONDS,
+  UNIT_SAMPLES
+} TimeUnit;
+
 size_t SampleFormatBytesPerFrame(int channelCount, SampleFormat fmt);
 
 typedef struct SoundData {
@@ -35,6 +40,7 @@ SoundData* lovrSoundDataCreateStream(uint32_t bufferSizeInFrames, uint32_t chann
 SoundData* lovrSoundDataCreateFromFile(struct Blob* blob, bool decode);
 
 // returns the number of frames successfully appended (if it's less than the size of blob, the internal ring buffer is full)
+size_t lovrSoundDataStreamAppendBuffer(SoundData *dest, const void *buf, size_t byteSize);
 size_t lovrSoundDataStreamAppendBlob(SoundData *dest, struct Blob* blob);
 size_t lovrSoundDataStreamAppendSound(SoundData *dest, SoundData *src);
 void lovrSoundDataSetSample(SoundData* soundData, size_t index, float value);

--- a/src/modules/headset/headset_pico.c
+++ b/src/modules/headset/headset_pico.c
@@ -224,6 +224,7 @@ static struct {
   arr_t(NativeCanvas) canvases;
   void (*renderCallback)(void*);
   void* renderUserdata;
+  permissionsCallback onPermissionEvent;
 } state;
 
 static bool pico_init(float supersample, float offset, uint32_t msaa) {
@@ -412,6 +413,20 @@ static void pico_renderTo(void (*callback)(void*), void* userdata) {
 
 static void pico_update(float dt) {
   //
+}
+
+void lovrPlatformRequestPermission(Permission permission) {
+  // todo
+}
+
+void lovrPlatformOnPermissionEvent(permissionsCallback callback) {
+  state.onPermissionEvent = callback;
+}
+
+JNIEXPORT void JNICALL Java_org_lovr_app_Activity_lovrPermissionEvent(JNIEnv* jni, jobject activity, jint permission, jboolean granted) {
+  if (state.onPermissionEvent) {
+    state.onPermissionEvent(permission, granted);
+  }
 }
 
 HeadsetInterface lovrHeadsetPicoDriver = {


### PR DESCRIPTION
I realized it's silly to have two separate ring buffer abstractions. Nicer to back mic capture by a proper SoundData. Then I can even move that over a channel to another thread, and read from it without a lock! (E g move mic data _directly_ from audio thread to network thread, without touching main thread).

I think the API is nicer too.

This is based on top of https://github.com/bjornbytes/lovr/pull/347 .