### PR TITLE
Realtime (audio-thread) audio generation in pure Lua

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ option(LOVR_ENABLE_SYSTEM "Enable the system module" ON)
 option(LOVR_ENABLE_THREAD "Enable the thread module" ON)
 option(LOVR_ENABLE_TIMER "Enable the timer module" ON)
 
+option(LOVR_ENABLE_EXTAUDIO "Enable extended audio module" ON)
+
 option(LOVR_USE_LUAJIT "Use LuaJIT instead of Lua" ON)
 option(LOVR_USE_OPENVR "Enable the OpenVR backend for the headset module" ON)
 option(LOVR_USE_OPENXR "Enable the OpenXR backend for the headset module" OFF)
@@ -567,6 +569,13 @@ if(LOVR_ENABLE_TIMER)
   target_sources(lovr PRIVATE src/modules/timer/timer.c src/api/l_timer.c)
 else()
   target_compile_definitions(lovr PRIVATE LOVR_DISABLE_TIMER)
+endif()
+
+
+if (LOVR_ENABLE_EXTAUDIO)
+  add_definitions(-DLOVR_ENABLE_EXTAUDIO)
+  target_sources(lovr PRIVATE game/audio/hook-audio.cpp)
+  target_include_directories(lovr PRIVATE game/include)
 endif()
 
 # Resources

