### PR TITLE
lovrSoundCreateFromCallback

### DIFF
--- a/src/modules/data/sound.h
+++ b/src/modules/data/sound.h
@@ -18,9 +18,17 @@ typedef enum {
 } ChannelLayout;
 
 typedef struct Sound Sound;
+
+typedef uint32_t (SoundCallback)(Sound* sound, uint32_t offset, uint32_t count, void* data);
+typedef void (SoundDestroyCallback)(Sound* sound);
+
+// Can pass as the maxFrames argument to lovrSoundCreateFromCallback
+#define LOVR_SOUND_ENDLESS 0xFFFFFFFF
+
 Sound* lovrSoundCreateRaw(uint32_t frames, SampleFormat format, ChannelLayout channels, uint32_t sampleRate, struct Blob* data);
 Sound* lovrSoundCreateStream(uint32_t frames, SampleFormat format, ChannelLayout channels, uint32_t sampleRate);
 Sound* lovrSoundCreateFromFile(struct Blob* blob, bool decode);
+Sound* lovrSoundCreateFromCallback(SoundCallback read, void *callbackMemo, SoundDestroyCallback callbackDataDestroy, SampleFormat format, uint32_t sampleRate, ChannelLayout channels, uint32_t maxFrames);
 void lovrSoundDestroy(void* ref);
 struct Blob* lovrSoundGetBlob(Sound* sound);
 SampleFormat lovrSoundGetFormat(Sound* sound);
@@ -34,3 +42,4 @@ bool lovrSoundIsStream(Sound* sound);
 uint32_t lovrSoundRead(Sound* sound, uint32_t offset, uint32_t count, void* data);
 uint32_t lovrSoundWrite(Sound* sound, uint32_t offset, uint32_t count, const void* data);
 uint32_t lovrSoundCopy(Sound* src, Sound* dst, uint32_t frames, uint32_t srcOffset, uint32_t dstOffset);
+void *lovrSoundGetCallbackMemo(Sound *sound);


### PR DESCRIPTION
Allows a Sound to be created from a callback. Because Sound already has a "read" callback, this will integrate cleanly with the existing lovr.audio module. The callback will be called to generate the audio.

The callback-based Sound is allowed to be of infinite length. It is allowed to store a "memo" pointer in the Sound. It is also allowed to have a custom "destroy" callback called on destruction (which must destroy the memo pointer if appropriate).

This is of zero immediate use. It is handy to me because I have forked lovr. If this were accepted upstream, it would make a lovr fork (like mine) easier to maintain because custom audio types could be added without modifying audio.c. However, most people have not forked lovr.

In future, I would like to attempt live pcm audio generation in Lua. (I have a prototype API for this in my PortAudio branch already.) This callback feature could naturally be used as the basis for the lua audio generation feature, because it would allow l_audio.c to contain the Lua callback functionality entirely within itself and not make audio.c have to be aware of Lua. However, that hypothetical feature would be substantially more complicated and probably require an architecture discussion.