### PR TITLE
Texture:replacePixels: Add support for string and lightuserdata

### DIFF
--- a/src/api/l_graphics_texture.c
+++ b/src/api/l_graphics_texture.c
@@ -85,12 +85,21 @@ static int l_lovrTextureGetWrap(lua_State* L) {
 
 static int l_lovrTextureReplacePixels(lua_State* L) {
   Texture* texture = luax_checktype(L, 1, Texture);
-  Image* image = luax_checktype(L, 2, Image);
   int x = luaL_optinteger(L, 3, 0);
   int y = luaL_optinteger(L, 4, 0);
   int slice = luaL_optinteger(L, 5, 1) - 1;
   int mipmap = luaL_optinteger(L, 6, 1) - 1;
-  lovrTextureReplacePixels(texture, image, x, y, slice, mipmap);
+  if (lua_type(L, 2) == LUA_TSTRING) {
+    size_t len = 0;
+    const char *data = lua_tolstring(L, 2, &len);
+    lovrTextureReplacePixelsBuffer(texture, (void*)data, x, y, slice, mipmap);
+  } else if (lua_type(L, 2) == LUA_TLIGHTUSERDATA) {
+    const void *data = lua_touserdata(L, 2);
+     lovrTextureReplacePixelsBuffer(texture, (void*)data, x, y, slice, mipmap);
+  } else {
+    Image* image = luax_checktype(L, 2, Image);
+    lovrTextureReplacePixels(texture, image, x, y, slice, mipmap);
+  }
   return 0;
 }
 

--- a/src/modules/graphics/texture.h
+++ b/src/modules/graphics/texture.h
@@ -20,6 +20,7 @@ Texture* lovrTextureCreateFromHandle(uint32_t handle, TextureType type, uint32_t
 void lovrTextureDestroy(void* ref);
 void lovrTextureAllocate(Texture* texture, uint32_t width, uint32_t height, uint32_t depth, TextureFormat format);
 void lovrTextureReplacePixels(Texture* texture, struct Image* data, uint32_t x, uint32_t y, uint32_t slice, uint32_t mipmap);
+void lovrTextureReplacePixelsBuffer(Texture* texture, void* data, uint32_t x, uint32_t y, uint32_t slice, uint32_t mipmap);
 uint64_t lovrTextureGetId(Texture* texture);
 uint32_t lovrTextureGetWidth(Texture* texture, uint32_t mipmap);
 uint32_t lovrTextureGetHeight(Texture* texture, uint32_t mipmap);


### PR DESCRIPTION
Moves pixels into a texture without copying the c buffer. 

Not sure how to handle mipmaps. If the goal is to copy pixels quickly one probably doesn't want to spend time generating mipmaps.

The use case is video textures. 