### PR TITLE
Font:getWidth and lovr.graphics.print now support a first-line indent

### DIFF
--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -1047,7 +1047,8 @@ static int l_lovrGraphicsPrint(lua_State* L) {
   float wrap = luax_optfloat(L, index++, 0.f);
   HorizontalAlign halign = luax_checkenum(L, index++, HorizontalAlign, "center");
   VerticalAlign valign = luax_checkenum(L, index++, VerticalAlign, "middle");
-  lovrGraphicsPrint(str, length, transform, wrap, halign, valign);
+  float indent = luax_optfloat(L, index++, 0.f);
+  lovrGraphicsPrint(str, length, transform, wrap, halign, valign, indent);
   return 0;
 }
 

--- a/src/api/l_graphics_font.c
+++ b/src/api/l_graphics_font.c
@@ -15,7 +15,8 @@ static int l_lovrFontGetWidth(lua_State* L) {
   float height;
   uint32_t lineCount;
   uint32_t glyphCount;
-  lovrFontMeasure(font, string, length, wrap, &width, &lastLineWidth, &height, &lineCount, &glyphCount);
+  float indent = luax_optfloat(L, 4, 0.f);
+  lovrFontMeasure(font, string, length, wrap, indent, &width, &lastLineWidth, &height, &lineCount, &glyphCount);
   lua_pushnumber(L, width);
   lua_pushnumber(L, lineCount + 1);
   lua_pushnumber(L, lastLineWidth);

--- a/src/modules/graphics/font.c
+++ b/src/modules/graphics/font.c
@@ -106,17 +106,17 @@ Texture* lovrFontGetTexture(Font* font) {
   return font->texture;
 }
 
-void lovrFontRender(Font* font, const char* str, size_t length, float wrap, HorizontalAlign halign, float* vertices, uint16_t* indices, uint16_t baseVertex) {
+void lovrFontRender(Font* font, const char* str, size_t length, float wrap, HorizontalAlign halign, float indent, float* vertices, uint16_t* indices, uint16_t baseVertex) {
   FontAtlas* atlas = &font->atlas;
   bool flip = font->flip;
 
   int height = lovrRasterizerGetHeight(font->rasterizer);
 
-  float cx = 0.f;
+  float scale = 1.f / font->pixelDensity;
+  float cx = indent / scale;
   float cy = -height * .8f * (flip ? -1.f : 1.f);
   float u = atlas->width;
   float v = atlas->height;
-  float scale = 1.f / font->pixelDensity;
 
   const char* start = str;
   const char* end = str + length;
@@ -160,7 +160,7 @@ void lovrFontRender(Font* font, const char* str, size_t length, float wrap, Hori
 
     // Start over if texture was repacked
     if (u != atlas->width || v != atlas->height) {
-      lovrFontRender(font, start, length, wrap, halign, vertices, indices, baseVertex);
+      lovrFontRender(font, start, length, wrap, halign, indent, vertices, indices, baseVertex);
       return;
     }
 
@@ -199,13 +199,13 @@ void lovrFontRender(Font* font, const char* str, size_t length, float wrap, Hori
   lovrFontAlignLine(lineStart, vertexCursor, cx, halign);
 }
 
-void lovrFontMeasure(Font* font, const char* str, size_t length, float wrap, float* width, float* lastLineWidth, float* height, uint32_t* lineCount, uint32_t* glyphCount) {
-  float x = 0.f;
+void lovrFontMeasure(Font* font, const char* str, size_t length, float wrap, float indent, float* width, float* lastLineWidth, float* height, uint32_t* lineCount, uint32_t* glyphCount) {
+  float scale = 1.f / font->pixelDensity;
+  float x = indent / scale;
   const char* end = str + length;
   size_t bytes;
   unsigned int previous = '\0';
   unsigned int codepoint;
-  float scale = 1.f / font->pixelDensity;
   *width = 0.f;
   *lastLineWidth = 0.f;
   *lineCount = 0;

--- a/src/modules/graphics/font.h
+++ b/src/modules/graphics/font.h
@@ -24,8 +24,8 @@ Font* lovrFontCreate(struct Rasterizer* rasterizer, uint32_t padding, double spr
 void lovrFontDestroy(void* ref);
 struct Rasterizer* lovrFontGetRasterizer(Font* font);
 struct Texture* lovrFontGetTexture(Font* font);
-void lovrFontRender(Font* font, const char* str, size_t length, float wrap, HorizontalAlign halign, float* vertices, uint16_t* indices, uint16_t baseVertex);
-void lovrFontMeasure(Font* font, const char* string, size_t length, float wrap, float* width, float* lastLineWidth, float* height, uint32_t* lineCount, uint32_t* glyphCount);
+void lovrFontRender(Font* font, const char* str, size_t length, float wrap, HorizontalAlign halign, float indent, float* vertices, uint16_t* indices, uint16_t baseVertex);
+void lovrFontMeasure(Font* font, const char* string, size_t length, float wrap, float indent, float* width, float* lastLineWidth, float* height, uint32_t* lineCount, uint32_t* glyphCount);
 uint32_t lovrFontGetPadding(Font* font);
 double lovrFontGetSpread(Font* font);
 float lovrFontGetHeight(Font* font);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -1249,14 +1249,14 @@ void lovrGraphicsSkybox(Texture* texture) {
   }
 }
 
-void lovrGraphicsPrint(const char* str, size_t length, mat4 transform, float wrap, HorizontalAlign halign, VerticalAlign valign) {
+void lovrGraphicsPrint(const char* str, size_t length, mat4 transform, float wrap, HorizontalAlign halign, VerticalAlign valign, float indent) {
   float width;
   float lastLineWidth;
   float height;
   uint32_t lineCount;
   uint32_t glyphCount;
   Font* font = lovrGraphicsGetFont();
-  lovrFontMeasure(font, str, length, wrap, &width, &lastLineWidth, &height, &lineCount, &glyphCount);
+  lovrFontMeasure(font, str, length, wrap, indent, &width, &lastLineWidth, &height, &lineCount, &glyphCount);
 
   if (glyphCount == 0) {
     return;
@@ -1287,7 +1287,7 @@ void lovrGraphicsPrint(const char* str, size_t length, mat4 transform, float wra
     .baseVertex = &baseVertex
   });
 
-  lovrFontRender(font, str, length, wrap, halign, vertices, indices, baseVertex);
+  lovrFontRender(font, str, length, wrap, halign, indent, vertices, indices, baseVertex);
 }
 
 void lovrGraphicsFill(Texture* texture, float u, float v, float w, float h) {

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -179,7 +179,7 @@ void lovrGraphicsCircle(DrawStyle style, struct Material* material, mat4 transfo
 void lovrGraphicsCylinder(struct Material* material, mat4 transform, float r1, float r2, bool capped, int segments);
 void lovrGraphicsSphere(struct Material* material, mat4 transform, int segments);
 void lovrGraphicsSkybox(struct Texture* texture);
-void lovrGraphicsPrint(const char* str, size_t length, mat4 transform, float wrap, HorizontalAlign halign, VerticalAlign valign);
+void lovrGraphicsPrint(const char* str, size_t length, mat4 transform, float wrap, HorizontalAlign halign, VerticalAlign valign, float indent);
 void lovrGraphicsFill(struct Texture* texture, float u, float v, float w, float h);
 void lovrGraphicsDrawMesh(struct Mesh* mesh, mat4 transform, uint32_t instances, float* pose);
 #define lovrGraphicsStencil lovrGpuStencil


### PR DESCRIPTION
**Motivation**

I want to be able to do some really basic text layout. In particular, I want to highlight exactly one word as red in a text printout. The best way I can think of to do this is to print the text before the word in white, the word in red, and then the text after the word in white. In order to do this, I must `print` each of the three substrings, then after each `print` use `getWidth` to "advance" my text pointer. The new "last line" feature in `getWidth` makes this possible.

**Problem**

The problem is once I have the "last line" width, I cannot do anything with it. If I add that width to the `print` location, then the entire paragraph will be pushed right, not just the line I'm trying to advance.

**Solution**

The patch allows the "last line" number to be passed back in to `print` or `getWidth` as an "indent". The indent is in in-font sizing (IE it is before the fontScale transformation).

**Test**

Copy this [main.lua.txt](https://github.com/bjornbytes/lovr/files/7150020/main.lua.txt) into a folder as main.lua and run it with the patch.

<img width="1192" alt="Screen Shot 2021-09-12 at 1 19 34 PM" src="https://user-images.githubusercontent.com/277318/132996922-f888ed45-5a6a-487d-8296-9ed80f98916c.png">

**Other approaches?**

lovr.graphics.print is already calculating the values `getWidth` computes (it calls Measure()), so it could return those values when it's called and save a call and a little bit of time.