### PR TITLE
Font filtering now respects the default setting.

### DIFF
--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -1247,8 +1247,8 @@ static int l_lovrGraphicsNewFont(lua_State* L) {
     padding = luaL_optinteger(L, 2, padding);
     spread = luaL_optnumber(L, 3, spread);
   }
-
-  Font* font = lovrFontCreate(rasterizer, padding, spread);
+  TextureFilter defaultFilter = lovrGraphicsGetDefaultFilter();
+  Font* font = lovrFontCreate(rasterizer, padding, spread, defaultFilter.mode);
   luax_pushtype(L, Font, font);
   lovrRelease(rasterizer, lovrRasterizerDestroy);
   lovrRelease(font, lovrFontDestroy);

--- a/src/modules/graphics/font.c
+++ b/src/modules/graphics/font.c
@@ -27,6 +27,7 @@ struct Font {
   uint32_t padding;
   float lineHeight;
   float pixelDensity;
+  FilterMode filterMode;
   bool flip;
 };
 
@@ -49,7 +50,7 @@ static void lovrFontAddGlyph(Font* font, Glyph* glyph);
 static void lovrFontExpandTexture(Font* font);
 static void lovrFontCreateTexture(Font* font);
 
-Font* lovrFontCreate(Rasterizer* rasterizer, uint32_t padding, double spread) {
+Font* lovrFontCreate(Rasterizer* rasterizer, uint32_t padding, double spread, FilterMode filterMode) {
   Font* font = calloc(1, sizeof(Font));
   lovrAssert(font, "Out of memory");
   font->ref = 1;
@@ -60,6 +61,7 @@ Font* lovrFontCreate(Rasterizer* rasterizer, uint32_t padding, double spread) {
   font->spread = spread;
   font->lineHeight = 1.f;
   font->pixelDensity = (float) lovrRasterizerGetHeight(rasterizer);
+  font->filterMode = filterMode;
   map_init(&font->kerning, 0);
 
   // Atlas
@@ -354,7 +356,7 @@ static void lovrFontCreateTexture(Font* font) {
   lovrRelease(font->texture, lovrTextureDestroy);
   Image* image = lovrImageCreate(font->atlas.width, font->atlas.height, NULL, 0x0, FORMAT_RGBA16F);
   font->texture = lovrTextureCreate(TEXTURE_2D, &image, 1, false, false, 0);
-  lovrTextureSetFilter(font->texture, (TextureFilter) { .mode = FILTER_BILINEAR });
+  lovrTextureSetFilter(font->texture, (TextureFilter) { .mode = font->filterMode });
   lovrTextureSetWrap(font->texture, (TextureWrap) { .s = WRAP_CLAMP, .t = WRAP_CLAMP });
   lovrRelease(image, lovrImageDestroy);
 }

--- a/src/modules/graphics/font.h
+++ b/src/modules/graphics/font.h
@@ -1,6 +1,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include "data/modelData.h"
 
 #pragma once
 
@@ -20,7 +21,7 @@ typedef enum {
 } VerticalAlign;
 
 typedef struct Font Font;
-Font* lovrFontCreate(struct Rasterizer* rasterizer, uint32_t padding, double spread);
+Font* lovrFontCreate(struct Rasterizer* rasterizer, uint32_t padding, double spread, FilterMode filterMode);
 void lovrFontDestroy(void* ref);
 struct Rasterizer* lovrFontGetRasterizer(Font* font);
 struct Texture* lovrFontGetTexture(Font* font);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -483,7 +483,7 @@ Font* lovrGraphicsGetFont() {
   if (!state.font) {
     if (!state.defaultFont) {
       Rasterizer* rasterizer = lovrRasterizerCreate(NULL, 32);
-      state.defaultFont = lovrFontCreate(rasterizer, 1, 3.);
+      state.defaultFont = lovrFontCreate(rasterizer, 1, 3., state.defaultFilter.mode);
       lovrRelease(rasterizer, lovrRasterizerDestroy);
     }
 


### PR DESCRIPTION
Per the discussion on https://github.com/bjornbytes/lovr/issues/536.  The default filter setting is now flowed through and used as the font filter.

However, there's a caveat: previously (before this PR) font filter was set to bilinear, as default and always. With this change, it's now configurable, _but_ the default is now trilinear (which is the default for the textures.)

Probably not an issue, but just wanted to bring this up in case it is.
 
I tested this on Linux and Windows and it fixes my issue.