### PR TITLE
Fix distance attenuation in Oculus spatializer

### DIFF
--- a/src/modules/audio/spatializer_oculus.c
+++ b/src/modules/audio/spatializer_oculus.c
@@ -191,6 +191,8 @@ static uint32_t oculus_apply(Source* source, const float* input, float* output, 
       state.sources[idx].source = source;
       state.sources[idx].occupied = true;
       ovrAudio_ResetAudioSource(state.context, idx);
+      ovrAudio_SetAudioSourceAttenuationMode(state.context, idx,
+        lovrSourceIsEffectEnabled(source, EFFECT_ATTENUATION) ? ovrAudioSourceAttenuationMode_InverseSquare : ovrAudioSourceAttenuationMode_None, 1.0f);
     }
   }
 


### PR DESCRIPTION
Oops. There's literally been no distance attenuation in the Oculus Spatializer since we merged it. This one-line fix addresses this.