### PR TITLE
Fix a discrepancy between lovrRasterizerMeasure and lovrFontRender wrapping

### DIFF
--- a/src/modules/data/rasterizer.c
+++ b/src/modules/data/rasterizer.c
@@ -197,13 +197,15 @@ void lovrRasterizerMeasure(Rasterizer* rasterizer, const char* str, size_t lengt
   *glyphCount = 0;
 
   while ((bytes = utf8_decode(str, end, &codepoint)) > 0) {
-    if (codepoint == '\n' || (wrap && x > wrap && codepoint == ' ')) {
+    if (codepoint == '\n' || (wrap && x > wrap && (codepoint == ' ' || previous == ' '))) {
       *width = MAX(*width, x);
       (*lineCount)++;
       x = 0.f;
       previous = '\0';
-      str += bytes;
-      continue;
+      if (codepoint == ' ' || codepoint == '\n') {
+        str += bytes;
+        continue;
+      }
     }
 
     // Tabs


### PR DESCRIPTION
The font renderer also looks at the previous character and wraps if it is a space. This caused issues in some cases when we tried to render geometry at the end of wrapped text

https://github.com/bjornbytes/lovr/blob/1e91eea9b01876180ca59fa180151ac92f4925d5/src/modules/graphics/font.c#L137-L146