### PR TITLE
Allow boot.lua to run without debug object

### DIFF
--- a/src/resources/boot.lua
+++ b/src/resources/boot.lua
@@ -238,7 +238,9 @@ end
 
 function lovr.errhand(message, traceback)
   message = tostring(message)
-  message = message .. formatTraceback(traceback or debug.traceback('', 4))
+  if debug then
+    message = message .. formatTraceback(traceback or debug.traceback('', 4))
+  end
   print('Error:\n' .. message)
   if not lovr.graphics then return function() return 1 end end
 


### PR DESCRIPTION
This one is *very* silly and I'll understand if you don't take it…

I'm doing a [Rust port](https://github.com/mcclure/rovr) of Lovr, to learn Rust. I don't expect I'll finish this or that it will displace my use of the C version on my VR projects.

The Rust port uses the C version's exact `boot.lua` but does not, in its current early form, have the debug object. This means that if there is any error, the default lovr.errhand will crash with the brutal "error occurred while trying to process another error" message because it tries to call debug.traceback and fails. This patch simply checks for debug.traceback before calling it, which allows it to continue as normal and print the error message by itself.

Accepting this patch would be low cost (one if, triggered only when default lovr.errhand is called), would allow me to continue to use the *exact* boot.lua from the lovr repo possibly indefinitely and so avoid annoying repeated merges, and could also possibly help with other pathological situations, like other ports (we do talk sometimes about moving some of lovr to Zig) or someone for some reason I can't fathom specifically wanting to ship a game with the debug object omitted.

Note: I originally wrote this as "if debug and debug.traceback" for total armor plating but shortened it to "if debug" when I made the PR because I can't imagine even a hypothetical scenario where a vm includes an object named debug but doesn't implement some of the standard methods. I could change it back.