### PR TITLE
Fix copy so that plugins can work on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,11 +666,20 @@ elseif(APPLE)
   endif()
   function(move_lib)
     if(TARGET ${ARGV0})
-      add_custom_command(TARGET lovr POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-        $<TARGET_SONAME_FILE:${ARGV0}>
-        ${EXE_DIR}/$<TARGET_SONAME_FILE_NAME:${ARGV0}>
-      )
+      get_target_property(TARGET_TYPE ${ARGV0} TYPE)
+      if(${TARGET_TYPE} STREQUAL "MODULE_LIBRARY")
+        add_custom_command(TARGET lovr POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy
+          $<TARGET_FILE:${ARGV0}>
+          ${EXE_DIR}/$<TARGET_FILE_NAME:${ARGV0}>
+        )
+      else()
+        add_custom_command(TARGET lovr POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy
+          $<TARGET_SONAME_FILE:${ARGV0}>
+          ${EXE_DIR}/$<TARGET_SONAME_FILE_NAME:${ARGV0}>
+        )
+      endif()
     endif()
   endfunction()
   move_lib(${LOVR_GLFW})


### PR DESCRIPTION
Tried to build on mac with cjson plugin. Got this error.

<img width="752" alt="Screen Shot 2021-06-24 at 4 01 54 PM" src="https://user-images.githubusercontent.com/277318/123362567-e618b680-d53e-11eb-98e7-25f96e53df87.png">

Bjorn suggested the fix in this patch based on the UNIX code. I tried it. It worked.