### PR TITLE
pbr-fix to display glass-like materials

### DIFF
--- a/src/resources/shaders.c
+++ b/src/resources/shaders.c
@@ -267,7 +267,7 @@ const char* lovrStandardFragmentShader = ""
 "  result = tonemap_ACES(result * lovrExposure); \n"
 "#endif \n"
 
-"  return lovrGraphicsColor * vec4(result, 1.); \n"
+"  return lovrGraphicsColor * vec4(result, lovrDiffuseColor.a ); \n"
 "}"
 
 // Helpers


### PR DESCRIPTION
the alpha-value of 'roughness' get assigned to lovrDiffuse (which is always 1) unless you set the alpha on the pbr-shader:

![image](https://user-images.githubusercontent.com/180068/147786094-cbf4c906-3113-48a0-bd0e-15af235150f8.png)

(above is a screenshot of blender before exporting to glTF)