### PR TITLE
Allow get sample rate in conf.lua, read back with lovr.audio.getSampleRate()

### DIFF
--- a/src/api/l_audio.c
+++ b/src/api/l_audio.c
@@ -202,7 +202,7 @@ static int l_lovrAudioGetSpatializer(lua_State *L) {
   return 1;
 }
 
-static int l_lovrAudioGetSampleRate(lua_State *L) {
+static uint32_t l_lovrAudioGetSampleRate(lua_State *L) {
   lua_pushnumber(L, lovrAudioGetSampleRate());
   return 1;
 }
@@ -319,7 +319,7 @@ int luaopen_lovr_audio(lua_State* L) {
     spatializer = lua_tostring(L, -1);
     lua_pop(L, 1);
 
-    lua_getfield(L, -1, "sampleRate");
+    lua_getfield(L, -1, "samplerate");
     int userSampleRate = luaL_optnumber(L, -1, 0);
     if (userSampleRate > 0)
       sampleRate = userSampleRate;

--- a/src/api/l_audio.c
+++ b/src/api/l_audio.c
@@ -311,7 +311,7 @@ int luaopen_lovr_audio(lua_State* L) {
 
   bool start = true;
   const char *spatializer = NULL;
-  int sampleRate = DEFAULT_SAMPLE_RATE;
+  int sampleRate = 48000; // Set default here
   luax_pushconf(L);
   lua_getfield(L, -1, "audio");
   if (lua_istable(L, -1)) {

--- a/src/api/l_audio.c
+++ b/src/api/l_audio.c
@@ -202,6 +202,11 @@ static int l_lovrAudioGetSpatializer(lua_State *L) {
   return 1;
 }
 
+static int l_lovrAudioGetSampleRate(lua_State *L) {
+  lua_pushnumber(L, lovrAudioGetSampleRate());
+  return 1;
+}
+
 static int l_lovrAudioGetAbsorption(lua_State* L) {
   float absorption[3];
   lovrAudioGetAbsorption(absorption);
@@ -290,6 +295,7 @@ static const luaL_Reg lovrAudio[] = {
   { "setPose", l_lovrAudioSetPose },
   { "setGeometry", l_lovrAudioSetGeometry },
   { "getSpatializer", l_lovrAudioGetSpatializer },
+  { "getSampleRate", l_lovrAudioGetSampleRate },
   { "getAbsorption", l_lovrAudioGetAbsorption },
   { "setAbsorption", l_lovrAudioSetAbsorption },
   { "newSource", l_lovrAudioNewSource },
@@ -305,11 +311,18 @@ int luaopen_lovr_audio(lua_State* L) {
 
   bool start = true;
   const char *spatializer = NULL;
+  int sampleRate = DEFAULT_SAMPLE_RATE;
   luax_pushconf(L);
   lua_getfield(L, -1, "audio");
   if (lua_istable(L, -1)) {
     lua_getfield(L, -1, "spatializer");
     spatializer = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
+    lua_getfield(L, -1, "sampleRate");
+    int userSampleRate = luaL_optnumber(L, -1, 0);
+    if (userSampleRate > 0)
+      sampleRate = userSampleRate;
     lua_pop(L, 1);
 
     lua_getfield(L, -1, "start");
@@ -318,7 +331,7 @@ int luaopen_lovr_audio(lua_State* L) {
   }
   lua_pop(L, 2);
 
-  if (lovrAudioInit(spatializer)) {
+  if (lovrAudioInit(spatializer, sampleRate)) {
     luax_atexit(L, lovrAudioDestroy);
     if (start) {
       lovrAudioSetDevice(AUDIO_PLAYBACK, NULL, 0, NULL, AUDIO_SHARED);

--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -52,7 +52,7 @@ static struct {
   float leftovers[BUFFER_SIZE * 2];
   float absorption[3];
   ma_data_converter playbackConverter;
-  int sampleRate;
+  uint32_t sampleRate;
 } state;
 
 static const ma_format miniaudioFormats[] = {
@@ -227,7 +227,7 @@ static Spatializer* spatializers[] = {
 
 // Entry
 
-bool lovrAudioInit(const char* spatializer, int sampleRate) {
+bool lovrAudioInit(const char* spatializer, uint32_t sampleRate) {
   if (state.initialized) return false;
 
   state.sampleRate = sampleRate;
@@ -406,7 +406,7 @@ const char* lovrAudioGetSpatializer() {
   return state.spatializer->name;
 }
 
-int lovrAudioGetSampleRate() {
+uint32_t lovrAudioGetSampleRate() {
   return state.sampleRate;
 }
 

--- a/src/modules/audio/audio.h
+++ b/src/modules/audio/audio.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#define DEFAULT_SAMPLE_RATE 48000
 #define BUFFER_SIZE 256
 #define MAX_SOURCES 64
 

--- a/src/modules/audio/audio.h
+++ b/src/modules/audio/audio.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#define SAMPLE_RATE 48000
+#define DEFAULT_SAMPLE_RATE 48000
 #define BUFFER_SIZE 256
 #define MAX_SOURCES 64
 
@@ -59,7 +59,7 @@ typedef enum {
 
 typedef void AudioDeviceCallback(const void* id, size_t size, const char* name, bool isDefault, void* userdata);
 
-bool lovrAudioInit(const char* spatializer);
+bool lovrAudioInit(const char* spatializer, int sampleRate);
 void lovrAudioDestroy(void);
 void lovrAudioEnumerateDevices(AudioType type, AudioDeviceCallback* callback, void* userdata);
 bool lovrAudioSetDevice(AudioType type, void* id, size_t size, struct Sound* sink, AudioShareMode shareMode);
@@ -72,6 +72,7 @@ void lovrAudioGetPose(float position[4], float orientation[4]);
 void lovrAudioSetPose(float position[4], float orientation[4]);
 bool lovrAudioSetGeometry(float* vertices, uint32_t* indices, uint32_t vertexCount, uint32_t indexCount, AudioMaterial material);
 const char* lovrAudioGetSpatializer(void);
+int lovrAudioGetSampleRate();
 void lovrAudioGetAbsorption(float absorption[3]);
 void lovrAudioSetAbsorption(float absorption[3]);
 

--- a/src/modules/audio/audio.h
+++ b/src/modules/audio/audio.h
@@ -59,7 +59,7 @@ typedef enum {
 
 typedef void AudioDeviceCallback(const void* id, size_t size, const char* name, bool isDefault, void* userdata);
 
-bool lovrAudioInit(const char* spatializer, int sampleRate);
+bool lovrAudioInit(const char* spatializer, uint32_t sampleRate);
 void lovrAudioDestroy(void);
 void lovrAudioEnumerateDevices(AudioType type, AudioDeviceCallback* callback, void* userdata);
 bool lovrAudioSetDevice(AudioType type, void* id, size_t size, struct Sound* sink, AudioShareMode shareMode);
@@ -72,7 +72,7 @@ void lovrAudioGetPose(float position[4], float orientation[4]);
 void lovrAudioSetPose(float position[4], float orientation[4]);
 bool lovrAudioSetGeometry(float* vertices, uint32_t* indices, uint32_t vertexCount, uint32_t indexCount, AudioMaterial material);
 const char* lovrAudioGetSpatializer(void);
-int lovrAudioGetSampleRate();
+uint32_t lovrAudioGetSampleRate();
 void lovrAudioGetAbsorption(float absorption[3]);
 void lovrAudioSetAbsorption(float absorption[3]);
 

--- a/src/modules/audio/spatializer_oculus.c
+++ b/src/modules/audio/spatializer_oculus.c
@@ -106,7 +106,7 @@ static bool oculus_init(void) {
 
   config.acc_Size = sizeof(config);
   config.acc_MaxNumSources = MAX_SOURCES;
-  config.acc_SampleRate = SAMPLE_RATE;
+  config.acc_SampleRate = lovrAudioGetSampleRate();
   config.acc_BufferLength = BUFFER_SIZE; // Stereo
 
   if (ovrAudio_CreateContext(&state.context, &config) != ovrSuccess) {

--- a/src/modules/audio/spatializer_phonon.c
+++ b/src/modules/audio/spatializer_phonon.c
@@ -146,7 +146,7 @@ bool phonon_init() {
   status = phonon_iplCreateEnvironment(state.context, NULL, simulationSettings, NULL, NULL, &state.environment);
   if (status != IPL_STATUS_SUCCESS) return phonon_destroy(), false;
 
-  state.renderingSettings.samplingRate = SAMPLE_RATE;
+  state.renderingSettings.samplingRate = lovrAudioGetSampleRate();
   state.renderingSettings.frameSize = BUFFER_SIZE;
   state.renderingSettings.convolutionType = IPL_CONVOLUTIONTYPE_PHONON;
 

--- a/src/modules/audio/spatializer_simple.c
+++ b/src/modules/audio/spatializer_simple.c
@@ -60,7 +60,7 @@ uint32_t simple_apply(Source* source, const float* input, float* output, uint32_
   float* gain = state.gain[index];
 
   float lerpDuration = .05f;
-  float lerpFrames = SAMPLE_RATE * lerpDuration;
+  float lerpFrames = lovrAudioGetSampleRate() * lerpDuration;
   float lerpRate = 1.f / lerpFrames;
 
   for (uint32_t c = 0; c < 2; c++) {


### PR DESCRIPTION
This patch has been submitted before and rejected before, and that's okay, I'm just submitting an updated version so you can close the PR and there will be a record of it. :)

This patch allows setting the sample rate. The sample rate still cannot be changed once the program starts, but it can be set in lovr.conf with t.audio.sampleRate and queried with lovr.audio.getSampleRate().

I maintain this patch because sometimes in my fork I need to run at 44.1khz sample rate, but not all the time (so changing audio.h is slightly inconvenient).