### PR TITLE
Add new XML attributes required for Oculus

### DIFF
--- a/src/resources/AndroidManifest_oculus.xml
+++ b/src/resources/AndroidManifest_oculus.xml
@@ -11,7 +11,7 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <application android:allowBackup="false" android:label="LÖVR" android:extractNativeLibs="false" android:debuggable="true">
     <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
-    <activity android:name="Activity" android:excludeFromRecents="true">
+    <activity android:name="Activity" android:launchMode="singleTask" android:screenOrientation="landscape" android:excludeFromRecents="true">
       <meta-data android:name="android.app.lib_name" android:value="lovr"/>
       <meta-data android:name="com.oculus.vr.focusaware" android:value="true"/>
       <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2"/>


### PR DESCRIPTION
Oculus Store is currently requiring these XML attributes for submission.

By the way, in my fork I've broken out all these various attributes onto their own indented lines— this makes merging less of a problem if individual things have changed (like, you want to change excludeFromRecents because you're making a release build, or you want to bump your version number on the top stanza). Would you be interested in this formatting chagne upstream?