--- a/game/audio/hook-audio.cpp
+++ b/game/audio/hook-audio.cpp
@@ -1,0 +1,172 @@
+extern "C" {
+#include "api/api.h"
+#include "audio/audio.h"
+#include "core/util.h"
+#include "data/sound.h"
+#include "event/event.h"
+#include "data/blob.h"
+#include "thread/thread.h"
+#include "thread/channel.h"
+#include <lua.h>
+#include <lauxlib.h>
+}
+#include <string>
+#include "lib/tinycthread/tinycthread.h"
+
+// State of a thread-based Sound
+struct SoundCallbackData {
+	bool dead;                 // An audio Source will never call a dead Sound, but a user calling Sound methods manually might
+	Thread *thread;
+	lua_State *L;
+	Blob *blob;                // Attempt to reuse blob storage between frames // FIXME use Sound instead of Blob?
+	size_t blobDataTrueCount;  // Count in frames [floats]
+};
+
+extern "C" {
+lua_State *threadSetup(Thread *thread);
+void threadError(Thread *thread, lua_State*L);
+
+// FIXME: Why does this exist separately from threadError?
+int CrashAndReturnEmpty(SoundCallbackData *soundCallbackData, std::string err) {
+	err = "Audio render thread: " + err;
+	Thread *thread = soundCallbackData->thread;
+	lua_State *L = soundCallbackData->L;
+
+	lua_pushstring(L, err.c_str());
+	threadError(thread, L);
+	soundCallbackData->dead = true;
+	return 0;
+}
+
+static const char *audioBlobName = "Audio thread output";
+
+uint32_t readCallback(Sound* sound, uint32_t offset, uint32_t frameCount, void* data) {
+	SoundCallbackData *soundCallbackData = (SoundCallbackData *)lovrSoundGetCallbackMemo(sound);
+
+	if (soundCallbackData->dead) return 0;
+
+	// We can't predict frame size until we start getting requests, so we wait to allocate the blob storage until then
+	if (frameCount > soundCallbackData->blobDataTrueCount) { // Every time request size increases, re-allocate
+		lovrRelease(soundCallbackData->blob, lovrBlobDestroy);
+		soundCallbackData->blob = lovrBlobCreate(malloc(frameCount*sizeof(float)), frameCount*sizeof(float), audioBlobName);
+		soundCallbackData->blobDataTrueCount = frameCount;
+	}
+	void *blobDataWas = soundCallbackData->blob->data; // Track this so we can detect if the blob changed during thread run
+	soundCallbackData->blob->size = frameCount*sizeof(float); // Allow the blob to under-report its size. This is safe, but violates Bjorn's rules
+
+	Blob *resultBlob = NULL; // Blob returned from thread
+	bool resultNil = false;  // Did blob return nil?
+	int blobProgress = 0; // Used to track how close we got to success so we can display a useful error message
+	lua_State *L = soundCallbackData->L;
+	lua_getglobal(L, "lovr"); // We will execute the function lovr.audio()
+	if (!lua_isnoneornil(L, -1)) {
+		blobProgress++;
+		lua_getfield(L, -1, "audio");
+		if (!lua_isnoneornil(L, -1)) {
+			blobProgress++;
+			Variant variant; variant.type = TYPE_OBJECT; // Wrap blob in variant
+			variant.value.object.pointer = soundCallbackData->blob;
+			variant.value.object.type = "Blob";
+			variant.value.object.destructor = lovrBlobDestroy;
+
+			luax_pushvariant(L, &variant);
+			int result = lua_pcall (L, 1, 1, 0);
+
+			if (result) {
+				// Failure
+				threadError(soundCallbackData->thread, L);
+				soundCallbackData->dead = true;
+			} else {
+				blobProgress++;
+				resultNil = lua_isnil(L, -1);
+				if (!resultNil) {
+					resultBlob = luax_totype(L, -1, Blob);
+					lovrRetain(resultBlob);
+				}
+				lua_settop(L, 0);
+			}
+		}
+	}
+	if (resultNil)
+		return 0; // No error, code simply indicated it is done returning audio
+	if (!resultBlob) { // Blob was never set, but this is not because nil was returned. Some error occurred.
+		switch (blobProgress) {
+			case 0:
+				return CrashAndReturnEmpty(soundCallbackData, "No lovr object in audio thread global scope");
+			case 1:
+				return CrashAndReturnEmpty(soundCallbackData, "No lovr.audio in audio thread");
+			case 2: // ThreadError case
+				return 0;
+			default:
+				return CrashAndReturnEmpty(soundCallbackData, "lovr.audio returned wrong type");
+		}
+	}
+	int resultCount = std::min<int>(resultBlob->size/sizeof(float), frameCount);
+	memcpy(data, resultBlob->data, resultCount*sizeof(float));
+	if (resultBlob != soundCallbackData->blob) {
+		lovrRelease(soundCallbackData->blob, lovrBlobDestroy);
+		soundCallbackData->blob = resultBlob;
+	}
+	if (blobDataWas != soundCallbackData->blob->data)
+		soundCallbackData->blobDataTrueCount = resultCount;
+
+	return resultCount;
+}
+
+static void destroyCallback(Sound* sound) {
+  SoundCallbackData *soundCallbackData = (SoundCallbackData *)lovrSoundGetCallbackMemo(sound);
+  lovrRelease(soundCallbackData->thread, lovrThreadDestroy);
+  if (soundCallbackData->L)
+  	lua_close(soundCallbackData->L);
+  lovrRelease(soundCallbackData->blob, lovrBlobDestroy);
+  free(soundCallbackData);
+}
+
+static int l_audioNewThreadSound(lua_State *L) {
+  Thread* thread = luax_checktype(L, 1, Thread);
+  lovrAssert(!lovrThreadIsRunning(thread), "Thread for audio is already started");
+
+  thread->argumentCount = MIN(MAX_THREAD_ARGUMENTS, lua_gettop(L) - 1);
+  for (size_t i = 0; i < thread->argumentCount; i++) {
+    luax_checkvariant(L, 2 + i, &thread->arguments[i]);
+  }
+
+  SoundCallbackData *soundCallbackData = (SoundCallbackData *)calloc(1, sizeof(SoundCallbackData));	
+  lovrRetain(thread);
+  soundCallbackData->thread = thread;
+  soundCallbackData->L = threadSetup(thread); // FIXME: Should do this on audio thread?
+  if (!soundCallbackData->L) {
+  	soundCallbackData->dead = true;
+  }
+
+  Sound *sound = lovrSoundCreateFromCallback(readCallback, soundCallbackData, destroyCallback, SAMPLE_F32, SAMPLE_RATE, CHANNEL_MONO, LOVR_SOUND_ENDLESS);
+  luax_pushtype(L, Sound, sound);
+  lovrRelease(sound, lovrSoundDestroy);
+
+  return 1;
+}
+
+static int l_blobCopy(lua_State *L) {
+  Blob* a = luax_checktype(L, 1, Blob);
+  Blob* b = luax_checktype(L, 2, Blob);
+  int len = MIN(a->size, b->size);
+  memcpy(a->data, b->data, len);
+  return 0;
+}
+
+const luaL_Reg audioLua[] = {
+  { "newThreadSound", l_audioNewThreadSound },
+
+  { "blobCopy", l_blobCopy },
+  { NULL, NULL }
+};
+
+// Register Lua module-- not the same as gameInitFUnc
+int luaopen_ext_audio(lua_State* L) {
+  lua_newtable(L);
+  luaL_register(L, NULL, audioLua);
+
+  return 1;
+}
+
+}

--- a/game/include/audio/hook-audio.h
+++ b/game/include/audio/hook-audio.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <lua.h>
+
+int luaopen_ext_audio(lua_State* L);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -65,6 +65,10 @@ static int luax_module__gc(lua_State* L) {
   return 0;
 }
 
