### PR TITLE
Allow using alpha with hexcode when setting color

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -400,14 +400,12 @@ void luax_readcolor(lua_State* L, int index, Color* color) {
     color->g = luax_checkfloat(L, index + 1);
     color->b = luax_checkfloat(L, index + 2);
     color->a = luax_optfloat(L, index + 3, 1.);
-  } else if (lua_gettop(L) == index) {
+  } else if (lua_gettop(L) <= index + 1) {
     uint32_t x = luaL_checkinteger(L, index);
     color->r = ((x >> 16) & 0xff) / 255.f;
     color->g = ((x >> 8) & 0xff) / 255.f;
     color->b = ((x >> 0) & 0xff) / 255.f;
-    color->a = 1.f;
-  } else {
-    luaL_error(L, "Invalid color, expected a hexcode, 3 numbers, 4 numbers, or a table");
+    color->a = luax_optfloat(L, index + 1, 1.);
   }
 }
 


### PR DESCRIPTION
Implements #411 proposal. I needed this variant before so I think this is good extension to setColor.

When setColor() is called without arguments it will throw `bad argument #1 to 'setColor' (number expected, got no value)"`. It does not convey all possible combinations of arguments, but I think this is acceptable to keep the error message concise.