### PR TITLE
initialize XrSystemProperties type

### DIFF
--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -542,7 +542,9 @@ static void openxr_destroy(void) {
 }
 
 static bool openxr_getName(char* name, size_t length) {
-  XrSystemProperties properties;
+  XrSystemProperties properties = {
+    .type = XR_TYPE_SYSTEM_PROPERTIES
+  };
   XR(xrGetSystemProperties(state.instance, state.system, &properties));
   strncpy(name, properties.systemName, length - 1);
   name[length - 1] = '\0';


### PR DESCRIPTION
fixes
```
XR_ERROR_VALIDATION_FAILURE: xrGetSystemProperties(properties->type == 4294967295)
Error:
OpenXR Error: XR_ERROR_VALIDATION_FAILURE at ../src/modules/headset/headset_openxr.c:546
```