### PR TITLE
Fix horizontal rotation bug in Oculus spatializer

### DIFF
--- a/src/modules/audio/spatializer_oculus.c
+++ b/src/modules/audio/spatializer_oculus.c
@@ -245,8 +245,9 @@ static uint32_t oculus_tail(float* scratch, float* output, uint32_t frames) {
 
 // Oculus math primitives
 
+ // Note: Mirror on YZ plane. There appears to be some difference between Lovr and Oculus Audio quaternions.
 static void oculusUnpackQuat(ovrQuatf* oq, float* lq) {
-  oq->x = lq[0]; oq->y = lq[1]; oq->z = lq[2]; oq->w = lq[3];
+  oq->x = lq[0]; oq->y = lq[1]; oq->z = -lq[2]; oq->w = -lq[3];
 }
 
 static void oculusUnpackVec(ovrVector3f* ov, float* p) {


### PR DESCRIPTION
In my testing, feeding the results from lovr.headset.getPose directly into lovr.audio.setPose produces, in the Oculus spatializer, a situation where spatialization works BUT everything acts as if it has been reflected "horizontally", that is, reflected across the XZ plane. Turning my head left sounds like I turned it right and vice versa. Nothing weird happens on other axes of rotation.

Patch corrects the quaternion being fed into Oculus Audio to reverse this. With this patch my tests show correct orientation on all axes.