### PR TITLE
Oculus spatializer for miniaudio branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "deps/ode"]
 	path = deps/ode
 	url = https://github.com/bjornbytes/ode
-[submodule "deps/openal-soft"]
-	path = deps/openal-soft
-	url = https://github.com/kcat/openal-soft
 [submodule "deps/openvr"]
 	path = deps/openvr
 	url = https://github.com/ValveSoftware/openvr

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(LOVR_USE_OCULUS "Enable the LibOVR backend for the headset module (be sur
 option(LOVR_USE_VRAPI "Enable the VrApi backend for the headset module" OFF)
 option(LOVR_USE_PICO "Enable the Pico backend for the headset module" OFF)
 option(LOVR_USE_DESKTOP_HEADSET "Enable the keyboard/mouse backend for the headset module" ON)
+option(LOVR_USE_OCULUS_AUDIO "Enable the Oculus Audio spatializer (be sure to also set LOVR_OCULUS_AUDIO_PATH)" OFF)
 option(LOVR_USE_LINUX_EGL "Use the EGL graphics extension on Linux" OFF)
 
 option(LOVR_SYSTEM_ENET "Use the system-provided enet" OFF)
@@ -343,6 +344,36 @@ if(LOVR_ENABLE_AUDIO)
     src/api/l_audio_source.c
     src/lib/miniaudio/miniaudio.c
   )
+
+  if(LOVR_USE_OCULUS_AUDIO)
+    if(NOT LOVR_OCULUS_AUDIO_PATH)
+      message(FATAL_ERROR "LOVR_USE_OCULUS_AUDIO requires the LOVR_OCULUS_AUDIO_PATH to be set to the location of the Oculus Spatializer Native (AudioSDK) folder")
+    endif()
+
+    include_directories("${LOVR_OCULUS_AUDIO_PATH}/Include")
+
+    add_library(OculusAudio SHARED IMPORTED)
+    if (ANDROID)
+      set_target_properties(OculusAudio PROPERTIES IMPORTED_LOCATION "${LOVR_OCULUS_AUDIO_PATH}/Lib/Android/arm64-v8a/libovraudio64.so")
+    elseif(WIN32) # Note: This has *not* been tested.
+      if (CMAKE_GENERATOR_PLATFORM STREQUAL "x64")
+        set_target_properties(OculusAudio PROPERTIES IMPORTED_IMPLIB "${LOVR_OCULUS_AUDIO_PATH}/Lib/x64/ovraudio64.lib")
+        set_target_properties(OculusAudio PROPERTIES IMPORTED_LOCATION "${LOVR_OCULUS_AUDIO_PATH}/Lib/x64/ovraudio64.dll")
+      else () # ARM and ARM64 are also valid values for CMAKE_GENERATOR_PLATFORM but we will ignore this
+        set_target_properties(OculusAudio PROPERTIES IMPORTED_IMPLIB "${LOVR_OCULUS_AUDIO_PATH}/Lib/Win32/ovraudio32.lib")
+        set_target_properties(OculusAudio PROPERTIES IMPORTED_LOCATION "${LOVR_OCULUS_AUDIO_PATH}/Lib/Win32/ovraudio32.dll")
+      endif()
+    elseif (APPLE) # This *might* be possible-- there is a .framework in "macub/" ("universal binary"?)
+      message(FATAL_ERROR "LOVR_USE_OCULUS_AUDIO is not currently supported on Apple platforms")
+    else() # Assume Linux. Note: This has *not* been tested. FIXME: When is the .so copied?
+      set_target_properties(OculusAudio PROPERTIES IMPORTED_LOCATION "${LOVR_OCULUS_AUDIO_PATH}/Lib/Linux64/libovraudio64.so")
+    endif()
+
+    set(LOVR_OCULUS_AUDIO OculusAudio)
+    add_definitions(-DLOVR_ENABLE_OCULUS_AUDIO)
+    target_sources(lovr PRIVATE src/modules/audio/spatializers/oculus_spatializer.c)
+    target_link_libraries(lovr ${LOVR_OCULUS_AUDIO}) # TODO: Reorder?
+  endif()
 endif()
 
 if(LOVR_ENABLE_DATA)
@@ -533,6 +564,7 @@ if(WIN32)
   move_dll(${LOVR_ODE})
   move_dll(${LOVR_OPENVR})
   move_dll(${LOVR_MSDF})
+  move_dll(${LOVR_OCULUS_AUDIO})
   target_compile_definitions(lovr PRIVATE -DLOVR_GL)
 elseif(APPLE)
   target_link_libraries(lovr objc)

