### PR TITLE
Fix crash on startup on Oculus driver

### DIFF
--- a/src/modules/headset/headset_oculus.c
+++ b/src/modules/headset/headset_oculus.c
@@ -83,6 +83,8 @@ static ovrInputState *refreshButtons(void) {
 }
 
 static bool oculus_init(float supersample, float offset, uint32_t msaa) {
+  arr_init(&state.textures, realloc);
+
   ovrResult result = ovr_Initialize(NULL);
   if (OVR_FAILURE(result)) {
     return false;
@@ -112,6 +114,7 @@ static void oculus_destroy(void) {
   for (size_t i = 0; i < state.textures.length; i++) {
     lovrRelease(state.textures.data[i], lovrTextureDestroy);
   }
+  arr_free(&state.textures);
   map_free(&state.textureLookup);
 
   if (state.mirror) {

--- a/src/modules/headset/headset_oculus.c
+++ b/src/modules/headset/headset_oculus.c
@@ -5,6 +5,7 @@
 #include "graphics/texture.h"
 #include "core/maf.h"
 #include "core/map.h"
+#include "core/os.h"
 #include <OVR_CAPI.h>
 #include <OVR_CAPI_GL.h>
 #include <stdlib.h>


### PR DESCRIPTION
I think the API for arr_t changed but the oculus driver code did not change to the new rules