### PR TITLE
Use find_library to link android liblog.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,7 +602,11 @@ elseif(EMSCRIPTEN)
   target_sources(lovr PRIVATE src/core/os_web.c)
   target_compile_definitions(lovr PRIVATE LOVR_WEBGL)
 elseif(ANDROID)
-  target_link_libraries(lovr log EGL GLESv3 OpenSLES android dl)
+  find_library( # Right now just linking "log" will always work, but this may not be true in future.
+    log-lib
+    log
+  )
+  target_link_libraries(lovr ${log-lib} EGL GLESv3 OpenSLES android dl)
   target_compile_definitions(lovr PRIVATE LOVR_GLES)
   target_include_directories(lovr PRIVATE "${ANDROID_NDK}/sources/android/native_app_glue")
 


### PR DESCRIPTION
This is iffy.

So a couple weeks back I was having a problem with the Lovr Android. I looked on Stack Overflow. Somebody recommended to find android "log" lib using find_library instead of hardcoding -llog. I tried this. They claimed this is required for newer versions of Android / newer Android toolchains. It did not help me.
But!
It does appear the documentation suggests doing this in the case of log.
 https://developer.android.com/studio/projects/configure-cmake

Why?
Is this required?
Will it be required in future?
Is the documentation just trying to demonstrate how find_library works?

I have no idea!
It doesn't seem to make anything *worse*.