--- a/src/api/l_audio.c
+++ b/src/api/l_audio.c
@@ -166,7 +166,7 @@ int luaopen_lovr_audio(lua_State* L) {
   luax_register(L, lovrAudio);
   luax_registertype(L, Source);
 
-  char *spatializer = NULL;
+  const char *spatializer = NULL;
   int spatializerMaxSourcesHint = AUDIO_SPATIALIZER_MAX_SOURCES_HINT;
   luax_pushconf(L);
   lua_getfield(L, -1, "audio");
@@ -190,8 +190,8 @@ int luaopen_lovr_audio(lua_State* L) {
 
   // First config is for output device, second is for input device
   AudioDeviceConfig deviceConfig[2] = {
-    { .enable = true, .start = true },
-    { .enable = false, .start = false }
+    [AUDIO_PLAYBACK] = { .enable = true, .start = true },
+    [AUDIO_CAPTURE] = { .enable = false, .start = false }
   };
   if (lovrAudioInit(config, deviceConfig)) {
     luax_atexit(L, lovrAudioDestroy);

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -90,7 +90,7 @@ static int generateSource(Source* source, float* output, uint32_t count) {
   ma_uint64 framesIn = 0;
   while (framesIn < count) { // Read from source until raw buffer filled
     ma_uint64 framesRequested = count - framesIn;
-    // FIXME: Buffer size math will break (crash) if channels > 1
+    // FIXME: Buffer size math will break (crash) if channels > 2
     ma_uint64 framesRead = source->sound->read(source->sound, source->offset, framesRequested,
       raw + framesIn * SampleFormatBytesPerFrame(source->sound->channels, source->sound->format));
     framesIn += framesRead;

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -19,7 +19,10 @@ static const ma_format miniAudioFormatFromLovr[] = {
 #define OUTPUT_FORMAT SAMPLE_F32
 #define OUTPUT_CHANNELS 2
 #define CAPTURE_CHANNELS 1
-#define CAPTURE_BUFFER_SIZE ((int)(LOVR_AUDIO_SAMPLE_RATE * 1.0))
+
+#define CALLBACK_PERIODS 3
+#define PERIOD_LENGTH 128
+#define CALLBACK_LENGTH (PERIOD_LENGTH*CALLBACK_PERIODS)
 
 //#define LOVR_DEBUG_AUDIOTAP
 #ifdef LOVR_DEBUG_AUDIOTAP
@@ -39,7 +42,9 @@ struct Source {
   bool playing;
   bool looping;
   bool spatial;
-  float transform[16];
+  float position[4];
+  float orientation[4];
+  intptr_t spatializerMemo; // Spatializer can put anything it wants here
 };
 
 static inline int outputChannelCountForSource(Source *source) { return source->spatial ? 1 : OUTPUT_CHANNELS; }
@@ -47,13 +52,19 @@ static inline int outputChannelCountForSource(Source *source) { return source->s
 static struct {
   bool initialized;
   ma_context context;
-  AudioConfig config[AUDIO_TYPE_COUNT];
+  AudioDeviceConfig deviceConfig[AUDIO_TYPE_COUNT];
   ma_device devices[AUDIO_TYPE_COUNT];
   ma_mutex playbackLock;
   Source* sources;
   ma_pcm_rb captureRingbuffer;
   arr_t(ma_data_converter*) converters;
   Spatializer* spatializer;
+  bool fixedBuffer;
+  uint32_t bufferSize;
+  float *scratchBuffer1, *scratchBuffer2; // Used internally by mix(). Contains bufferSize stereo frames.
+  float *persistBuffer;  // If fixedBuffer, preserves excess audio between frames.
+  float *persistBufferContent; // Pointer into persistBuffer
+  uint32_t persistBufferRemaining; // In fixedBuffer mode, how much of the previous frame's mixBuffer was consumed?
 
 #ifdef LOVR_DEBUG_AUDIOTAP
   bool audiotapWriting;
@@ -62,71 +73,151 @@ static struct {
 
 // Device callbacks
 
-static bool mix(Source* source, float* output, uint32_t count) {
-  float raw[2048];
-  float aux[2048];
-  float mix[4096];
-
-  // TODO
-  // frameLimitIn =
-  // frameLimitOut =
-
-  while (count > 0) {
-    uint32_t chunk = MIN(sizeof(raw) / SampleFormatBytesPerFrame(source->sound->channels, source->sound->format),
-        ma_data_converter_get_required_input_frame_count(source->converter, count));
-        // ^^^ Note need to min `count` with 'capacity of aux buffer' and 'capacity of mix buffer'
-        // could skip min-ing with one of the buffers if you can guarantee that one is bigger/equal to the other (you can because their formats are known)
-    ma_uint64 framesIn = source->sound->read(source->sound, source->offset, chunk, raw);
-    ma_uint64 framesOut = sizeof(aux) / (sizeof(float) * outputChannelCountForSource(source));
-
-    ma_data_converter_process_pcm_frames(source->converter, raw, &framesIn, aux, &framesOut);
-
-    if (source->spatial) {
-      state.spatializer->apply(source, source->transform, aux, mix, framesOut);
-    } else {
-      memcpy(mix, aux, framesOut * SampleFormatBytesPerFrame(OUTPUT_CHANNELS, SAMPLE_F32));
-    }
-
-    for (uint32_t i = 0; i < framesOut * OUTPUT_CHANNELS; i++) {
-      output[i] += mix[i] * source->volume;
-    }
-
-    if (framesIn == 0) {
-      source->offset = 0;
-      if (!source->looping) {
-        source->playing = false;
-        return false;
-      }
-    } else {
-      source->offset += framesIn;
-    }
-
-    count -= framesOut;
-    output += framesOut * OUTPUT_CHANNELS;
+// Return value is number of stereo frames in buffer
+// Note: output is always equal to scratchBuffer1. This saves a little memory but is ugly.
+//       count is always less than or equal to the size of scratchBuffer1
+static int generateSource(Source* source, float* output, uint32_t count) {
+  char *raw; float *aux; // Scratch buffers: Raw generated audio from source; converted to float by converter
+  if (source->spatial) { // In spatial mode, raw and aux are mono and only output is stereo
+    raw = (char *)state.scratchBuffer1;
+    aux = state.scratchBuffer2;
+  } else {               // Otherwise, the data converter will produce stereo and aux=output is stereo
+    raw = (char *)state.scratchBuffer2;
+    aux = output;
   }
 
-  return true;
+  bool sourceFinished = false;
+  ma_uint64 framesIn = 0;
+  while (framesIn < count) { // Read from source until raw buffer filled
+    ma_uint64 framesRequested = count - framesIn;
+    // FIXME: Buffer size math will break (crash) if channels > 1
+    ma_uint64 framesRead = source->sound->read(source->sound, source->offset, framesRequested,
+      raw + framesIn * SampleFormatBytesPerFrame(source->sound->channels, source->sound->format));
+    framesIn += framesRead;
+    if (framesRead < framesRequested) {
+      source->offset = 0;
+      if (!source->looping) { // Source has reached its final end
+        sourceFinished = true;
+        break;
+      }
+    } else {
+      source->offset += framesRead;
+    }
+  }
+  // 1 channel for spatial, 2 otherwise
+  ma_uint64 framesConverted = framesIn * outputChannelCountForSource(source);
+
+  // We assume framesConverted is not changed by calling this and discard its value
+  ma_data_converter_process_pcm_frames(source->converter, raw, &framesIn, aux, &framesConverted);
+
+  ma_uint64 framesOut = framesIn;
+
+  if (source->spatial) {
+    // Fixed buffer mode we have to pad buffer with silence if it underran
+    if (state.fixedBuffer && sourceFinished) {
+      memset(aux + framesIn, 0, (count - framesIn)*sizeof(float)); // Note always mono
+      framesOut = count;
+    }
+    framesOut = state.spatializer->apply(source, aux, output, framesIn, framesOut);
+  }
+
+  if (sourceFinished) {
+    lovrSourcePause(source);
+  }
+
+  return framesOut;
 }
 
-static void onPlayback(ma_device* device, void* output, const void* _, uint32_t count) {
+static void onPlayback(ma_device* device, void* outputUntyped, const void* _, uint32_t count) {
+  float *output = outputUntyped;
+
 #ifdef LOVR_DEBUG_AUDIOTAP
   int originalCount = count;
 #endif
 
-    ma_mutex_lock(&state.playbackLock);
+//  printf("Persist buffer remaining %d, Count %d\n", state.persistBufferRemaining, count); // Can't call lovrLog from audio thread
 
-  // For each Source, remove it if it isn't playing or process it and remove it if it stops
-  for (Source** list = &state.sources, *source = *list; source != NULL; source = *list) {
-    if (source->playing && mix(source, output, count)) {
-      list = &source->next;
-    } else {
-      *list = source->next;
-      source->tracked = false;
-      lovrRelease(Source, source);
-    }
+  // This case means we are in fixedBuffer mode and there was excess data generated last frame
+  if (state.persistBufferRemaining > 0) {
+    uint32_t persistConsumed = MIN(count, state.persistBufferRemaining);
+    memcpy(output, state.persistBufferContent, persistConsumed*OUTPUT_CHANNELS*sizeof(float)); // Stereo frames
+    // Move forward both the persistBufferContent and output pointers so the right thing happens regardless of which is larger
+    // persistBufferRemaining being larger than count is deeply unlikely, but it is not impossible
+    state.persistBufferContent += persistConsumed*OUTPUT_CHANNELS;
+    state.persistBufferRemaining -= persistConsumed;
+    output += persistConsumed*OUTPUT_CHANNELS;
+    count -= persistConsumed;
   }
 
-  ma_mutex_unlock(&state.playbackLock);
+  while (count > 0) { // Mixing will be done in a series of passes
+    ma_mutex_lock(&state.playbackLock);
+
+    // Usually we mix directly into the output buffer.
+    // But if we're in fixed buffer mode and the fixed buffer size is bigger than output,
+    // we mix into persistBuffer and save the excess until next onPlayback() call.
+    uint32_t passSize;
+    float *mixBuffer;
+    bool usingPersistBuffer;
+    if (state.fixedBuffer) {
+      usingPersistBuffer = state.bufferSize > count;
+      passSize = state.bufferSize;
+      if (usingPersistBuffer) {
+        mixBuffer = state.persistBuffer;
+        state.persistBufferRemaining = state.bufferSize;
+        memset(mixBuffer, 0, state.bufferSize*sizeof(float)*OUTPUT_CHANNELS);
+      } else {
+        mixBuffer = output;
+        state.persistBufferRemaining = 0;
+      }
+    } else {
+      usingPersistBuffer = false;
+      mixBuffer = output;
+      passSize = MIN(count, state.bufferSize); // In non-fixedBuffer mode we can use a buffer smaller than bufferSize, but not larger
+    }
+
+    // For each Source, remove it if it isn't playing or process it and remove it if it stops
+    for (Source** list = &state.sources, *source = *list; source != NULL; source = *list) {
+      bool playing = source->playing;
+      if (playing) {
+        // Generate audio
+        uint32_t generated = generateSource(source, state.scratchBuffer1, passSize);
+        playing = source->playing; // Can change during generateSource
+
+        // Mix and apply volume
+        for (uint32_t i = 0; i < generated * OUTPUT_CHANNELS; i++) {
+          mixBuffer[i] += state.scratchBuffer1[i] * source->volume;
+        }
+      }
+
+      // Iterate/manage list
+      if (playing) {
+        list = &source->next;
+      } else {
+        *list = source->next;
+        source->tracked = false;
+        lovrRelease(Source, source);
+      }
+    }
+    {
+      uint32_t tailGenerated = state.spatializer->tail(state.scratchBuffer2, state.scratchBuffer1, passSize);
+      // Mix tail
+      for (uint32_t i = 0; i < tailGenerated * OUTPUT_CHANNELS; i++) {
+        mixBuffer[i] += state.scratchBuffer1[i];
+      }
+    }
+    ma_mutex_unlock(&state.playbackLock);
+
+    if (usingPersistBuffer) { // Copy persist buffer into output (if needed)
+      // Remember, in this scenario state.persistBuffer is mixBuffer and we just overwrote it in full
+      memcpy(output, state.persistBuffer, count * OUTPUT_CHANNELS * sizeof(float));
+      state.persistBufferContent = state.persistBuffer + count * OUTPUT_CHANNELS;
+      state.persistBufferRemaining -= count;
+      count = 0;
+    } else {
+      output += passSize * OUTPUT_CHANNELS;
+      count -= passSize;
+    }
+  }
 
 #ifdef LOVR_DEBUG_AUDIOTAP
   if (state.audiotapWriting)
@@ -158,15 +249,18 @@ static void onCapture(ma_device* device, void* outputUntyped, const void* inputU
 static const ma_device_callback_proc callbacks[] = { onPlayback, onCapture };
 
 static Spatializer *spatializers[] = {
+#ifdef LOVR_ENABLE_OCULUS_AUDIO
+  &oculusSpatializer,
+#endif
   &dummySpatializer,
 };
 
 // Entry
 
-bool lovrAudioInit(AudioConfig config[2]) {
+bool lovrAudioInit(AudioConfig config, AudioDeviceConfig deviceConfig[2]) {
   if (state.initialized) return false;
 
-  memcpy(state.config, config, sizeof(state.config));
+  memcpy(state.deviceConfig, deviceConfig, sizeof(state.deviceConfig));
 
   if (ma_context_init(NULL, 0, NULL, &state.context)) {
     return false;
@@ -177,8 +271,36 @@ bool lovrAudioInit(AudioConfig config[2]) {
 
   lovrAudioReset();
 
+  SpatializerConfigIn spatializerConfigIn = {
+    .maxSourcesHint = config.spatializerMaxSourcesHint,
+    .fixedBuffer=CALLBACK_LENGTH,
+    .sampleRate=LOVR_AUDIO_SAMPLE_RATE
+  };
+  SpatializerConfigOut spatializerConfigOut = {0};
+  // Find first functioning spatializer
+  for (size_t i = 0; i < sizeof(spatializers) / sizeof(spatializers[0]); i++) {
+    if (config.spatializer && strcmp(config.spatializer, spatializers[i]->name))
+      continue; // If a name was provided, only match spatializers with that exact name
+    if (spatializers[i]->init(spatializerConfigIn, &spatializerConfigOut)) {
+      state.spatializer = spatializers[i];
+      break;
+    }
+  }
+  lovrAssert(state.spatializer != NULL, "Must have at least one spatializer");
+
+  state.fixedBuffer = spatializerConfigOut.needFixedBuffer;
+  state.bufferSize = state.fixedBuffer ? CALLBACK_LENGTH : 1024;
+  state.scratchBuffer1 = malloc(state.bufferSize*sizeof(float)*OUTPUT_CHANNELS);
+  state.scratchBuffer2 = malloc(state.bufferSize*sizeof(float)*OUTPUT_CHANNELS);
+  if (state.fixedBuffer)
+    state.persistBuffer = malloc(state.bufferSize*sizeof(float)*OUTPUT_CHANNELS);
+  state.persistBufferRemaining = 0;
+
+  arr_init(&state.converters);
+
+  // FIXME: This starts the audio. This is a recent change. Should this happen so early?
   for (int i = 0; i < AUDIO_TYPE_COUNT; i++) {
-    if (config[i].enable && config[i].start) {
+    if (deviceConfig[i].enable && deviceConfig[i].start) {
       int startStatus = ma_device_start(&state.devices[i]);
       if(startStatus != MA_SUCCESS) {
         lovrAudioDestroy();
@@ -193,16 +315,6 @@ bool lovrAudioInit(AudioConfig config[2]) {
     lovrAudioDestroy();
     return false;
   }
-
-  for (size_t i = 0; i < sizeof(spatializers) / sizeof(spatializers[0]); i++) {
-    if (spatializers[i]->init()) {
-      state.spatializer = spatializers[i];
-      break;
-    }
-  }
-  lovrAssert(state.spatializer != NULL, "Must have at least one spatializer");
-
-  arr_init(&state.converters);
 
 #ifdef LOVR_DEBUG_AUDIOTAP
   lovrFilesystemWrite("lovrDebugAudio.raw", NULL, 0, false); // Erase file
@@ -225,6 +337,9 @@ void lovrAudioDestroy() {
   }
   arr_free(&state.converters);
   memset(&state, 0, sizeof(state));
+  free(state.scratchBuffer1); state.scratchBuffer1 = NULL;
+  free(state.scratchBuffer2); state.scratchBuffer2 = NULL;
+  free(state.persistBuffer);  state.persistBuffer = NULL;
 
 #ifdef LOVR_DEBUG_AUDIOTAP
   state.audiotapWriting = false;
@@ -241,6 +356,8 @@ bool lovrAudioInitDevice(AudioType type) {
   config.playback.channels = OUTPUT_CHANNELS;
   config.capture.channels = CAPTURE_CHANNELS;
   config.dataCallback = callbacks[type];
+  config.periodSizeInFrames = PERIOD_LENGTH;
+  config.periods = 3;
   config.performanceProfile = ma_performance_profile_low_latency;
 
   int err = ma_device_init(&state.context, &config, &state.devices[type]); 
@@ -259,7 +376,7 @@ bool lovrAudioReset() {
     }
 
     // .. and create new one
-    if (state.config[i].enable) {
+    if (state.deviceConfig[i].enable) {
       lovrAudioInitDevice(i);
     }
   }
@@ -268,7 +385,7 @@ bool lovrAudioReset() {
 }
 
 bool lovrAudioStart(AudioType type) {
-  if (state.config[type].enable == false) {
+  if (state.deviceConfig[type].enable == false) {
     if (lovrAudioInitDevice(type) == false) {
       if (type == AUDIO_CAPTURE) {
         lovrPlatformRequestPermission(AUDIO_CAPTURE_PERMISSION);
@@ -276,7 +393,7 @@ bool lovrAudioStart(AudioType type) {
       }
       return false;
     }
-    state.config[type].enable = state.config[type].start = true;
+    state.deviceConfig[type].enable = state.deviceConfig[type].start = true;
   }
   int status = ma_device_start(&state.devices[type]);
   return status == MA_SUCCESS;
@@ -340,14 +457,15 @@ Source* lovrSourceCreate(SoundData* sound, bool spatial) {
   source->volume = 1.f;
   
   source->spatial = spatial;
-  mat4_identity(source->transform);
   _lovrSourceAssignConverter(source);
+  state.spatializer->sourceCreate(source);
 
   return source;
 }
 
 void lovrSourceDestroy(void* ref) {
   Source* source = ref;
+  state.spatializer->sourceDestroy(source);
   lovrRelease(SoundData, source->sound);
 }
 
@@ -404,10 +522,14 @@ bool lovrSourceGetSpatial(Source *source) {
 
 void lovrSourceSetPose(Source *source, float position[4], float orientation[4]) {
   ma_mutex_lock(&state.playbackLock);
-  mat4_identity(source->transform);
-  mat4_translate(source->transform, position[0], position[1], position[2]);
-  mat4_rotate(source->transform, orientation[0], orientation[1], orientation[2], orientation[3]);
+  memcpy(source->position, position, sizeof(source->position));
+  memcpy(source->orientation, orientation, sizeof(source->orientation));
   ma_mutex_unlock(&state.playbackLock);
+}
+
+void lovrSourceGetPose(Source *source, float position[4], float orientation[4]) {
+  memcpy(position, source->position, sizeof(source->position));
+  memcpy(orientation, source->orientation, sizeof(source->orientation));
 }
 
 uint32_t lovrSourceGetTime(Source* source) {
@@ -478,4 +600,12 @@ struct SoundData* lovrAudioCapture(uint32_t frameCount, SoundData *soundData, ui
   }
 
   return soundData;
+}
+
+intptr_t *lovrSourceGetSpatializerMemoField(Source *source) {
+  return &source->spatializerMemo;
+}
+
+const char *lovrSourceGetSpatializerName() {
+  return state.spatializer->name;
 }

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -113,8 +113,9 @@ static void onPlayback(ma_device* device, void* output, const void* _, uint32_t 
   ma_mutex_unlock(&state.playbackLock);
 }
 
-static void onCapture(ma_device* device, void* output, const void* input, uint32_t frames) {
+static void onCapture(ma_device* device, void* outputUntyped, const void* inputUntyped, uint32_t frames) {
   // note: ma_pcm_rb is lockless
+  const float *input = inputUntyped;
   void *store;
   size_t bytesPerFrame = SampleFormatBytesPerFrame(CAPTURE_CHANNELS, OUTPUT_FORMAT);
   while(frames > 0) {
@@ -436,7 +437,7 @@ struct SoundData* lovrAudioCapture(uint32_t frameCount, SoundData *soundData, ui
       lovrAssert(false, "Failed to acquire ring buffer for read: %d\n", acquire_status);
       return NULL;
     }
-    memcpy(soundData->blob->data + offset * bytesPerFrame, store, availableFramesInRB * bytesPerFrame);
+    memcpy(((unsigned char *)soundData->blob->data) + offset * bytesPerFrame, store, availableFramesInRB * bytesPerFrame);
     ma_result commit_status = ma_pcm_rb_commit_read(&state.captureRingbuffer, availableFramesInRB, store);
     if (commit_status != MA_SUCCESS) {
       lovrAssert(false, "Failed to commit ring buffer for read: %d\n", acquire_status);

--- a/src/modules/audio/audio.h
+++ b/src/modules/audio/audio.h
@@ -25,15 +25,20 @@ typedef enum {
 } TimeUnit;
 
 typedef struct {
+  char *spatializer; // Owned by caller
+  int spatializerMaxSourcesHint;
+} AudioConfig;
+
+typedef struct {
   bool enable;
   bool start;
-} AudioConfig;
+} AudioDeviceConfig;
 
 #ifndef LOVR_AUDIO_SAMPLE_RATE
 #  define LOVR_AUDIO_SAMPLE_RATE 44100
 #endif
 
-bool lovrAudioInit(AudioConfig config[2]);
+bool lovrAudioInit(AudioConfig config, AudioDeviceConfig deviceConfig[2]);
 void lovrAudioDestroy(void);
 bool lovrAudioReset(void);
 bool lovrAudioStart(AudioType type);
@@ -54,9 +59,12 @@ float lovrSourceGetVolume(Source* source);
 void lovrSourceSetVolume(Source* source, float volume);
 bool lovrSourceGetSpatial(Source *source);
 void lovrSourceSetPose(Source *source, float position[4], float orientation[4]);
+void lovrSourceGetPose(Source *source, float position[4], float orientation[4]);
 uint32_t lovrSourceGetTime(Source* source);
 void lovrSourceSetTime(Source* source, uint32_t sample);
 struct SoundData* lovrSourceGetSoundData(Source* source);
+const char *lovrSourceGetSpatializerName();
+intptr_t *lovrSourceGetSpatializerMemoField(Source *source);
 
 uint32_t lovrAudioGetCaptureSampleCount();
 struct SoundData* lovrAudioCapture(uint32_t sampleCount, struct SoundData *soundData, uint32_t offset);

--- a/src/modules/audio/audio.h
+++ b/src/modules/audio/audio.h
@@ -25,7 +25,7 @@ typedef enum {
 } TimeUnit;
 
 typedef struct {
-  char *spatializer; // Owned by caller
+  const char *spatializer; // Owned by caller
   int spatializerMaxSourcesHint;
 } AudioConfig;
 

--- a/src/modules/audio/spatializer.h
+++ b/src/modules/audio/spatializer.h
@@ -2,14 +2,46 @@
 #include "core/maf.h"
 
 typedef struct {
-  bool (*init)(void);
+	int maxSourcesHint;
+	int fixedBuffer;
+	int sampleRate;
+} SpatializerConfigIn;
+
+typedef struct {
+	bool needFixedBuffer;
+} SpatializerConfigOut;
+
+typedef struct {
+  // return true on success
+  bool (*init)(SpatializerConfigIn configIn, SpatializerConfigOut *configOut);
   void (*destroy)(void);
-  void (*apply)(Source* source, mat4 transform, const float* input /*mono*/, float* output/*stereo*/, uint32_t frames);
+
+  // input is mono, output is interleaved stereo, framesIn is mono frames, framesOut is stereo frames.
+  // Safe to assume framesIn == framesOut unless spatializer requests needFixedBuffer.
+  // Return value is number of samples written into output.
+  uint32_t (*apply)(Source* source, const float* input, float* output, uint32_t framesIn, uint32_t framesOut);
+  // called at end of frame for any "additional noise", like echo.
+  // output is stereo, frames is stereo frames, scratch is a buffer the length of output (in case that helps)
+  // return value is number of stereo frames written.
+  uint32_t (*tail)(float *scratch, float* output, uint32_t frames);
+
   void (*setListenerPose)(float position[4], float orientation[4]);
+
+  void (*sourceCreate)(Source *source);
+  void (*sourceDestroy)(Source *source);
+
   const char *name;
 } Spatializer;
 
-bool dummy_spatializer_init(void);
+bool dummy_spatializer_init(SpatializerConfigIn configIn, SpatializerConfigOut *configOut);
 void dummy_spatializer_destroy(void);
-void dummy_spatializer_apply(Source* source, mat4 transform, const float* input, float* output, uint32_t frames);
+uint32_t dummy_spatializer_source_apply(Source* source, const float* input, float* output, uint32_t framesIn, uint32_t framesOut);
+uint32_t dummy_spatializer_tail(float *scratch, float* output, uint32_t frames);
+void dummy_spatializer_setListenerPose(float position[4], float orientation[4]);
+void dummy_spatializer_source_create(Source *);
+void dummy_spatializer_source_destroy(Source *);
 extern Spatializer dummySpatializer;
+
+#ifdef LOVR_ENABLE_OCULUS_AUDIO
+extern Spatializer oculusSpatializer;
+#endif

--- a/src/modules/audio/spatializers/dummy_spatializer.c
+++ b/src/modules/audio/spatializers/dummy_spatializer.c
@@ -4,7 +4,7 @@ struct {
   float listener[16];
 } state;
 
-bool dummy_spatializer_init(void)
+bool dummy_spatializer_init(SpatializerConfigIn configIn, SpatializerConfigOut *configOut)
 {
   mat4_identity(state.listener);
   return true;
@@ -13,16 +13,17 @@ void dummy_spatializer_destroy(void)
 {
 
 }
-void dummy_spatializer_apply(Source* source, mat4 transform, const float* input, float* output, uint32_t frames) {
-  float sourcePos[4] = {0};
-  mat4_transform(transform, sourcePos);
+
+uint32_t dummy_spatializer_source_apply(Source* source, const float* input, float* output, uint32_t frames, uint32_t _frames) {
+  float sourcePos[4], sourceOrientation[4];
+  lovrSourceGetPose(source, sourcePos, sourceOrientation);
 
   float listenerPos[4] = {0};
   mat4_transform(state.listener, listenerPos);
 
   float distance = vec3_distance(sourcePos, listenerPos);
-  float leftEar[4] = {-0.1,0,0,1};
-  float rightEar[4] = {0.1,0,0,1};
+  float leftEar[4]  = {-0.1f, 0.0f, 0.0f, 1.0f};
+  float rightEar[4] = { 0.1f, 0.0f, 0.0f, 1.0f};
   mat4_transform(state.listener, leftEar);
   mat4_transform(state.listener, rightEar);
   float ldistance = vec3_distance(sourcePos, leftEar);
@@ -31,20 +32,32 @@ void dummy_spatializer_apply(Source* source, mat4 transform, const float* input,
   float leftAttenuation = 0.5 + (rdistance-ldistance)*2.5;
   float rightAttenuation = 0.5 + (ldistance-rdistance)*2.5;
 
-  for(int i = 0; i < frames; i++) {
+  for(unsigned int i = 0; i < frames; i++) {
     output[i*2] = input[i] * distanceAttenuation * leftAttenuation;
     output[i*2+1] = input[i] * distanceAttenuation * rightAttenuation;
   }
+
+  return frames;
+}
+uint32_t dummy_spatializer_tail(float *scratch, float* output, uint32_t frames) {
+  return 0;
 }
 void dummy_spatializer_setListenerPose(float position[4], float orientation[4]) {
   mat4_identity(state.listener);
   mat4_translate(state.listener, position[0], position[1], position[2]);
   mat4_rotate(state.listener, orientation[0], orientation[1], orientation[2], orientation[3]);
 }
+void dummy_spatializer_source_create(Source *source) {
+}
+void dummy_spatializer_source_destroy(Source *source) {
+}
 Spatializer dummySpatializer = {
   dummy_spatializer_init,
   dummy_spatializer_destroy,
-  dummy_spatializer_apply,
+  dummy_spatializer_source_apply,
+  dummy_spatializer_tail,
   dummy_spatializer_setListenerPose,
+  dummy_spatializer_source_create,
+  dummy_spatializer_source_destroy,
   "dummy"
 };

--- a/src/modules/audio/spatializers/oculus_spatializer.c
+++ b/src/modules/audio/spatializers/oculus_spatializer.c
@@ -103,6 +103,8 @@ static uint32_t oculus_spatializer_source_apply(Source* source, const float* inp
   }
 
   // This source doesn't have a record. If it's playing, try to assign it one.
+  // If there are no free source records, we will simply not play the sound,
+  // but if there's a record which is only playing a tail, in *that* case we will override the tail.
   if (idx < 0 && lovrSourceIsPlaying(source)) {
     if (state.occupiedCount < state.sourceMax) { // There's an empty slot
       for (idx = 0; idx < state.sourceMax; idx++)
@@ -208,7 +210,8 @@ static void oculus_spatializer_source_create(Source *source) {
 }
 static void oculus_spatializer_source_destroy(Source *source) {
   intptr_t *spatializerMemo = lovrSourceGetSpatializerMemoField(source);
-  state.sources[*spatializerMemo].source = NULL;
+  if (*spatializerMemo >= 0)
+    state.sources[*spatializerMemo].source = NULL;
 }
 Spatializer oculusSpatializer = {
   oculus_spatializer_init,

--- a/src/modules/audio/spatializers/oculus_spatializer.c
+++ b/src/modules/audio/spatializers/oculus_spatializer.c
@@ -154,6 +154,7 @@ static uint32_t oculus_spatializer_source_apply(Source* source, const float* inp
 static uint32_t oculus_spatializer_tail(float *scratch, float* output, uint32_t frames) {
   bool didAnything = false;
   for (int idx = 0; idx < state.sourceMax; idx++) {
+    // If a sound is finished, feed in NULL input on its index until reverb tail completes.
     if (state.sources[idx].occupied && !state.sources[idx].usedSourceThisPlayback) {
       uint32_t outStatus = 0;
       if (!didAnything) {
@@ -164,7 +165,7 @@ static uint32_t oculus_spatializer_tail(float *scratch, float* output, uint32_t 
       if (outStatus & ovrAudioSpatializationStatus_Finished) {
         state.sources[idx].occupied = false;
       }
-      for(int i = 0; i < frames*2; i++) {
+      for(unsigned int i = 0; i < frames*2; i++) {
         output[i] += scratch[i];
       }
     }

--- a/src/modules/audio/spatializers/oculus_spatializer.c
+++ b/src/modules/audio/spatializers/oculus_spatializer.c
@@ -1,0 +1,222 @@
+#include "audio/audio.h"
+#include "audio/spatializer.h"
+#include "lib/miniaudio/miniaudio.h"
+#include "oculus_spatializer_math_shim.h"
+#include "OVR_Audio.h"
+#include <stdlib.h>
+
+typedef struct {
+  Source* source;
+  bool usedSourceThisPlayback; // If true source was non-NULL at some point between midPlayback going high and tail()
+  bool occupied; // If true either source->playing or Oculus Audio is doing an echo tailoff
+} SourceRecord;
+
+struct {
+  uint32_t sampleRate;
+
+  ovrAudioContext context;
+  SourceRecord *sources;
+  int sourceMax;   // Maximum allowed simultaneous sources
+
+  int sourceCount; // Number of active sources seen this playback
+  int occupiedCount; // Number of sources+tailoffs seen this playback (ie strictly gte sourceCount)
+  bool midPlayback; // An onPlayback callback is in progress
+
+  bool poseUpdated; // setListenerPose has been called since the last playback
+  ovrPoseStatef pose;
+  ma_mutex poseLock; // Using ma_mutex in case holding a lovr lock inside a ma lock is weird
+  bool poseLockInited;
+} state;
+
+static bool oculus_spatializer_init(SpatializerConfigIn configIn, SpatializerConfigOut *configOut)
+{
+  // Initialize own state
+  state.sampleRate = configIn.sampleRate;
+  configOut->needFixedBuffer = true;
+  state.sourceMax = configIn.maxSourcesHint;
+  state.sources = calloc(state.sourceMax, sizeof(SourceRecord));
+
+  if (!state.poseLockInited) {
+    int mutexStatus = ma_mutex_init(&state.poseLock);
+    lovrAssert(mutexStatus == MA_SUCCESS, "Failed to create audio mutex");
+    state.poseLockInited = true;
+  }
+
+  // Initialize Oculus
+  ovrAudioContextConfiguration config = {0};
+
+  config.acc_Size = sizeof( config );
+  config.acc_MaxNumSources = state.sourceMax;
+  config.acc_SampleRate = state.sampleRate;
+  config.acc_BufferLength = configIn.fixedBuffer; // Stereo
+
+  if ( ovrAudio_CreateContext( &state.context, &config ) != ovrSuccess )
+  {
+    return false;
+  }
+
+  return true;
+}
+static void oculus_spatializer_destroy(void)
+{
+  free(state.sources);
+  state.sources = NULL;
+}
+static uint32_t oculus_spatializer_source_apply(Source* source, const float* input, float* output, uint32_t framesIn, uint32_t framesOut) {
+  if (!state.midPlayback) { // Run this code only on the first Source of a playback
+    state.midPlayback = true;
+
+    for(int idx = 0; idx < state.sourceMax; idx++) { // Clear presence tracking and get starting positions
+      SourceRecord *record = &state.sources[idx];
+      record->usedSourceThisPlayback = false;
+      if (record->source)
+        state.sourceCount++;
+      if (record->occupied)
+        state.occupiedCount++;
+    }
+
+    if (state.poseUpdated) {
+      { // Tell Oculus Audio where the headset is
+        ovrPoseStatef pose;
+
+        ma_mutex_lock(&state.poseLock); // Do nothing inside lock but make a copy of the pose
+        memcpy(&pose, &state.pose, sizeof(pose));
+        state.poseUpdated = false;
+        ma_mutex_unlock(&state.poseLock);
+
+        ovrAudio_SetListenerPoseStatef(state.context, &pose); // Upload pose
+      }
+      state.poseUpdated = false;
+    }
+  }
+
+  intptr_t *spatializerMemo = lovrSourceGetSpatializerMemoField(source);
+
+  // Lovr allows for an unlimited number of simultaneous sources but OculusAudio makes us predeclare a limit.
+  // We maintain a list of sources and keep the index each source is associated with in its memo field.
+  // So that spatializers don't need to be notified of pauses and unpauses, we assign fields anew each onPlayback call.
+  int idx = *spatializerMemo;
+
+  // This source had a record, but we gave it away.
+  if (idx >= 0 && state.sources[idx].source != source) {
+    idx = *spatializerMemo = -1;
+  }
+
+  // This source doesn't have a record. If it's playing, try to assign it one.
+  if (idx < 0 && lovrSourceIsPlaying(source)) {
+    if (state.occupiedCount < state.sourceMax) { // There's an empty slot
+      for (idx = 0; idx < state.sourceMax; idx++)
+        if (!state.sources[idx].occupied) // Claim the first unoccupied slot
+          break;
+    } else if (state.sourceCount < state.sourceMax) { // There's a slot doing a tail
+      for (idx = 0; idx < state.sourceMax; idx++)
+        if (!state.sources[idx].occupied // Claim the first unsourced slot
+         && !state.sources[idx].usedSourceThisPlayback) // Does OculusAudio allow reusing indexes within a playback? Let's guess no for now.
+          break;
+    }
+
+    if (idx >= 0) { // Successfully assigned
+      *spatializerMemo = idx;
+      state.sourceCount++;
+      state.occupiedCount++;
+      state.sources[idx].source = source;
+      state.sources[idx].occupied = true;
+      ovrAudio_ResetAudioSource(state.context, idx);
+    }
+  }
+
+  // This source has (or was just assigned) a record.
+  if (idx >= 0) {
+    uint32_t outStatus = 0;
+    state.sources[idx].usedSourceThisPlayback = true;
+
+    float position[4], orientation[4];
+    lovrSourceGetPose(source, position, orientation);
+
+    ovrAudio_SetAudioSourcePos(state.context, idx, position[0], position[1], position[2]);
+
+    ovrAudio_SpatializeMonoSourceInterleaved(state.context, idx, &outStatus, output, input);
+
+    if (!lovrSourceIsPlaying(source)) { // Source is finished
+      state.sources[idx].source = NULL;
+      *spatializerMemo = -1;
+      if (outStatus & ovrAudioSpatializationStatus_Finished) { // Source done playing, echo tailoff is done
+        state.sources[idx].occupied = false;
+      }
+    }
+    return framesOut;
+  }
+  return 0;
+}
+
+static uint32_t oculus_spatializer_tail(float *scratch, float* output, uint32_t frames) {
+  bool didAnything = false;
+  for (int idx = 0; idx < state.sourceMax; idx++) {
+    if (state.sources[idx].occupied && !state.sources[idx].usedSourceThisPlayback) {
+      uint32_t outStatus = 0;
+      if (!didAnything) {
+        didAnything = true;
+        memset(output, 0, frames*sizeof(float)*2);
+      }
+      ovrAudio_SpatializeMonoSourceInterleaved(state.context, idx, &outStatus, scratch, NULL);
+      if (outStatus & ovrAudioSpatializationStatus_Finished) {
+        state.sources[idx].occupied = false;
+      }
+      for(int i = 0; i < frames*2; i++) {
+        output[i] += scratch[i];
+      }
+    }
+  }
+  return didAnything ? frames : 0;
+}
+
+// Oculus math primitives
+
+static void oculusUnpackQuat(ovrQuatf* oq, float* lq) {
+  oq->x = lq[0]; oq->y = lq[1]; oq->z = lq[2]; oq->w = lq[3];
+}
+static void oculusUnpackVec(ovrVector3f* ov, float *p) {
+  ov->x = p[0]; ov->y = p[1]; ov->z = p[2];
+}
+
+static void oculusRecreatePose(ovrPoseStatef *out, float position[4], float orientation[4]) {
+  ovrPosef pose;
+  oculusUnpackVec(&pose.Position, position);
+  oculusUnpackQuat(&pose.Orientation, orientation);
+  out->ThePose = pose;
+  float zero[4] = {0}; // TODO
+  oculusUnpackVec(&out->AngularVelocity, zero);
+  oculusUnpackVec(&out->LinearVelocity, zero);
+  oculusUnpackVec(&out->AngularAcceleration, zero);
+  oculusUnpackVec(&out->LinearAcceleration, zero);
+  out->TimeInSeconds = 0; //TODO-OS
+}
+
+static void oculus_spatializer_setListenerPose(float position[4], float orientation[4]) {
+  ovrPoseStatef pose;
+
+  oculusRecreatePose(&pose, position, orientation);
+
+  ma_mutex_lock(&state.poseLock); // Do nothing inside lock but make a copy of the pose
+  memcpy(&state.pose, &pose, sizeof(state.pose));
+  state.poseUpdated = true;
+  ma_mutex_unlock(&state.poseLock);
+}
+static void oculus_spatializer_source_create(Source *source) {
+  intptr_t *spatializerMemo = lovrSourceGetSpatializerMemoField(source);
+  *spatializerMemo = -1;
+}
+static void oculus_spatializer_source_destroy(Source *source) {
+  intptr_t *spatializerMemo = lovrSourceGetSpatializerMemoField(source);
+  state.sources[*spatializerMemo].source = NULL;
+}
+Spatializer oculusSpatializer = {
+  oculus_spatializer_init,
+  oculus_spatializer_destroy,
+  oculus_spatializer_source_apply,
+  oculus_spatializer_tail,
+  oculus_spatializer_setListenerPose,
+  oculus_spatializer_source_create,
+  oculus_spatializer_source_destroy, // Need noop
+  "oculus"
+};

--- a/src/modules/audio/spatializers/oculus_spatializer_math_shim.h
+++ b/src/modules/audio/spatializers/oculus_spatializer_math_shim.h
@@ -1,0 +1,70 @@
+#ifndef OVR_CAPI_h
+#define OVR_CAPI_h
+
+// Just the definition of a pose from OVR_CAPI.h. Lets OVR_Audio work right.
+
+#if !defined(OVR_UNUSED_STRUCT_PAD)
+    #define OVR_UNUSED_STRUCT_PAD(padName, size) char padName[size];
+#endif
+
+#if !defined(OVR_ALIGNAS)
+    #if defined(__GNUC__) || defined(__clang__)
+        #define OVR_ALIGNAS(n) __attribute__((aligned(n)))
+    #elif defined(_MSC_VER) || defined(__INTEL_COMPILER)
+        #define OVR_ALIGNAS(n) __declspec(align(n))
+    #elif defined(__CC_ARM)
+        #define OVR_ALIGNAS(n) __align(n)
+    #else
+        #error Need to define OVR_ALIGNAS
+    #endif
+#endif
+
+/// A quaternion rotation.
+typedef struct OVR_ALIGNAS(4) ovrQuatf_
+{
+    float x, y, z, w;
+} ovrQuatf;
+
+/// A 2D vector with float components.
+typedef struct OVR_ALIGNAS(4) ovrVector2f_
+{
+    float x, y;
+} ovrVector2f;
+
+/// A 3D vector with float components.
+typedef struct OVR_ALIGNAS(4) ovrVector3f_
+{
+    float x, y, z;
+} ovrVector3f;
+
+/// A 4x4 matrix with float elements.
+typedef struct OVR_ALIGNAS(4) ovrMatrix4f_
+{
+    float M[4][4];
+} ovrMatrix4f;
+
+
+/// Position and orientation together.
+typedef struct OVR_ALIGNAS(4) ovrPosef_
+{
+    ovrQuatf     Orientation;
+    ovrVector3f  Position;
+} ovrPosef;
+
+/// A full pose (rigid body) configuration with first and second derivatives.
+///
+/// Body refers to any object for which ovrPoseStatef is providing data.
+/// It can be the HMD, Touch controller, sensor or something else. The context
+/// depends on the usage of the struct.
+typedef struct OVR_ALIGNAS(8) ovrPoseStatef_
+{
+    ovrPosef     ThePose;               ///< Position and orientation.
+    ovrVector3f  AngularVelocity;       ///< Angular velocity in radians per second.
+    ovrVector3f  LinearVelocity;        ///< Velocity in meters per second.
+    ovrVector3f  AngularAcceleration;   ///< Angular acceleration in radians per second per second.
+    ovrVector3f  LinearAcceleration;    ///< Acceleration in meters per second per second.
+    OVR_UNUSED_STRUCT_PAD(pad0, 4)      ///< \internal struct pad.
+    double       TimeInSeconds;         ///< Absolute time that this pose refers to. \see ovr_GetTimeInSeconds
+} ovrPoseStatef;
+
+#endif

--- a/src/modules/data/soundData.c
+++ b/src/modules/data/soundData.c
@@ -65,7 +65,8 @@ static uint32_t lovrSoundDataReadMp3(SoundData* soundData, uint32_t offset, uint
 }
 */
 
-static uint32_t lovrSoundDataReadRing(SoundData* soundData, uint32_t offset, uint32_t count, void* data) {
+static uint32_t lovrSoundDataReadRing(SoundData* soundData, uint32_t offset, uint32_t count, void* _data) {
+  char *data = _data;
   size_t bytesPerFrame = SampleFormatBytesPerFrame(soundData->channels, soundData->format);
   size_t totalRead = 0;
   while(count > 0) {
@@ -169,7 +170,7 @@ size_t lovrSoundDataStreamAppendBlob(SoundData *dest, struct Blob* blob) {
     uint32_t availableFrames = frameCount;
     ma_result acquire_status = ma_pcm_rb_acquire_write(dest->ring, &availableFrames, &store);
     lovrAssert(acquire_status == MA_SUCCESS, "Failed to acquire ring buffer");
-    memcpy(store, blob->data + blobOffset, availableFrames * bytesPerFrame);
+    memcpy(store, ((char *)blob->data) + blobOffset, availableFrames * bytesPerFrame);
     ma_result commit_status = ma_pcm_rb_commit_write(dest->ring, availableFrames, store);
     lovrAssert(commit_status == MA_SUCCESS, "Failed to commit to ring buffer");
     if (availableFrames == 0) {


### PR DESCRIPTION
This is a large patch which adds a new Oculus Audio spatializer. Oculus Audio is slightly different from the dummy spatializer in a few ways:

- It *must* receive fixed-size input buffers, every time, always.
- It can only handle a fixed number of spatialized sound sources at a time.
- It has a concept of "tails"; the spatialization of a sound can continue after the sound itself ends (eg echo).

Changes to audio.c were needed to support Oculus Audio's quirks:

- audio.c now supports a "fixedBuffer" mode which invokes the generator/spatializer in fixed size chunks
- Each source now has an intptr_t "memo" field that the spatializer may use to store whatever (Oculus spatializer uses this to handle the sound source limit).
- The spatializer interface got a couple new methods: A "tail" method which returns a sound buffer after all sources are processed; and "create" and "destroy" methods that are called when a sound source is created or destroyed (Oculus spatializer uses this to populate/clear the "memo" field).

Along the way some other miscellaneous changes got made:

- lovr.audio.getSpatializerName() returns the current spatializer
- Spatializer init now takes in "config in" and "config out" structs (Spatializer changes fields in config out to request things, currently fixed buffer mode).
- lovr.conf now takes t.audio.spatializer (string name of desired spatializer) and t.audio.spatializerMaxSourcesHint (Spatializers with max sources limits like Oculus will use this as the limit).
- audio.c went back to tracking position/orientation as vectors rather than a matrix
- A file oculus_spatializer_math_shim.h was added containing a minimal copypaste of OVR_CAPI.h from Oculus SDK to support a ovrPoseStatef the spatializer API needs. This may have license consequences but we are probably OK via a combination of fair use and the fact that a user cannot use this header file without accepting Oculus's license through other means.
- (Standalone commits) Fixed build problems with MSVC2019 and Mercurial
- (Standalone commit) I added an "audio tap" debug feature that can only be enabled by uncommenting a particular line in audio.c. This dumps all audio played to a file. This is invaluable for debugging weird audio bugs.

Some work remains to be done, in particular there is an entire reverb feature I did not touch and **LOVR_USE_OCULUS_AUDIO cannot be activated from tup**. Oculus Spatializer works better when it has velocity and time information but this patch does not supply it.
