### PR TITLE
Give shaderBlock:send() the ability to send only part of the block

### DIFF
--- a/src/api/l_graphics_shaderBlock.c
+++ b/src/api/l_graphics_shaderBlock.c
@@ -42,10 +42,15 @@ static int l_lovrShaderBlockSend(lua_State* L) {
     Blob* blob = luax_checktype(L, 2, Blob);
     Buffer* buffer = lovrShaderBlockGetBuffer(block);
     void* data = lovrBufferMap(buffer, 0, false);
+    int offset = luaL_optinteger(L, 3, 0);
+    lovrAssert(offset >= 0, "Negative offset");
+    lovrAssert(offset < blob->size, "Offset %d larger than blob (size %d)", offset, (int) blob->size);
+    int size = luaL_optnumber(L, 4, blob->size - offset);
+    lovrAssert(size <= blob->size - offset, "Size %d offset %d larger than blob (size %d)", offset, size, (int) blob->size);
     size_t bufferSize = lovrBufferGetSize(buffer);
-    size_t copySize = MIN(bufferSize, blob->size);
-    memcpy(data, blob->data, copySize);
-    lovrBufferFlush(buffer, 0, copySize);
+    size_t copySize = MIN(bufferSize, size);
+    memcpy(data, ((uint8_t*) blob->data) + offset, copySize);
+    lovrBufferFlush(buffer, offset, copySize);
     lua_pushinteger(L, copySize);
     return 1;
   }


### PR DESCRIPTION
shaderBlock:send() has two additional arguments with this patch: An offset and a size.
If present, only the range [offset…offset+size) will be sent.

Usually this is not super useful because it is usually efficient-ish to send even a large shader block all at once.
I believe the reason I added this was I had a shaderblock that was being simultaneously written into by send()s from code and written into by a compute shader, so I wanted to avoid stomping the compute-shader-owned part of the shader block.
Anyway it's nice to have.

This is an API change and will require a doc change.