### PR TITLE
Store the Lua source location that created shaders and canvases

### DIFF
--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -1205,7 +1205,10 @@ static int l_lovrGraphicsNewCanvas(lua_State* L) {
     height = lovrTextureGetHeight(attachments[0].texture, attachments[0].level);
   }
 
-  Canvas* canvas = lovrCanvasCreate(width, height, flags);
+  luax_traceback(L, L, "", 0);
+  char *from = strdup(lua_tostring(L, -1));
+  lua_pop(L, 1);
+  Canvas* canvas = lovrCanvasCreate(width, height, flags, from);
 
   if (anonymous) {
     bool multiview = flags.stereo && lovrGraphicsGetFeatures()->multiview;
@@ -1514,6 +1517,10 @@ static int l_lovrGraphicsNewShader(lua_State* L) {
   bool multiview = true;
   Shader* shader;
 
+  luax_traceback(L, L, "", 0);
+  char *from = strdup(lua_tostring(L, -1));
+  lua_pop(L, 1);
+
   if (lua_isstring(L, 1) && (lua_istable(L, 2) || lua_gettop(L) == 1)) {
     DefaultShader shaderType = luax_checkenum(L, 1, DefaultShader, NULL);
 
@@ -1527,7 +1534,7 @@ static int l_lovrGraphicsNewShader(lua_State* L) {
       lua_pop(L, 1);
     }
 
-    shader = lovrShaderCreateDefault(shaderType, flags, flagCount, multiview);
+    shader = lovrShaderCreateDefault(shaderType, flags, flagCount, multiview, from);
 
     // Builtin uniforms
     if (shaderType == SHADER_STANDARD) {
@@ -1551,7 +1558,7 @@ static int l_lovrGraphicsNewShader(lua_State* L) {
       lua_pop(L, 1);
     }
 
-    shader = lovrShaderCreateGraphics(vertexSource, vertexSourceLength, fragmentSource, fragmentSourceLength, flags, flagCount, multiview);
+    shader = lovrShaderCreateGraphics(vertexSource, vertexSourceLength, fragmentSource, fragmentSourceLength, flags, flagCount, multiview, from);
   }
 
   luax_pushtype(L, Shader, shader);
@@ -1566,13 +1573,17 @@ static int l_lovrGraphicsNewComputeShader(lua_State* L) {
   ShaderFlag flags[MAX_SHADER_FLAGS];
   uint32_t flagCount = 0;
 
+  luax_traceback(L, L, "", 0);
+  char *from = strdup(lua_tostring(L, -1));
+  lua_pop(L, 1);
+
   if (lua_istable(L, 2)) {
     lua_getfield(L, 2, "flags");
     luax_parseshaderflags(L, -1, flags, &flagCount);
     lua_pop(L, 1);
   }
 
-  Shader* shader = lovrShaderCreateCompute(source, sourceLength, flags, flagCount);
+  Shader* shader = lovrShaderCreateCompute(source, sourceLength, flags, flagCount, from);
   luax_pushtype(L, Shader, shader);
   lovrRelease(Shader, shader);
   return 1;

--- a/src/modules/graphics/canvas.h
+++ b/src/modules/graphics/canvas.h
@@ -25,7 +25,7 @@ typedef struct {
 } CanvasFlags;
 
 typedef struct Canvas Canvas;
-Canvas* lovrCanvasCreate(uint32_t width, uint32_t height, CanvasFlags flags);
+Canvas* lovrCanvasCreate(uint32_t width, uint32_t height, CanvasFlags flags, char *from);
 Canvas* lovrCanvasCreateFromHandle(uint32_t width, uint32_t height, CanvasFlags flags, uint32_t framebuffer, uint32_t depthBuffer, uint32_t resolveBuffer, uint32_t attachmentCount, bool immortal);
 void lovrCanvasDestroy(void* ref);
 const Attachment* lovrCanvasGetAttachments(Canvas* canvas, uint32_t* count);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -577,7 +577,7 @@ static void lovrGraphicsBatch(BatchRequest* req) {
   Mesh* mesh = req->mesh ? req->mesh : (req->instanced ? state.instancedMesh : state.mesh);
   Canvas* canvas = state.canvas ? state.canvas : state.backbuffer;
   bool stereo = lovrCanvasIsStereo(canvas);
-  Shader* shader = state.shader ? state.shader : (state.defaultShaders[req->shader][stereo] ? state.defaultShaders[req->shader][stereo] : (state.defaultShaders[req->shader][stereo] = lovrShaderCreateDefault(req->shader, NULL, 0, stereo)));
+  Shader* shader = state.shader ? state.shader : (state.defaultShaders[req->shader][stereo] ? state.defaultShaders[req->shader][stereo] : (state.defaultShaders[req->shader][stereo] = lovrShaderCreateDefault(req->shader, NULL, 0, stereo, "batch")));
   Pipeline* pipeline = req->pipeline ? req->pipeline : &state.pipeline;
   Material* material = req->material ? req->material : (state.defaultMaterial ? state.defaultMaterial : (state.defaultMaterial = lovrMaterialCreate()));
 

--- a/src/modules/graphics/shader.h
+++ b/src/modules/graphics/shader.h
@@ -105,9 +105,9 @@ typedef arr_t(UniformBlock) arr_block_t;
 // Shader
 
 typedef struct Shader Shader;
-Shader* lovrShaderCreateGraphics(const char* vertexSource, int vertexSourceLength, const char* fragmentSource, int fragmentSourceLength, ShaderFlag* flags, uint32_t flagCount, bool multiview);
-Shader* lovrShaderCreateCompute(const char* source, int length, ShaderFlag* flags, uint32_t flagCount);
-Shader* lovrShaderCreateDefault(DefaultShader type, ShaderFlag* flags, uint32_t flagCount, bool multiview);
+Shader* lovrShaderCreateGraphics(const char* vertexSource, int vertexSourceLength, const char* fragmentSource, int fragmentSourceLength, ShaderFlag* flags, uint32_t flagCount, bool multiview, char *from);
+Shader* lovrShaderCreateCompute(const char* source, int length, ShaderFlag* flags, uint32_t flagCount, char *from);
+Shader* lovrShaderCreateDefault(DefaultShader type, ShaderFlag* flags, uint32_t flagCount, bool multiview, char *from);
 void lovrShaderDestroy(void* ref);
 ShaderType lovrShaderGetType(Shader* shader);
 int lovrShaderGetAttributeLocation(Shader* shader, const char* name, bool* integer);

--- a/src/modules/headset/headset_vrapi.c
+++ b/src/modules/headset/headset_vrapi.c
@@ -681,7 +681,7 @@ static void vrapi_renderTo(void (*callback)(void*), void* userdata) {
     lovrAssert(state.swapchainLength <= sizeof(state.canvases) / sizeof(state.canvases[0]), "VrApi: The swapchain is too long");
 
     for (uint32_t i = 0; i < state.swapchainLength; i++) {
-      state.canvases[i] = lovrCanvasCreate(width, height, flags);
+      state.canvases[i] = lovrCanvasCreate(width, height, flags, "vrapi_renderTo");
       uint32_t handle = vrapi_GetTextureSwapChainHandle(state.swapchain, i);
       Texture* texture = lovrTextureCreateFromHandle(handle, TEXTURE_ARRAY, 2, 1);
       lovrCanvasSetAttachments(state.canvases[i], &(Attachment) { .texture = texture }, 1);


### PR DESCRIPTION
Otherwise it's really hard to know from error messages where
the fault originated in your source code, since the validation
of your shader/canvas occurs much later than the creation.

I implemented this patch to fix the pico build of alloverse. it was really hard to find the location on my own, but with this debug code it was super easy. It's not much of an overhead and could probably be super useful for debugging other shader problems in the future, so I figured I'd suggest it as an upstream feature. Feel free to discard if you think it's too noisy :)