### PR TITLE
Fix stencil color mask;

### DIFF
--- a/src/modules/graphics/opengl.c
+++ b/src/modules/graphics/opengl.c
@@ -1500,6 +1500,11 @@ void lovrGpuPresent() {
 
 void lovrGpuStencil(StencilAction action, int replaceValue, StencilCallback callback, void* userdata) {
   lovrGraphicsFlush();
+
+  uint8_t lastColorMask = state.colorMask;
+  state.colorMask = 0;
+  glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+
   if (!state.stencilEnabled) {
     state.stencilEnabled = true;
     glEnable(GL_STENCIL_TEST);
@@ -1524,6 +1529,9 @@ void lovrGpuStencil(StencilAction action, int replaceValue, StencilCallback call
   lovrGraphicsFlush();
   state.stencilWriting = false;
   state.stencilMode = ~0; // Dirty
+
+  state.colorMask = lastColorMask;
+  glColorMask(state.colorMask & 0x8, state.colorMask & 0x4, state.colorMask & 0x2, state.colorMask & 0x1);
 }
 
 void lovrGpuDirtyTexture() {


### PR DESCRIPTION
- When calling lovr.graphics.stencil, the color mask is initially
  disabled, and gets restored to its initial state afterwards.
- However, when it's restored, it uses lovrGraphicsSetColorMask, which
  just sets shadow state that doesn't make it all the way to GL until
  another draw is done.
- The consequence of this is that if you call .stencil and then don't do
  a draw, any clears that happen will use the old (disabled) color mask,
  preventing the color buffer from being cleared.
- The solution here is to lower the color mask change down into opengl.c
  where it can directly hit OpenGL.

Need to look over this to make sure there aren't any unintended consequences.