### PR TITLE
Add support for fixed joint in physics

### DIFF
--- a/src/api/api.h
+++ b/src/api/api.h
@@ -33,6 +33,7 @@ extern const luaL_Reg lovrCollider[];
 extern const luaL_Reg lovrCurve[];
 extern const luaL_Reg lovrCylinderShape[];
 extern const luaL_Reg lovrDistanceJoint[];
+extern const luaL_Reg lovrFixedJoint[];
 extern const luaL_Reg lovrFont[];
 extern const luaL_Reg lovrHingeJoint[];
 extern const luaL_Reg lovrMat4[];

--- a/src/api/l_physics.c
+++ b/src/api/l_physics.c
@@ -120,6 +120,16 @@ static int l_lovrPhysicsNewSliderJoint(lua_State* L) {
   return 1;
 }
 
+static int l_lovrPhysicsNewFixedJoint(lua_State* L) {
+  Collider* a = luax_checktype(L, 1, Collider);
+  Collider* b = luax_checktype(L, 2, Collider);
+  FixedJoint* joint = lovrFixedJointCreate(a, b);
+  lovrFixedJointReset(joint);
+  luax_pushtype(L, FixedJoint, joint);
+  lovrRelease(Joint, joint);
+  return 1;
+}
+
 static int l_lovrPhysicsNewSphereShape(lua_State* L) {
   float radius = luax_optfloat(L, 1, 1.f);
   SphereShape* sphere = lovrSphereShapeCreate(radius);
@@ -136,6 +146,7 @@ static const luaL_Reg lovrPhysics[] = {
   { "newCylinderShape", l_lovrPhysicsNewCylinderShape },
   { "newDistanceJoint", l_lovrPhysicsNewDistanceJoint },
   { "newHingeJoint", l_lovrPhysicsNewHingeJoint },
+  { "newFixedJoint", l_lovrPhysicsNewFixedJoint },
   { "newSliderJoint", l_lovrPhysicsNewSliderJoint },
   { "newSphereShape", l_lovrPhysicsNewSphereShape },
   { NULL, NULL }
@@ -150,6 +161,7 @@ int luaopen_lovr_physics(lua_State* L) {
   luax_registertype(L, DistanceJoint);
   luax_registertype(L, HingeJoint);
   luax_registertype(L, SliderJoint);
+  luax_registertype(L, FixedJoint);
   luax_registertype(L, SphereShape);
   luax_registertype(L, BoxShape);
   luax_registertype(L, CapsuleShape);

--- a/src/api/l_physics_joints.c
+++ b/src/api/l_physics_joints.c
@@ -7,6 +7,7 @@ void luax_pushjoint(lua_State* L, Joint* joint) {
     case JOINT_DISTANCE: luax_pushtype(L, DistanceJoint, joint); break;
     case JOINT_HINGE: luax_pushtype(L, HingeJoint, joint); break;
     case JOINT_SLIDER: luax_pushtype(L, SliderJoint, joint); break;
+    case JOINT_FIXED: luax_pushtype(L, FixedJoint, joint); break;
     default: lovrThrow("Unreachable");
   }
 }
@@ -19,7 +20,8 @@ Joint* luax_checkjoint(lua_State* L, int index) {
       hash64("BallJoint", strlen("BallJoint")),
       hash64("DistanceJoint", strlen("DistanceJoint")),
       hash64("HingeJoint", strlen("HingeJoint")),
-      hash64("SliderJoint", strlen("SliderJoint"))
+      hash64("SliderJoint", strlen("SliderJoint")),
+      hash64("FixedJoint", strlen("FixedJoint"))
     };
 
     for (size_t i = 0; i < sizeof(hashes) / sizeof(hashes[0]); i++) {
@@ -421,5 +423,51 @@ const luaL_Reg lovrSliderJoint[] = {
   { "setUpperLimit", l_lovrSliderJointSetUpperLimit },
   { "getLimits", l_lovrSliderJointGetLimits },
   { "setLimits", l_lovrSliderJointSetLimits },
+  { NULL, NULL }
+};
+
+static int l_lovrFixedJointReset(lua_State* L) {
+  FixedJoint* joint = luax_checktype(L, 1, FixedJoint);
+  lovrFixedJointReset(joint);
+  return 0;
+}
+
+static int l_lovrFixedJointGetResponseTime(lua_State* L) {
+  Joint* joint = luax_checkjoint(L, 1);
+  float responseTime = lovrFixedJointGetResponseTime(joint);
+  lua_pushnumber(L, responseTime);
+  return 1;
+}
+
+static int l_lovrFixedJointSetResponseTime(lua_State* L) {
+  Joint* joint = luax_checkjoint(L, 1);
+  float responseTime = luax_checkfloat(L, 2);
+  lovrAssert(responseTime >= 0, "Negative response time causes simulation instability");
+  lovrFixedJointSetResponseTime(joint, responseTime);
+  return 0;
+}
+
+static int l_lovrFixedJointGetTightness(lua_State* L) {
+  Joint* joint = luax_checkjoint(L, 1);
+  float tightness = lovrFixedJointGetTightness(joint);
+  lua_pushnumber(L, tightness);
+  return 1;
+}
+
+static int l_lovrFixedJointSetTightness(lua_State* L) {
+  Joint* joint = luax_checkjoint(L, 1);
+  float tightness = luax_checkfloat(L, 2);
+  lovrAssert(tightness >= 0, "Negative tightness factor causes simulation instability");
+  lovrFixedJointSetTightness(joint, tightness);
+  return 0;
+}
+
+const luaL_Reg lovrFixedJoint[] = {
+  lovrJoint,
+  { "reset", l_lovrFixedJointReset},
+  { "getResponseTime", l_lovrFixedJointGetResponseTime},
+  { "setResponseTime", l_lovrFixedJointSetResponseTime},
+  { "getTightness", l_lovrFixedJointGetTightness},
+  { "setTightness", l_lovrFixedJointSetTightness},
   { NULL, NULL }
 };

--- a/src/modules/physics/physics.c
+++ b/src/modules/physics/physics.c
@@ -907,7 +907,7 @@ void lovrCylinderShapeSetLength(CylinderShape* cylinder, float length) {
 
 MeshShape* lovrMeshShapeInit(MeshShape* mesh, int vertexCount, float vertices[], int indexCount, dTriIndex indices[]) {
   dTriMeshDataID dataID = dGeomTriMeshDataCreate();
-  dGeomTriMeshDataBuildSingle(dataID, vertices, 3 * sizeof(float), vertexCount, 
+  dGeomTriMeshDataBuildSingle(dataID, vertices, 3 * sizeof(float), vertexCount,
                               indices, indexCount, 3 * sizeof(dTriIndex));
   dGeomTriMeshDataPreprocess2(dataID, (1U << dTRIDATAPREPROCESS_BUILD_FACE_ANGLES), NULL);
   mesh->id = dCreateTriMesh(0, dataID, 0, 0, 0);
@@ -1161,4 +1161,34 @@ float lovrSliderJointGetUpperLimit(SliderJoint* joint) {
 
 void lovrSliderJointSetUpperLimit(SliderJoint* joint, float limit) {
   dJointSetSliderParam(joint->id, dParamHiStop, limit);
+}
+
+FixedJoint* lovrFixedJointInit(FixedJoint* joint, Collider* a, Collider* b) {
+  lovrAssert(a->world == b->world, "Joint bodies must exist in same World");
+  joint->type = JOINT_FIXED;
+  joint->id = dJointCreateFixed(a->world->id, 0);
+  dJointSetData(joint->id, joint);
+  dJointAttach(joint->id, a->body, b->body);
+  lovrRetain(joint);
+  return joint;
+}
+
+void lovrFixedJointReset(FixedJoint* joint) {
+  dJointSetFixed(joint->id);
+}
+
+float lovrFixedJointGetResponseTime(Joint* joint) {
+  return dJointGetFixedParam(joint->id, dParamCFM);
+}
+
+void lovrFixedJointSetResponseTime(Joint* joint, float responseTime) {
+  dJointSetFixedParam(joint->id, dParamCFM, responseTime);
+}
+
+float lovrFixedJointGetTightness(Joint* joint) {
+  return dJointGetFixedParam(joint->id, dParamERP);
+}
+
+void lovrFixedJointSetTightness(Joint* joint, float tightness) {
+  dJointSetFixedParam(joint->id, dParamERP, tightness);
 }

--- a/src/modules/physics/physics.h
+++ b/src/modules/physics/physics.h
@@ -22,7 +22,8 @@ typedef enum {
   JOINT_BALL,
   JOINT_DISTANCE,
   JOINT_HINGE,
-  JOINT_SLIDER
+  JOINT_SLIDER,
+  JOINT_FIXED
 } JointType;
 
 typedef struct Collider Collider;
@@ -76,6 +77,7 @@ typedef Joint BallJoint;
 typedef Joint DistanceJoint;
 typedef Joint HingeJoint;
 typedef Joint SliderJoint;
+typedef Joint FixedJoint;
 
 typedef void (*CollisionResolver)(World* world, void* userdata);
 typedef void (*RaycastCallback)(Shape* shape, float x, float y, float z, float nx, float ny, float nz, void* userdata);
@@ -276,3 +278,12 @@ float lovrSliderJointGetLowerLimit(SliderJoint* joint);
 void lovrSliderJointSetLowerLimit(SliderJoint* joint, float limit);
 float lovrSliderJointGetUpperLimit(SliderJoint* joint);
 void lovrSliderJointSetUpperLimit(SliderJoint* joint, float limit);
+
+FixedJoint* lovrFixedJointInit(FixedJoint* joint, Collider* a, Collider* b);
+#define lovrFixedJointCreate(...) lovrFixedJointInit(lovrAlloc(FixedJoint), __VA_ARGS__)
+#define lovrFixedJointDestroy lovrJointDestroy
+void lovrFixedJointReset(FixedJoint* joint);
+float lovrFixedJointGetResponseTime(Joint* joint);
+void lovrFixedJointSetResponseTime(Joint* joint, float responseTime);
+float lovrFixedJointGetTightness(Joint* joint);
+void lovrFixedJointSetTightness(Joint* joint, float tightness);


### PR DESCRIPTION
Fixed joint is used to instructing colliders to maintain fixed distance
AND relative rotation. Such functionality required 2 joints before.This
is similar to adding multiple shapes to same collider. The difference is
fixed joint is more dynamic (can be added and removed anytime without
disturbing simulation) and is less rigid.

The joint's force can be changed with `joint:setTightness(f)`, while
speed of response and frequency of spring oscillations is changed with
`joint:setResponseTime(t)`.

When created, joint marks current relative position and orientation
between colliders. At any later time that relative orientation can be
set again by moving any of colliders and calling `joint:reset()`.

In VR the fixed joint can be used for rigging physical systems. Some
examples are gripping and holding onto physical objects, making item
that floats in air, trampoline, inventory item strapped to belt,
breakable objects...