### PR TITLE
Fix MSVC build

### DIFF
--- a/src/lib/stdatomic/stdatomic.h
+++ b/src/lib/stdatomic/stdatomic.h
@@ -148,4 +148,6 @@ typedef unsigned int atomic_uint;
 #define atomic_fetch_add(p, x) _InterlockedExchangeAdd(p, x)
 #define atomic_fetch_sub(p, x) _InterlockedExchangeAdd(p, -(x))
 
+#define ATOMIC_INT_LOCK_FREE 2
+
 #endif

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -5,7 +5,7 @@
 #include "lib/miniaudio/miniaudio.h"
 #include <string.h>
 #include <stdlib.h>
-#ifdef _MSVC_VER
+#ifdef _MSC_VER
 #include <intrin.h>
 #define CTZL _tzcnt_u64
 #else


### PR DESCRIPTION
- stdatomic.h had not defined ATOMIC_INT_LOCK_FREE, but it is now required
- It's _MSC_VER, not _MSVC_VER