### PR TITLE
Add luax_checku32 and luax_optu32;

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -392,6 +392,21 @@ void luax_atexit(lua_State* L, voidFn* destructor) {
   lua_pop(L, 1);
 }
 
+uint32_t _luax_checku32(lua_State* L, int index) {
+  double x = lua_tonumber(L, index);
+
+  if (x == 0. && !lua_isnumber(L, index)) {
+    luaL_typerror(L, index, "number");
+  }
+
+  if (x < 0. || x > UINT32_MAX) {
+    const char* message = lua_pushfstring(L, "expected a number between 0 and %u, got %g", UINT32_MAX, x);
+    luaL_argerror(L, index, message);
+  }
+
+  return (uint32_t) x;
+}
+
 void luax_readcolor(lua_State* L, int index, Color* color) {
   color->r = color->g = color->b = color->a = 1.f;
 

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -82,6 +82,12 @@ typedef struct {
 #define LUA_RIDX_MAINTHREAD 1
 #endif
 
+#ifdef LOVR_UNCHECKED
+#define luax_checku32(L, i) (uint32_t) lua_tonumber(L, i)
+#else
+#define luax_checku32(L, i) _luax_checku32(L, i)
+#endif
+
 #define luax_registertype(L, T) _luax_registertype(L, #T, lovr ## T, lovr ## T ## Destroy)
 #define luax_totype(L, i, T) (T*) _luax_totype(L, i, hash64(#T, sizeof(#T) - 1))
 #define luax_checktype(L, i, T) (T*) _luax_checktype(L, i, hash64(#T, sizeof(#T) - 1), #T)
@@ -90,6 +96,7 @@ typedef struct {
 #define luax_pushenum(L, T, x) lua_pushlstring(L, (lovr ## T)[x].string, (lovr ## T)[x].length)
 #define luax_checkfloat(L, i) (float) luaL_checknumber(L, i)
 #define luax_optfloat(L, i, x) (float) luaL_optnumber(L, i, x)
+#define luax_optu32(L, i, x) lua_isnoneornil(L, i) ? (x) : luax_checku32(L, i)
 #define luax_geterror(L) lua_getfield(L, LUA_REGISTRYINDEX, "_lovrerror")
 #define luax_seterror(L) lua_setfield(L, LUA_REGISTRYINDEX, "_lovrerror")
 #define luax_clearerror(L) lua_pushnil(L), luax_seterror(L)
@@ -111,6 +118,7 @@ void luax_pushconf(struct lua_State* L);
 int luax_setconf(struct lua_State* L);
 void luax_setmainthread(struct lua_State* L);
 void luax_atexit(struct lua_State* L, void (*destructor)(void));
+uint32_t _luax_checku32(struct lua_State* L, int index);
 void luax_readcolor(struct lua_State* L, int index, struct Color* color);
 int luax_readmesh(struct lua_State* L, int index, float** vertices, uint32_t* vertexCount, uint32_t** indices, uint32_t* indexCount, bool* shouldFree);
 

--- a/src/api/l_audio.c
+++ b/src/api/l_audio.c
@@ -320,7 +320,7 @@ int luaopen_lovr_audio(lua_State* L) {
     lua_pop(L, 1);
 
     lua_getfield(L, -1, "samplerate");
-    sampleRate = lua_isnil(L, -1) ? sampleRate : luaL_checkinteger(L, -1);
+    sampleRate = lua_isnil(L, -1) ? sampleRate : luax_checku32(L, -1);
     lua_pop(L, 1);
 
     lua_getfield(L, -1, "start");

--- a/src/api/l_data.c
+++ b/src/api/l_data.c
@@ -83,10 +83,10 @@ static int l_lovrDataNewRasterizer(lua_State* L) {
 static int l_lovrDataNewSound(lua_State* L) {
   int type = lua_type(L, 1);
   if (type == LUA_TNUMBER) {
-    uint64_t frames = luaL_checkinteger(L, 1);
+    uint32_t frames = luax_checku32(L, 1);
     SampleFormat format = luax_checkenum(L, 2, SampleFormat, "f32");
     ChannelLayout layout = luax_checkenum(L, 3, ChannelLayout, "stereo");
-    uint32_t sampleRate = luaL_optinteger(L, 4, 48000);
+    uint32_t sampleRate = luax_optu32(L, 4, 48000);
     Blob* blob = luax_totype(L, 5, Blob);
     const char* other = lua_tostring(L, 5);
     bool stream = other && !strcmp(other, "stream");
@@ -112,8 +112,8 @@ static int l_lovrDataNewSound(lua_State* L) {
 static int l_lovrDataNewImage(lua_State* L) {
   Image* image = NULL;
   if (lua_type(L, 1) == LUA_TNUMBER) {
-    int width = luaL_checkinteger(L, 1);
-    int height = luaL_checkinteger(L, 2);
+    uint32_t width = luax_checku32(L, 1);
+    uint32_t height = luax_checku32(L, 2);
     TextureFormat format = luax_checkenum(L, 3, TextureFormat, "rgba");
     Blob* blob = lua_isnoneornil(L, 4) ? NULL : luax_checktype(L, 4, Blob);
     image = lovrImageCreate(width, height, blob, 0x0, format);

--- a/src/api/l_data_image.c
+++ b/src/api/l_data_image.c
@@ -39,20 +39,20 @@ static int l_lovrImageGetFormat(lua_State* L) {
 static int l_lovrImagePaste(lua_State* L) {
   Image* image = luax_checktype(L, 1, Image);
   Image* source = luax_checktype(L, 2, Image);
-  uint32_t dx = luaL_optinteger(L, 3, 0);
-  uint32_t dy = luaL_optinteger(L, 4, 0);
-  uint32_t sx = luaL_optinteger(L, 5, 0);
-  uint32_t sy = luaL_optinteger(L, 6, 0);
-  uint32_t w = luaL_optinteger(L, 7, source->width);
-  uint32_t h = luaL_optinteger(L, 8, source->height);
+  uint32_t dx = luax_optu32(L, 3, 0);
+  uint32_t dy = luax_optu32(L, 4, 0);
+  uint32_t sx = luax_optu32(L, 5, 0);
+  uint32_t sy = luax_optu32(L, 6, 0);
+  uint32_t w = luax_optu32(L, 7, source->width);
+  uint32_t h = luax_optu32(L, 8, source->height);
   lovrImagePaste(image, source, dx, dy, sx, sy, w, h);
   return 0;
 }
 
 static int l_lovrImageGetPixel(lua_State* L) {
   Image* image = luax_checktype(L, 1, Image);
-  int x = luaL_checkinteger(L, 2);
-  int y = luaL_checkinteger(L, 3);
+  int x = luax_checku32(L, 2);
+  int y = luax_checku32(L, 3);
   Color color = lovrImageGetPixel(image, x, y);
   lua_pushnumber(L, color.r);
   lua_pushnumber(L, color.g);
@@ -63,8 +63,8 @@ static int l_lovrImageGetPixel(lua_State* L) {
 
 static int l_lovrImageSetPixel(lua_State* L) {
   Image* image = luax_checktype(L, 1, Image);
-  int x = luaL_checkinteger(L, 2);
-  int y = luaL_checkinteger(L, 3);
+  int x = luax_checku32(L, 2);
+  int y = luax_checku32(L, 3);
   Color color = {
     luax_optfloat(L, 4, 1.f),
     luax_optfloat(L, 5, 1.f),

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -9,7 +9,7 @@
 static ModelNode* luax_checknode(lua_State* L, int index, ModelData* model) {
   switch (lua_type(L, index)) {
     case LUA_TNUMBER: {
-      uint32_t node = lua_tointeger(L, index) - 1;
+      uint32_t node = luax_checku32(L, index) - 1;
       lovrCheck(node < model->nodeCount, "Invalid node index '%d'", node + 1);
       return &model->nodes[node];
     }
@@ -28,7 +28,7 @@ static ModelNode* luax_checknode(lua_State* L, int index, ModelData* model) {
 static ModelMaterial* luax_checkmaterial(lua_State* L, int index, ModelData* model) {
   switch (lua_type(L, index)) {
     case LUA_TNUMBER: {
-      uint32_t material = lua_tointeger(L, index) - 1;
+      uint32_t material = luax_checku32(L, index) - 1;
       lovrCheck(material < model->materialCount, "Invalid material index '%d'", material + 1);
       return &model->materials[material];
     }
@@ -47,7 +47,7 @@ static ModelMaterial* luax_checkmaterial(lua_State* L, int index, ModelData* mod
 static ModelAnimation* luax_checkanimation(lua_State* L, int index, ModelData* model) {
   switch (lua_type(L, index)) {
     case LUA_TNUMBER: {
-      uint32_t animation = lua_tointeger(L, index) - 1;
+      uint32_t animation = luax_checku32(L, index) - 1;
       lovrCheck(animation < model->animationCount, "Invalid animation index '%d'", animation + 1);
       return &model->animations[animation];
     }
@@ -71,7 +71,7 @@ static int l_lovrModelDataGetBlobCount(lua_State* L) {
 
 static int l_lovrModelDataGetBlob(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->blobCount, "Invalid blob index '%d'", index + 1);
   luax_pushtype(L, Blob, model->blobs[index]);
   return 1;
@@ -85,7 +85,7 @@ static int l_lovrModelDataGetImageCount(lua_State* L) {
 
 static int l_lovrModelDataGetImage(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->imageCount, "Invalid image index '%d'", index + 1);
   luax_pushtype(L, Image, model->images[index]);
   return 1;
@@ -105,7 +105,7 @@ static int l_lovrModelDataGetRootNode(lua_State* L) {
 
 static int l_lovrModelDataGetNodeName(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->nodeCount, "Invalid node index '%d'", index + 1);
   lua_pushstring(L, model->nodes[index].name);
   return 1;
@@ -238,7 +238,7 @@ static int l_lovrModelDataGetMeshCount(lua_State* L) {
 
 static int l_lovrModelDataGetMeshDrawMode(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
   ModelPrimitive* mesh = &model->primitives[index];
   luax_pushenum(L, DrawMode, mesh->mode);
@@ -247,7 +247,7 @@ static int l_lovrModelDataGetMeshDrawMode(lua_State* L) {
 
 static int l_lovrModelDataGetMeshMaterial(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
   ModelPrimitive* mesh = &model->primitives[index];
   if (mesh->material == ~0u) {
@@ -260,7 +260,7 @@ static int l_lovrModelDataGetMeshMaterial(lua_State* L) {
 
 static int l_lovrModelDataGetMeshVertexCount(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
   ModelPrimitive* mesh = &model->primitives[index];
   lua_pushinteger(L, mesh->attributes[ATTR_POSITION] ? mesh->attributes[ATTR_POSITION]->count : 0);
@@ -269,7 +269,7 @@ static int l_lovrModelDataGetMeshVertexCount(lua_State* L) {
 
 static int l_lovrModelDataGetMeshIndexCount(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
   ModelPrimitive* mesh = &model->primitives[index];
   lua_pushinteger(L, mesh->indices ? mesh->indices->count : 0);
@@ -278,7 +278,7 @@ static int l_lovrModelDataGetMeshIndexCount(lua_State* L) {
 
 static int l_lovrModelDataGetMeshVertexFormat(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
   ModelPrimitive* mesh = &model->primitives[index];
   lua_newtable(L);
@@ -314,7 +314,7 @@ static int l_lovrModelDataGetMeshVertexFormat(lua_State* L) {
 
 static int l_lovrModelDataGetMeshIndexFormat(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
   ModelPrimitive* mesh = &model->primitives[index];
   if (!mesh->indices) return lua_pushnil(L), 1;
@@ -327,10 +327,10 @@ static int l_lovrModelDataGetMeshIndexFormat(lua_State* L) {
 
 static int l_lovrModelDataGetMeshVertex(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
   ModelPrimitive* mesh = &model->primitives[index];
-  uint32_t vertex = luaL_checkinteger(L, 3) - 1;
+  uint32_t vertex = luax_checku32(L, 3) - 1;
   uint32_t vertexCount = mesh->attributes[ATTR_POSITION] ? mesh->attributes[ATTR_POSITION]->count : 0;
   lovrCheck(vertex < vertexCount, "Invalid vertex index '%d'", vertex + 1);
   uint32_t total = 0;
@@ -362,10 +362,10 @@ static int l_lovrModelDataGetMeshVertex(lua_State* L) {
 
 static int l_lovrModelDataGetMeshIndex(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t meshIndex = luaL_checkinteger(L, 2) - 1;
+  uint32_t meshIndex = luax_checku32(L, 2) - 1;
   lovrCheck(meshIndex < model->primitiveCount, "Invalid mesh index '%d'", meshIndex + 1);
   ModelPrimitive* mesh = &model->primitives[meshIndex];
-  uint32_t index = luaL_checkinteger(L, 3) - 1;
+  uint32_t index = luax_checku32(L, 3) - 1;
   uint32_t indexCount = mesh->indices ? mesh->indices->count : 0;
   lovrCheck(index < indexCount, "Invalid index index '%d'", index + 1);
   AttributeData data = { .raw = model->buffers[mesh->indices->buffer].data };
@@ -385,7 +385,7 @@ static int l_lovrModelDataGetMaterialCount(lua_State* L) {
 
 static int l_lovrModelDataGetMaterialName(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->nodeCount, "Invalid material index '%d'", index + 1);
   lua_pushstring(L, model->materials[index].name);
   return 1;
@@ -430,7 +430,7 @@ static int l_lovrModelDataGetAnimationCount(lua_State* L) {
 
 static int l_lovrModelDataGetAnimationName(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->animationCount, "Invalid animation index '%d'", index + 1);
   lua_pushstring(L, model->animations[index].name);
   return 1;
@@ -453,7 +453,7 @@ static int l_lovrModelDataGetAnimationChannelCount(lua_State* L) {
 static int l_lovrModelDataGetAnimationChannelNode(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   ModelAnimation* animation = luax_checkanimation(L, 2, model);
-  uint32_t index = luaL_checkinteger(L, 3) - 1;
+  uint32_t index = luax_checku32(L, 3) - 1;
   lovrCheck(index < animation->channelCount, "Invalid channel index '%d'", index + 1);
   ModelAnimationChannel* channel = &animation->channels[index];
   lua_pushinteger(L, channel->nodeIndex);
@@ -463,7 +463,7 @@ static int l_lovrModelDataGetAnimationChannelNode(lua_State* L) {
 static int l_lovrModelDataGetAnimationChannelProperty(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   ModelAnimation* animation = luax_checkanimation(L, 2, model);
-  uint32_t index = luaL_checkinteger(L, 3) - 1;
+  uint32_t index = luax_checku32(L, 3) - 1;
   lovrCheck(index < animation->channelCount, "Invalid channel index '%d'", index + 1);
   ModelAnimationChannel* channel = &animation->channels[index];
   luax_pushenum(L, AnimationProperty, channel->property);
@@ -473,7 +473,7 @@ static int l_lovrModelDataGetAnimationChannelProperty(lua_State* L) {
 static int l_lovrModelDataGetAnimationChannelSmoothMode(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   ModelAnimation* animation = luax_checkanimation(L, 2, model);
-  uint32_t index = luaL_checkinteger(L, 3) - 1;
+  uint32_t index = luax_checku32(L, 3) - 1;
   lovrCheck(index < animation->channelCount, "Invalid channel index '%d'", index + 1);
   ModelAnimationChannel* channel = &animation->channels[index];
   luax_pushenum(L, SmoothMode, channel->smoothing);
@@ -483,7 +483,7 @@ static int l_lovrModelDataGetAnimationChannelSmoothMode(lua_State* L) {
 static int l_lovrModelDataGetAnimationChannelKeyframeCount(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   ModelAnimation* animation = luax_checkanimation(L, 2, model);
-  uint32_t index = luaL_checkinteger(L, 3) - 1;
+  uint32_t index = luax_checku32(L, 3) - 1;
   lovrCheck(index < animation->channelCount, "Invalid channel index '%d'", index + 1);
   ModelAnimationChannel* channel = &animation->channels[index];
   lua_pushinteger(L, channel->keyframeCount);
@@ -493,10 +493,10 @@ static int l_lovrModelDataGetAnimationChannelKeyframeCount(lua_State* L) {
 static int l_lovrModelDataGetAnimationChannelKeyframe(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   ModelAnimation* animation = luax_checkanimation(L, 2, model);
-  uint32_t index = luaL_checkinteger(L, 3) - 1;
+  uint32_t index = luax_checku32(L, 3) - 1;
   lovrCheck(index < animation->channelCount, "Invalid channel index '%d'", index + 1);
   ModelAnimationChannel* channel = &animation->channels[index];
-  uint32_t keyframe = luaL_checkinteger(L, 4) - 1;
+  uint32_t keyframe = luax_checku32(L, 4) - 1;
   lovrCheck(keyframe < channel->keyframeCount, "Invalid keyframe index '%d'", keyframe + 1);
   lua_pushnumber(L, channel->times[keyframe]);
   size_t counts[] = { [PROP_TRANSLATION] = 3, [PROP_ROTATION] = 4, [PROP_SCALE] = 3 };
@@ -515,7 +515,7 @@ static int l_lovrModelDataGetSkinCount(lua_State* L) {
 
 static int l_lovrModelDataGetSkinJoints(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->skinCount, "Invalid skin index '%d'", index + 1);
   ModelSkin* skin = &model->skins[index];
   lua_createtable(L, skin->jointCount, 0);
@@ -528,10 +528,10 @@ static int l_lovrModelDataGetSkinJoints(lua_State* L) {
 
 static int l_lovrModelDataGetSkinInverseBindMatrix(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luaL_checkinteger(L, 2) - 1;
+  uint32_t index = luax_checku32(L, 2) - 1;
   lovrCheck(index < model->skinCount, "Invalid skin index '%d'", index + 1);
   ModelSkin* skin = &model->skins[index];
-  uint32_t joint = luaL_checkinteger(L, 3) - 1;
+  uint32_t joint = luax_checku32(L, 3) - 1;
   lovrCheck(index < skin->jointCount, "Invalid joint index '%d'", joint + 1);
   float* m = skin->inverseBindMatrices + joint * 16;
   for (uint32_t i = 0; i < 16; i++) {

--- a/src/api/l_data_rasterizer.c
+++ b/src/api/l_data_rasterizer.c
@@ -47,7 +47,7 @@ static int l_lovrRasterizerHasGlyphs(lua_State* L) {
     if (lua_type(L, i) == LUA_TSTRING) {
       hasGlyphs &= lovrRasterizerHasGlyphs(rasterizer, lua_tostring(L, i));
     } else {
-      hasGlyphs &= lovrRasterizerHasGlyph(rasterizer, luaL_checkinteger(L, i));
+      hasGlyphs &= lovrRasterizerHasGlyph(rasterizer, luax_checku32(L, i));
     }
   }
   lua_pushboolean(L, hasGlyphs);

--- a/src/api/l_data_sound.c
+++ b/src/api/l_data_sound.c
@@ -101,9 +101,9 @@ static int l_lovrSoundGetFrames(lua_State* L) {
   uint32_t frameCount = lovrSoundGetFrameCount(sound);
 
   int index = lua_type(L, 2) == LUA_TNUMBER ? 2 : 3;
-  uint32_t dstOffset = luaL_optinteger(L, index + 2, 0);
-  uint32_t srcOffset = luaL_optinteger(L, index + 1, 0);
-  uint32_t count = luaL_optinteger(L, index, frameCount - srcOffset);
+  uint32_t dstOffset = luax_optu32(L, index + 2, 0);
+  uint32_t srcOffset = luax_optu32(L, index + 1, 0);
+  uint32_t count = luax_optu32(L, index, frameCount - srcOffset);
   lovrAssert(srcOffset + count <= frameCount, "Tried to read samples past the end of the Sound");
   lua_settop(L, 2);
 
@@ -180,9 +180,9 @@ static int l_lovrSoundSetFrames(lua_State* L) {
     Blob* blob = luax_totype(L, 2, Blob);
 
     if (blob) {
-      uint32_t srcOffset = luaL_optinteger(L, 5, 0);
-      uint32_t dstOffset = luaL_optinteger(L, 4, 0);
-      uint32_t count = luaL_optinteger(L, 3, (blob->size - srcOffset) / stride);
+      uint32_t srcOffset = luax_optu32(L, 5, 0);
+      uint32_t dstOffset = luax_optu32(L, 4, 0);
+      uint32_t count = luax_optu32(L, 3, (blob->size - srcOffset) / stride);
       uint32_t frames = lovrSoundWrite(sound, dstOffset, count, (char*) blob->data + srcOffset);
       lua_pushinteger(L, frames);
       return 1;
@@ -191,9 +191,9 @@ static int l_lovrSoundSetFrames(lua_State* L) {
     Sound* other = luax_totype(L, 2, Sound);
 
     if (other) {
-      uint32_t srcOffset = luaL_optinteger(L, 5, 0);
-      uint32_t dstOffset = luaL_optinteger(L, 4, 0);
-      uint32_t count = luaL_optinteger(L, 3, lovrSoundGetCapacity(other) - srcOffset);
+      uint32_t srcOffset = luax_optu32(L, 5, 0);
+      uint32_t dstOffset = luax_optu32(L, 4, 0);
+      uint32_t count = luax_optu32(L, 3, lovrSoundGetCapacity(other) - srcOffset);
       uint32_t frames = lovrSoundCopy(other, sound, count, srcOffset, dstOffset);
       lua_pushinteger(L, frames);
       return 1;
@@ -205,10 +205,10 @@ static int l_lovrSoundSetFrames(lua_State* L) {
   }
 
   int length = luax_len(L, 2);
-  uint32_t srcOffset = luaL_optinteger(L, 5, 1);
-  uint32_t dstOffset = luaL_optinteger(L, 4, 0);
+  uint32_t srcOffset = luax_optu32(L, 5, 1);
+  uint32_t dstOffset = luax_optu32(L, 4, 0);
   uint32_t limit = MIN(frameCount - dstOffset, (length - srcOffset) / channels + 1);
-  uint32_t count = luaL_optinteger(L, 3, limit);
+  uint32_t count = luax_optu32(L, 3, limit);
   lovrAssert(count <= limit, "Tried to write too many frames (%d is over limit %d)", count, limit);
 
   uint32_t frames = 0;

--- a/src/api/l_event.c
+++ b/src/api/l_event.c
@@ -184,7 +184,7 @@ static int l_lovrEventPush(lua_State* L) {
 }
 
 static int l_lovrEventQuit(lua_State* L) {
-  int exitCode = luaL_optinteger(L, 1, 0);
+  int exitCode = luaL_optint(L, 1, 0);
   Event event = { .type = EVENT_QUIT, .data.quit.exitCode = exitCode };
   lovrEventPush(event);
   return 0;

--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -338,11 +338,11 @@ static int l_lovrGraphicsCreateWindow(lua_State* L) {
   luaL_checktype(L, 1, LUA_TTABLE);
 
   lua_getfield(L, 1, "width");
-  flags.width = luaL_optinteger(L, -1, 1080);
+  flags.width = luax_optu32(L, -1, 1080);
   lua_pop(L, 1);
 
   lua_getfield(L, 1, "height");
-  flags.height = luaL_optinteger(L, -1, 600);
+  flags.height = luax_optu32(L, -1, 600);
   lua_pop(L, 1);
 
   lua_getfield(L, 1, "fullscreen");
@@ -409,7 +409,7 @@ static int l_lovrGraphicsHasWindow(lua_State *L) {
 }
 
 static int l_lovrGraphicsGetViewPose(lua_State* L) {
-  uint32_t view = luaL_checkinteger(L, 1) - 1;
+  uint32_t view = luax_checku32(L, 1) - 1;
   lovrAssert(view < 2, "Invalid view index %d", view + 1);
   if (lua_gettop(L) > 1) {
     float* matrix = luax_checkvector(L, 2, V_MAT4, NULL);
@@ -435,7 +435,7 @@ static int l_lovrGraphicsGetViewPose(lua_State* L) {
 }
 
 static int l_lovrGraphicsSetViewPose(lua_State* L) {
-  uint32_t view = luaL_checkinteger(L, 1) - 1;
+  uint32_t view = luax_checku32(L, 1) - 1;
   lovrAssert(view < 2, "Invalid view index %d", view + 1);
   VectorType t;
   float* m = luax_tovector(L, 2, &t);
@@ -459,7 +459,7 @@ static int l_lovrGraphicsSetViewPose(lua_State* L) {
 }
 
 static int l_lovrGraphicsGetProjection(lua_State* L) {
-  uint32_t view = luaL_checkinteger(L, 1) - 1;
+  uint32_t view = luax_checku32(L, 1) - 1;
   lovrAssert(view < 2, "Invalid view index %d", view + 1);
   if (lua_gettop(L) > 1) {
     float* matrix = luax_checkvector(L, 2, V_MAT4, NULL);
@@ -479,7 +479,7 @@ static int l_lovrGraphicsGetProjection(lua_State* L) {
 }
 
 static int l_lovrGraphicsSetProjection(lua_State* L) {
-  uint32_t view = luaL_checkinteger(L, 1) - 1;
+  uint32_t view = luax_checku32(L, 1) - 1;
   lovrAssert(view < 2, "Invalid view index %d", view + 1);
   if (lua_type(L, 2) == LUA_TNUMBER) {
     float left = luax_checkfloat(L, 2);
@@ -1122,8 +1122,8 @@ static void luax_checkuniformtype(lua_State* L, int index, UniformType* baseType
 static int l_lovrGraphicsNewCanvas(lua_State* L) {
   Attachment attachments[MAX_CANVAS_ATTACHMENTS];
   int attachmentCount = 0;
-  int width = 0;
-  int height = 0;
+  uint32_t width = 0;
+  uint32_t height = 0;
   int index;
 
   if (luax_totype(L, 1, Texture)) {
@@ -1136,8 +1136,8 @@ static int l_lovrGraphicsNewCanvas(lua_State* L) {
     luax_readattachments(L, 1, attachments, &attachmentCount);
     index = 2;
   } else {
-    width = luaL_checkinteger(L, 1);
-    height = luaL_checkinteger(L, 2);
+    width = luax_checku32(L, 1);
+    height = luax_checku32(L, 2);
     index = 3;
   }
 
@@ -1292,12 +1292,12 @@ static int l_lovrGraphicsNewMesh(lua_State* L) {
   Blob* blob = NULL;
 
   if (lua_isnumber(L, 1)) {
-    count = lua_tointeger(L, 1);
+    count = luax_checku32(L, 1);
   } else if (lua_istable(L, 1)) {
     if (lua_isnumber(L, 2)) {
       drawModeIndex++;
       formatIndex = 1;
-      count = lua_tointeger(L, 2);
+      count = luax_checku32(L, 2);
       dataIndex = 0;
     } else if (lua_istable(L, 2)) {
       drawModeIndex++;

--- a/src/api/l_graphics_canvas.c
+++ b/src/api/l_graphics_canvas.c
@@ -13,7 +13,7 @@ static int luax_checkattachment(lua_State* L, int index, Attachment* attachment)
     lua_pop(L, 1);
 
     lua_rawgeti(L, index, 2);
-    attachment->slice = luaL_optinteger(L, -1, 1) - 1;
+    attachment->slice = luax_optu32(L, -1, 1) - 1;
     lua_pop(L, 1);
 
     lua_rawgeti(L, index, 3);

--- a/src/api/l_headset.c
+++ b/src/api/l_headset.c
@@ -213,7 +213,7 @@ static int l_lovrHeadsetGetViewCount(lua_State* L) {
 
 static int l_lovrHeadsetGetViewPose(lua_State* L) {
   float position[4], orientation[4];
-  uint32_t view = luaL_checkinteger(L, 1) - 1;
+  uint32_t view = luax_checku32(L, 1) - 1;
   if (!lovrHeadsetDisplayDriver->getViewPose(view, position, orientation)) {
     lua_pushnil(L);
     return 1;
@@ -232,7 +232,7 @@ static int l_lovrHeadsetGetViewPose(lua_State* L) {
 
 static int l_lovrHeadsetGetViewAngles(lua_State* L) {
   float left, right, up, down;
-  uint32_t view = luaL_checkinteger(L, 1) - 1;
+  uint32_t view = luax_checku32(L, 1) - 1;
   if (!lovrHeadsetDisplayDriver->getViewAngles(view, &left, &right, &up, &down)) {
     lua_pushnil(L);
     return 1;


### PR DESCRIPTION
These functions read an unsigned 32 bit integer from the Lua stack
and error if the value is negative or too big.  Currently converting
Lua numbers to integers will silently wrap or invoke undefined behavior
when they are outside of the acceptable range.

For projects that don't want the overhead of type/bounds checks, the
supercharge build option (LOVR_UNCHECKED) can now be used to skip all
type/bounds checks.

It may be a good idea to rename checkfloat/optfloat to checkf32 and optf32,
for consistency.

It may also be nice to support i32, u16, u8, etc., but those are seldom used.