+#ifdef LOVR_ENABLE_EXTAUDIO
+#include "audio/hook-audio.h"
+#endif
+
 void luax_preload(lua_State* L) {
   static const luaL_Reg lovrModules[] = {
     { "lovr", luaopen_lovr },
@@ -101,6 +105,10 @@ void luax_preload(lua_State* L) {
 #ifndef LOVR_DISABLE_TIMER
     { "lovr.timer", luaopen_lovr_timer },
 #endif
+#ifdef LOVR_ENABLE_EXTAUDIO
+    { "ext.audio", luaopen_ext_audio },
+#endif
+
     { NULL, NULL }
   };
 


### PR DESCRIPTION
**What is this?**

This is a patch consisting of two elements:

- A change to thread.c, splitting `threadRunner` into `threadRunner`, `threadSetup` and `threadError`.
- A file game/audio/hook-audio.cpp which exposes two new Lua functions: `ext.audio.newThreadSound()` and `ext.audio.blobCopy()`.

    newThreadSound takes as arguments a `Thread` object (one which is not running yet) followed by the arguments from `Thread:start()`. newThreadSound will execute the thread contents to completion [on the main thread], retain the environment, and return a `Sound` object. When paired with a `Source` and played, this `Sound` object will invoke `lovr.audio(blob)` on the audio OS thread, but in the environment of the lovr `Thread` supplied, once per miniaudio callback.

    The `Blob` returned by lovr.audio will be interpreted as a list of floats, and played as audio data. This allows for realtime audio synthesis in pure Lua. The input blob is a "sample" blob; its length is the number of samples required. Using `getPointer` and modifying the sample blob, then returning that, instead of creating a new blob, will result in optimal (no buffer allocations) behavior. If the blob returned by `lovr.audio` is smaller than the sample blob, or `nil` is returned, Lovr will halt the source.

**Why are lovr code standards not being followed?**

This is a "request for comments". I am waiting to clean this up to lovr standards until I know how much of this code @bjornbytes wants. There are three possibilities:

1. **Bjorn thinks newThreadSound is a good feature to add to Lovr:** I will convert newThreadSound to C (it's mostly C already) and shove it into `l_audio.c` (or whereever).
2. **Bjorn doesn't think newThreadSound is appropriate for Lovr core but finds the thread changes acceptable:** I will rename the functions in thread.c (to, for example, `lovrThreadSetup` and `lovrThreadError`) and submit that as a separate PR. At some point I will release newThreadSound separately as a plugin.
3. **Bjorn isn't interested in any of this:** I don't clean the code up to Lovr standards, and it lives in the `andi` fork forever.

I would like to request at least (2). (2) would be a non-intrusive change, and it would be useful for almost any plugins that do nonstandard things with Thread objects.

**How to test this?**

Download [callback-audio-demo.zip](https://github.com/bjornbytes/lovr/files/6423455/callback-audio-demo.zip) and execute it in this lovr fork. You will get this demo which generates chords as triangle waves:

<img width="832" alt="Screen Shot 2021-05-04 at 2 54 55 PM" src="https://user-images.githubusercontent.com/277318/117058667-e9d14f00-acec-11eb-9fbf-89d4b1b5e8c7.png">

Execute with the argument `midi.audio.sawTest` for a different demo which uses no 2D UI and plays various noisy FM triangle waves at random.

The demo uses some of the additional features in [lovr-ent](https://github.com/mcclure/lovr-ent) to build the UI and manage inter-thread communication. The "oscilloscope" feature visible in the screenshot is added by lovr-ent.

The demo displays in the mirror, so you might have to force the desktop driver for it to work properly. I have the code to make the demo run in pure VR but haven't set it up yet.

**What is the deal with the thread changes?**

Right now, there is a single `threadRunner()` that boots up a thread, creates an environment, runs it, handles any errors that arise, then disposes all resources. It is internal to `thread.c` and is used directly as the thread callback. This patch cuts those in three. `threadSetup` boots up a thread, creates an environment, and then either returns the environment or (if there was an error) calls `threadError`, deletes the environment and returns NULL. `threadError` does just the error handling and sets the thread as non-running (it does not dispose of the environment). `threadRunner` now just calls `threadSetup` and then immediately cleans up the (completed) thread and environment. 

This patch needs `threadSetup` so it can run the thread boot file but then retain the environment so the thread can "keep running" (eg to call `lovr.audio`). It needs `threadError` so that if an error needs to be flagged in the audio code (IE, the error happens outside Lua) it can do so.

I could imagine it would be possible for `threadSetup` to return the environment even in case of an error, but I'm not sure why.

**What is `blobCopy`?**

This basically takes two blobs and memcpys the one into the other. It's used by the `AudioScope` class to make copies of audio buffers to display. Yes this violates Bjorn's normal rules about blobs. I guess you could maybe do this with `getPointer` and either a loop or `ffi.copy` so it isn't really necessary.

**Why not use the "buffering" feature @nevyn has suggested?**

The buffering feature suggested by nevyn is better than audio-thread generation for some applications and not as good for others. The advantage is it's safer, you don't have to worry about lua code hanging or invoking a long GC happening on the audio thread. The problem with the buffering feature is that it is higher latency. The audio thread runs at a higher OS priority and it's just not possible for a normal thread to wake up often enough to refill the buffer with very low latency. The buffer approach is good for things where a moderate but consistent delay is acceptable, like music or voice in a voice chat environment (I think this is what nevyn was using it for). It's not so good for sound effects which are directly responsive to user input ("the jump button"), or music which the user is playing from some kind of musical instrument (in which case latency will be noticed). A really mature audio API would ideally eventually offer all three of "generate a fixed-length audio file and play it back", "allow audio synthesis by continuously refilling a buffer" and "run code in the audio thread to generate audio realtime".