### PR TITLE
Fix lovr.audio.setPose() in oculus spatializer mode

### DIFF
--- a/src/modules/audio/spatializer_oculus.c
+++ b/src/modules/audio/spatializer_oculus.c
@@ -237,6 +237,7 @@ static uint32_t oculus_tail(float* scratch, float* output, uint32_t frames) {
       }
     }
   }
+  state.midPlayback = false; // Allow the first Source of the next pass to recognize it is first
   return didAnything ? frames : 0;
 }
 


### PR DESCRIPTION
Critical bugfix to oculus spatializer. Due to this single line being missing, lovr.audio.setPose() never did anything and possibly the oculus spatializer would start doing incorrect things when too many sounds start playing at once.