### PR TITLE
Fix gamma/linear conversion of a RGB table

### DIFF
--- a/src/api/l_math.c
+++ b/src/api/l_math.c
@@ -192,9 +192,10 @@ static int l_lovrMathGammaToLinear(lua_State* L) {
   if (lua_istable(L, 1)) {
     for (int i = 0; i < 3; i++) {
       lua_rawgeti(L, 1, i + 1);
-      lua_pushnumber(L, lovrMathGammaToLinear(luax_checkfloat(L, -1)));
+      float component = luax_checkfloat(L, -1);
+      lua_pop(L, 1);
+      lua_pushnumber(L, lovrMathGammaToLinear(component));
     }
-    lua_pop(L, 3);
     return 3;
   } else {
     int n = CLAMP(lua_gettop(L), 1, 3);
@@ -209,9 +210,10 @@ static int l_lovrMathLinearToGamma(lua_State* L) {
   if (lua_istable(L, 1)) {
     for (int i = 0; i < 3; i++) {
       lua_rawgeti(L, 1, i + 1);
-      lua_pushnumber(L, lovrMathLinearToGamma(luax_checkfloat(L, -1)));
+      float component = luax_checkfloat(L, -1);
+      lua_pop(L, 1);
+      lua_pushnumber(L, lovrMathLinearToGamma(component));
     }
-    lua_pop(L, 3);
     return 3;
   } else {
     int n = CLAMP(lua_gettop(L), 1, 3);


### PR DESCRIPTION
Correcting the order of stack operations to fetch RGB components from
the table and to put in conversion the results.

Before the fix these two calls produced different results:
`lovr.math.gammaToLinear(  0.1, 0.2, 0.3  )`
`lovr.math.gammaToLinear( {0.1, 0.2, 0.3} )`