### PR TITLE
Encapsulate "uses spatializer?" nature in lovrSourceUsesSpatializer

### DIFF
--- a/src/modules/audio/audio.h
+++ b/src/modules/audio/audio.h
@@ -92,7 +92,7 @@ void lovrSourceSetVolume(Source* source, float volume, VolumeUnit units);
 void lovrSourceSeek(Source* source, double time, TimeUnit units);
 double lovrSourceTell(Source* source, TimeUnit units);
 double lovrSourceGetDuration(Source* source, TimeUnit units);
-bool lovrSourceIsSpatial(Source* source);
+bool lovrSourceUsesSpatializer(Source* source);
 void lovrSourceGetPose(Source* source, float position[4], float orientation[4]);
 void lovrSourceSetPose(Source* source, float position[4], float orientation[4]);
 float lovrSourceGetRadius(Source* source);


### PR DESCRIPTION
isSpatial() was removed because now the relevant concept is not "is it spatial?" but rather "does it have spatial effects?". Since all effects are currently spatial, this is the same as asking "does it have effects?".

However, the knowledge "no effects -> no spatializer use" is "magic", it's not obvious from the names and it isn't commented, and this knowledge is applied three times in audio.c. This patch encapsulates the knowledge into a UsesSpatializer() function and comments as appropriate.

Also, remove accessor prototype for old IsSpatial() function, which currently corresponds to no function.