### PR TITLE
Add mat4:targetAt and modify the mat4:lookAt

### DIFF
--- a/src/api/l_math_vectors.c
+++ b/src/api/l_math_vectors.c
@@ -1655,6 +1655,16 @@ static int l_lovrMat4LookAt(lua_State* L) {
   return 1;
 }
 
+static int l_lovrMat4Target(lua_State* L) {
+  mat4 m = luax_checkvector(L, 1, V_MAT4, NULL);
+  vec3 from = luax_checkvector(L, 2, V_VEC3, NULL);
+  vec3 to = luax_checkvector(L, 3, V_VEC3, NULL);
+  vec3 up = lua_isnoneornil(L, 4) ? (float[4]) { 0.f, 1.f, 0.f } : luax_checkvector(L, 4, V_VEC3, NULL);
+  mat4_target(m, from, to, up);
+  lua_settop(L, 1);
+  return 1;
+}
+
 static int l_lovrMat4__mul(lua_State* L) {
   mat4 m = luax_checkvector(L, 1, V_MAT4, NULL);
   VectorType type;
@@ -1738,6 +1748,7 @@ const luaL_Reg lovrMat4[] = {
   { "perspective", l_lovrMat4Perspective },
   { "fov", l_lovrMat4Fov },
   { "lookAt", l_lovrMat4LookAt },
+  { "target", l_lovrMat4Target },
   { "__mul", l_lovrMat4__mul },
   { "__tostring", l_lovrMat4__tostring },
   { "__newindex", l_lovrMat4__newindex },

--- a/src/core/maf.h
+++ b/src/core/maf.h
@@ -632,6 +632,32 @@ MAF mat4 mat4_lookAt(mat4 m, vec3 from, vec3 to, vec3 up) {
   vec3_normalize(vec3_cross(vec3_init(x, up), z));
   vec3_cross(vec3_init(y, z), x);
   m[0] = x[0];
+  m[1] = y[0];
+  m[2] = z[0];
+  m[3] = 0.f;
+  m[4] = x[1];
+  m[5] = y[1];
+  m[6] = z[1];
+  m[7] = 0.f;
+  m[8] = x[2];
+  m[9] = y[2];
+  m[10] = z[2];
+  m[11] = 0.f;
+  m[12] = -vec3_dot(x, from);
+  m[13] = -vec3_dot(y, from);
+  m[14] = -vec3_dot(z, from);
+  m[15] = 1.f;
+  return m;
+}
+
+MAF mat4 mat4_target(mat4 m, vec3 from, vec3 to, vec3 up) {
+  float x[4];
+  float y[4];
+  float z[4];
+  vec3_normalize(vec3_sub(vec3_init(z, from), to));
+  vec3_normalize(vec3_cross(vec3_init(x, up), z));
+  vec3_cross(vec3_init(y, z), x);
+  m[0] = x[0];
   m[1] = x[1];
   m[2] = x[2];
   m[3] = 0.f;
@@ -643,9 +669,9 @@ MAF mat4 mat4_lookAt(mat4 m, vec3 from, vec3 to, vec3 up) {
   m[9] = z[1];
   m[10] = z[2];
   m[11] = 0.f;
-  m[12] = -vec3_dot(x, from);
-  m[13] = -vec3_dot(y, from);
-  m[14] = -vec3_dot(z, from);
+  m[12] = from[0];
+  m[13] = from[1];
+  m[14] = from[2];
   m[15] = 1.f;
   return m;
 }


### PR DESCRIPTION
lookAt() returns view matrix that can be used to transform the camera
perspective. target() returns model matrix that is used to change
model transform. Results are matrix inversions of one another. Now both
functions exist it is possible to use right one and avoid extra matrix
inversion.