### PR TITLE
Fix compile on old macos

### DIFF
--- a/src/core/os_macos.c
+++ b/src/core/os_macos.c
@@ -12,6 +12,7 @@
 #import <AVFoundation/AVFoundation.h>
 
 #include "os_glfw.h"
+#include "util.h"
 
 static struct {
   uint64_t frequency;
@@ -64,7 +65,8 @@ void os_request_permission(os_permission permission) {
       if (state.onPermissionEvent) state.onPermissionEvent(permission, true);
       return;
     }
-    
+
+#if TARGET_OS_IOS || (defined(MAC_OS_X_VERSION_10_14) && __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_14)
     switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio]) {
       case AVAuthorizationStatusAuthorized:
         if (state.onPermissionEvent) state.onPermissionEvent(permission, true);
@@ -86,6 +88,9 @@ void os_request_permission(os_permission permission) {
         if (state.onPermissionEvent) state.onPermissionEvent(permission, false);
         break;
     }
+#else
+    lovrAssert(false, "Unreachable code");
+#endif
   }
 }
 


### PR DESCRIPTION
Our permissions code currently uses AVCaptureDevice, which only became available on MacOS with 10.14. The code attempts to deal with this with a [AVCaptureDevice respondsToSelector] check, which will work at runtime, but this check will never run because the code will fail to compile (I tested on 10.13). This change #ifs out the section that can't compile on 10.13. (I set it to throw an assert if the check is compiled out but found at runtime to be needed, on the assumption failing to run is better than running with incorrect permissions.)

There are various other ways we could do this, like late-binding tricks. But in tests this works.
