### PR TITLE
use static assert macro instead of keyword

### DIFF
--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -495,7 +495,7 @@ static bool openxr_init(float supersample, float offset, uint32_t msaa, bool ove
       { 0, NULL, "vibrate",          XR_ACTION_TYPE_VIBRATION_OUTPUT, 2, hands, "Vibrate" }
     };
 
-    _Static_assert(COUNTOF(actionInfo) == MAX_ACTIONS, "Unbalanced action table!");
+    static_assert(COUNTOF(actionInfo) == MAX_ACTIONS, "Unbalanced action table!");
 
     if (!state.features.viveTrackers) {
       actionInfo[ACTION_TRACKER_POSE].countSubactionPaths = 0;

--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -7,6 +7,7 @@
 #include "graphics/texture.h"
 #include "core/os.h"
 #include "util.h"
+#include <assert.h>
 #include <stdlib.h>
 #include <math.h>
 


### PR DESCRIPTION
This change fixes a linker error I noticed when compiling on my windows
sytstem. see #551

According to this link the macro is prefered to the keyword.
https://docs.microsoft.com/en-us/cpp/c-language/static-assert-c?view=msvc-170#:~:text=The%20_Static_assert%20keyword%2C%20and%20the%20static_assert%20macro%2C%20both,runtime%20and%20incur%20a%20runtime%20cost.%20Microsoft-specific%20behavior