### PR TITLE
Hardware raytracing acceleration

### DIFF
--- a/src/api/api.h
+++ b/src/api/api.h
@@ -69,6 +69,7 @@ extern StringEntry lovrVerticalAlign[];
 extern StringEntry lovrVolumeUnit[];
 extern StringEntry lovrWinding[];
 extern StringEntry lovrWrapMode[];
+extern StringEntry lovrRaytraceAccelerationType[];
 
 // General helpers
 

--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -608,6 +608,7 @@ static int l_lovrGraphicsGetFeatures(lua_State* L) {
   lua_pushboolean(L, features.float64), lua_setfield(L, -2, "float64");
   lua_pushboolean(L, features.int64), lua_setfield(L, -2, "int64");
   lua_pushboolean(L, features.int16), lua_setfield(L, -2, "int16");
+  lua_pushboolean(L, features.rayTracing), lua_setfield(L, -2, "rayTracing");
   return 1;
 }
 

--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -615,6 +615,8 @@ static int l_lovrGraphicsGetFeatures(lua_State* L) {
 static int l_lovrGraphicsGetLimits(lua_State* L) {
   GraphicsLimits limits;
   lovrGraphicsGetLimits(&limits);
+  GraphicsFeatures features; // Only needed to decide whether to populate raytrace table
+  lovrGraphicsGetFeatures(&features);
 
   lua_newtable(L);
   lua_pushinteger(L, limits.textureSize2D), lua_setfield(L, -2, "textureSize2D");
@@ -667,6 +669,19 @@ static int l_lovrGraphicsGetLimits(lua_State* L) {
 
   lua_pushnumber(L, limits.anisotropy), lua_setfield(L, -2, "anisotropy");
   lua_pushnumber(L, limits.pointSize), lua_setfield(L, -2, "pointSize");
+
+  if (features.rayTracing) {
+    lua_createtable(L, 7, 0);
+    lua_pushinteger(L, limits.raytrace.shaderGroupHandleSize), lua_setfield(L, -2, "shaderGroupHandleSize");
+    lua_pushinteger(L, limits.raytrace.maxRayRecursionDepth), lua_setfield(L, -2, "maxRayRecursionDepth");
+    lua_pushinteger(L, limits.raytrace.maxShaderGroupStride), lua_setfield(L, -2, "maxShaderGroupStride");
+    lua_pushinteger(L, limits.raytrace.shaderGroupBaseAlignment), lua_setfield(L, -2, "shaderGroupBaseAlignment");
+    lua_pushinteger(L, limits.raytrace.maxRayDispatchInvocationCount), lua_setfield(L, -2, "maxRayDispatchInvocationCount");
+    lua_pushinteger(L, limits.raytrace.shaderGroupHandleAlignment), lua_setfield(L, -2, "shaderGroupHandleAlignment");
+    lua_pushinteger(L, limits.raytrace.maxRayHitAttributeSize), lua_setfield(L, -2, "maxRayHitAttributeSize");
+    lua_setfield(L, -2, "raytrace");
+  }
+
   return 1;
 }
 

--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -1305,7 +1305,7 @@ static int l_lovrGraphicsGetPass(lua_State* L) {
 // TODO flags needed for update to work
 static int l_lovrGraphicsRaytraceGetSizes(lua_State* L) {
   RaytraceAccelerationType rat = luax_checkenum(L, 1, RaytraceAccelerationType, NULL);
-  Blob *blob = luax_totype(L, 2, Blob); //LUA_TUSERDATA
+  Blob *geometryBlob = luax_totype(L, 2, Blob); //LUA_TUSERDATA
   lovrAssert(lua_type(L, 3) == LUA_TTABLE, "Argument 3 must be table");
 
   int structCount = lua_objlen(L, 3);
@@ -1318,7 +1318,7 @@ static int l_lovrGraphicsRaytraceGetSizes(lua_State* L) {
   }
 
   RaytraceBuildsize buildsize;
-  bool success = lovrGraphicsRaytraceGetBuildsize(rat, structCount, structSizes, blob->data, &buildsize);
+  bool success = lovrGraphicsRaytraceGetBuildsize(rat, structCount, structSizes, geometryBlob->data, &buildsize);
 
   free(structSizes);
 

--- a/src/api/l_graphics_pass.c
+++ b/src/api/l_graphics_pass.c
@@ -7,6 +7,7 @@
 #include <lua.h>
 #include <lauxlib.h>
 #include <string.h>
+#include "l_graphics_raytrace_common.h"
 
 static int l_lovrPassGetType(lua_State* L) {
   Pass* pass = luax_checktype(L, 1, Pass);

--- a/src/api/l_graphics_pass.c
+++ b/src/api/l_graphics_pass.c
@@ -784,6 +784,14 @@ static int l_lovrPassMipmap(lua_State* L) {
   return 0;
 }
 
+static int l_lovrPassRaytraceBuild(lua_State *L) {
+  Pass* pass = luax_checktype(L, 1, Pass);
+  RaytraceAccelerationType rat = luax_checkenum(L, 1, RaytraceAccelerationType, NULL);
+  Blob *geometryBlob = luax_totype(L, 2, Blob); //LUA_TUSERDATA
+  Blob *rangeBlob = luax_totype(L, 2, Blob); //LUA_TUSERDATA
+  lovrPassRaytraceBuild(pass, rat, geometryBlob->data, rangeBlob->size/sizeof(void *), rangeBlob->data);
+}
+
 const luaL_Reg lovrPass[] = {
   { "getType", l_lovrPassGetType },
 
@@ -844,6 +852,8 @@ const luaL_Reg lovrPass[] = {
   { "copy", l_lovrPassCopy },
   { "blit", l_lovrPassBlit },
   { "mipmap", l_lovrPassMipmap },
+
+  { "raytraceBuild", l_lovrPassRaytraceBuild },
 
   { NULL, NULL }
 };

--- a/src/api/l_graphics_raytrace_common.h
+++ b/src/api/l_graphics_raytrace_common.h
@@ -1,0 +1,3 @@
+#include "api.h"
+
+

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -649,9 +649,21 @@ typedef struct {
   } vk;
 } gpu_config;
 
+typedef enum {
+  GPU_RAYTRACE_ACCELERATION_TYPE_TOP      = 0,
+  GPU_RAYTRACE_ACCELERATION_TYPE_BOTTOM   = 1,
+} gpu_raytrace_acceleration_type;
+
+typedef struct {
+  uint32_t resultSize; // TODO make gpu_size
+  uint32_t updateScratchSize;
+  uint32_t buildScratchSize;
+} gpu_raytrace_buildsize;
+
 bool gpu_init(gpu_config* config);
 void gpu_destroy(void);
 uint32_t gpu_begin(void);
 void gpu_submit(gpu_stream** streams, uint32_t count);
 bool gpu_finished(uint32_t tick);
 void gpu_wait(void);
+bool gpu_raytrace_get_buildsize(gpu_raytrace_acceleration_type rat, uint32_t structCount, uint32_t *structSizes, void *geometry, gpu_raytrace_buildsize *buildsize);

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -618,6 +618,15 @@ typedef struct {
   uint32_t instances;
   float anisotropy;
   float pointSize;
+  struct { // ALl members of VkPhysicalDeviceRayTracingPipelinePropertiesKHR except shaderGroupHandleCaptureReplaySize
+    uint32_t shaderGroupHandleSize;
+    uint32_t maxRayRecursionDepth;
+    uint32_t maxShaderGroupStride;
+    uint32_t shaderGroupBaseAlignment;
+    uint32_t maxRayDispatchInvocationCount;
+    uint32_t shaderGroupHandleAlignment;
+    uint32_t maxRayHitAttributeSize;
+  } raytrace;
 } gpu_limits;
 
 typedef struct {

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -584,6 +584,7 @@ typedef struct {
   bool float64;
   bool int64;
   bool int16;
+  bool rayTracing;
 } gpu_features;
 
 typedef struct {

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -551,6 +551,7 @@ void gpu_clear_buffer(gpu_stream* stream, gpu_buffer* buffer, uint32_t offset, u
 void gpu_clear_texture(gpu_stream* stream, gpu_texture* texture, float value[4], uint32_t layer, uint32_t layerCount, uint32_t level, uint32_t levelCount);
 void gpu_blit(gpu_stream* stream, gpu_texture* src, gpu_texture* dst, uint32_t srcOffset[4], uint32_t dstOffset[4], uint32_t srcExtent[3], uint32_t dstExtent[3], gpu_filter filter);
 void gpu_sync(gpu_stream* stream, gpu_barrier* barriers, uint32_t count);
+void gpu_raytrace_build(gpu_stream *stream, gpu_raytrace_acceleration_type rat, void *geometry, uint32_t rangeCount, void *ranges);
 
 // Entry
 

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -2833,3 +2833,16 @@ bool gpu_raytrace_get_buildsize(gpu_raytrace_acceleration_type rat, uint32_t str
 
   return true;
 }
+
+bool gpu_raytrace_build(gpu_stream *stream, gpu_raytrace_acceleration_type rat, uint32_t structCount, void *geometry, uint32_t rangeCount, void *ranges) {
+  VkAccelerationStructureBuildGeometryInfoKHR input;
+  input.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
+  input.type = rat==GPU_RAYTRACE_ACCELERATION_TYPE_TOP?
+    VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR :
+    VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+  input.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+  input.geometryCount = structCount;
+  input.pGeometries = (VkAccelerationStructureGeometryKHR *)geometry;
+
+  vkCmdBuildAccelerationStructuresKHR(stream->commands, 1, &input,)
+}

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -1806,19 +1806,17 @@ bool gpu_init(gpu_config* config) {
       bool canRaytrace = true;
       uint32_t deviceExtensionCount = 0;
       vkEnumerateDeviceExtensionProperties(state.adapter, NULL, &deviceExtensionCount, NULL);
-      lovrLog(1, "gpu_vk", "Extensions: %u\n", deviceExtensionCount);
       VkExtensionProperties *extensionProperties = malloc(sizeof(VkExtensionProperties)*deviceExtensionCount);
       vkEnumerateDeviceExtensionProperties(state.adapter, NULL, &deviceExtensionCount, extensionProperties);
       for(unsigned int idx = 0; idx < deviceExtensionCount; idx++) {
         VkExtensionProperties *property = &extensionProperties[idx];
-        lovrLog(1, "gpu_vk", "Extension: %s v %x\n", property->extensionName, property->specVersion);
         for(int check = 0; check < raytraceExtensionCount; check++) {
           if (strncmp(raytraceExtensions[check].name, property->extensionName, VK_MAX_EXTENSION_NAME_SIZE)) {
             raytraceExtensions[check].present = true;
           }
         }
       }
-      free(extensionProperties); // TODO save in extensions
+      free(extensionProperties);
       for(int check = 0; check < raytraceExtensionCount; check++) {
         canRaytrace = canRaytrace && raytraceExtensions[check].present;
       }
@@ -1853,7 +1851,6 @@ bool gpu_init(gpu_config* config) {
 
       // Combine extensions + features to ensure raytracing availability
       canRaytrace = canRaytrace && supportsAccelerationStructure.accelerationStructure;
-      lovrLog(1, "gpu_vk", "Can raytrace? %s (accel structure? %s)\n", canRaytrace?"Y":"N", supportsAccelerationStructure.accelerationStructure?"Y":"N");
       config->features->rayTracing = canRaytrace;
 
       // Format features

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -9,6 +9,9 @@
 #include <dlfcn.h>
 #endif
 
+// Malloc needed exactly once, to scan extensions
+#include <stdlib.h>
+
 // Objects
 
 struct gpu_buffer {
@@ -1890,7 +1893,7 @@ bool gpu_init(gpu_config* config) {
     }
     CHECK(state.queueFamilyIndex != ~0u, "Queue selection failed") return gpu_destroy(), false;
 
-    const char* extensions[1];
+    const char* extensions[1 + raytraceExtensionCount];
     uint32_t extensionCount = 0;
 
     if (state.surface) {

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -1787,6 +1787,11 @@ bool gpu_init(gpu_config* config) {
       .pNext = &multiviewFeatures
     };
 
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR enableAccelerationStructure = { // Raytracing (will be linked in later)
+      .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR,
+      .accelerationStructure = true
+    };
+
     if (config->features) {
       // Check required extensions for raytracing
       enum { raytraceExtensionCount = 2 };
@@ -1890,6 +1895,11 @@ bool gpu_init(gpu_config* config) {
 
     if (state.surface) {
       extensions[extensionCount++] = "VK_KHR_swapchain";
+      if (config->features && config->features->rayTracing) {
+        extensions[extensionCount++] = "VK_KHR_ray_tracing_pipeline";
+        extensions[extensionCount++] = "VK_KHR_acceleration_structure";
+        enableMultiview.pNext = &enableAccelerationStructure;
+      }
     }
 
     VkDeviceCreateInfo deviceInfo = {

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -9,9 +9,6 @@
 #include <dlfcn.h>
 #endif
 
-// Only needed for logging -- can be removed before merge
-#include "util.h"
-
 // Objects
 
 struct gpu_buffer {
@@ -1806,12 +1803,12 @@ bool gpu_init(gpu_config* config) {
       bool canRaytrace = true;
       uint32_t deviceExtensionCount = 0;
       vkEnumerateDeviceExtensionProperties(state.adapter, NULL, &deviceExtensionCount, NULL);
-      lovrLog(LOG_INFO, "gpu_vk", "Extensions: %u\n", deviceExtensionCount);
+      lovrLog(1, "gpu_vk", "Extensions: %u\n", deviceExtensionCount);
       VkExtensionProperties *extensionProperties = malloc(sizeof(VkExtensionProperties)*deviceExtensionCount);
       vkEnumerateDeviceExtensionProperties(state.adapter, NULL, &deviceExtensionCount, extensionProperties);
       for(unsigned int idx = 0; idx < deviceExtensionCount; idx++) {
         VkExtensionProperties *property = &extensionProperties[idx];
-        lovrLog(LOG_INFO, "gpu_vk", "Extension: %s v %x\n", property->extensionName, property->specVersion);
+        lovrLog(1, "gpu_vk", "Extension: %s v %x\n", property->extensionName, property->specVersion);
         for(int check = 0; check < raytraceExtensionCount; check++) {
           if (strncmp(raytraceExtensions[check].name, property->extensionName, VK_MAX_EXTENSION_NAME_SIZE)) {
             raytraceExtensions[check].present = true;
@@ -1853,7 +1850,7 @@ bool gpu_init(gpu_config* config) {
 
       // Combine extensions + features to ensure raytracing availability
       canRaytrace = canRaytrace && supportsAccelerationStructure.accelerationStructure;
-      lovrLog(LOG_INFO, "gpu_vk", "Can raytrace? %s (accel structure? %s)\n", canRaytrace?"Y":"N", supportsAccelerationStructure.accelerationStructure?"Y":"N");
+      lovrLog(1, "gpu_vk", "Can raytrace? %s (accel structure? %s)\n", canRaytrace?"Y":"N", supportsAccelerationStructure.accelerationStructure?"Y":"N");
       config->features->rayTracing = canRaytrace;
 
       // Format features
@@ -1906,7 +1903,7 @@ bool gpu_init(gpu_config* config) {
         }
 
         // Set up acceleration structure feature query by piggypacking on VkPhysicalDeviceFeatures2 chain
-        lovrAssert(!shaderDrawParameterFeatures.pNext, "Acceleration structure query must be appended to end of chain, not middle");
+        CHECK(!shaderDrawParameterFeatures.pNext, "Acceleration structure query must be appended to end of chain, not middle");
         shaderDrawParameterFeatures.pNext = &enableAccelerationStructure;
 
         // Only save raytrace limits if we got this far

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -610,6 +610,13 @@ void lovrGraphicsGetLimits(GraphicsLimits* limits) {
   limits->instances = state.limits.instances;
   limits->anisotropy = state.limits.anisotropy;
   limits->pointSize = state.limits.pointSize;
+  limits->raytrace.shaderGroupHandleSize = state.limits.raytrace.shaderGroupHandleSize;
+  limits->raytrace.maxRayRecursionDepth = state.limits.raytrace.maxRayRecursionDepth;
+  limits->raytrace.maxShaderGroupStride = state.limits.raytrace.maxShaderGroupStride;
+  limits->raytrace.shaderGroupBaseAlignment = state.limits.raytrace.shaderGroupBaseAlignment;
+  limits->raytrace.maxRayDispatchInvocationCount = state.limits.raytrace.maxRayDispatchInvocationCount;
+  limits->raytrace.shaderGroupHandleAlignment = state.limits.raytrace.shaderGroupHandleAlignment;
+  limits->raytrace.maxRayHitAttributeSize = state.limits.raytrace.maxRayHitAttributeSize;
 }
 
 bool lovrGraphicsIsFormatSupported(uint32_t format, uint32_t features) {

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -574,6 +574,7 @@ void lovrGraphicsGetFeatures(GraphicsFeatures* features) {
   features->float64 = state.features.float64;
   features->int64 = state.features.int64;
   features->int16 = state.features.int16;
+  features->rayTracing = state.features.rayTracing;
 }
 
 void lovrGraphicsGetLimits(GraphicsLimits* limits) {

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4137,3 +4137,15 @@ static void onMessage(void* context, const char* message, bool severe) {
     lovrLog(LOG_DEBUG, "GPU", message);
   }
 }
+
+bool lovrGraphicsRaytraceGetBuildsize(RaytraceAccelerationType _rat, uint32_t geoCount, uint32_t *geoSizes, void *geometry, RaytraceBuildsize *outBuildsize) {
+  gpu_raytrace_buildsize buildsize;
+  gpu_raytrace_acceleration_type rat = (gpu_raytrace_acceleration_type)_rat; // Rely on enums being identical
+  bool success = gpu_raytrace_get_buildsize(rat, geoCount, geoSizes, geometry, &buildsize);
+  if (success) {
+    outBuildsize->resultSize = buildsize.resultSize;
+    outBuildsize->updateScratchSize = buildsize.updateScratchSize;
+    outBuildsize->buildScratchSize = buildsize.buildScratchSize;
+  }
+  return success;
+}

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4149,3 +4149,8 @@ bool lovrGraphicsRaytraceGetBuildsize(RaytraceAccelerationType _rat, uint32_t ge
   }
   return success;
 }
+
+void lovrPassRaytraceBuild(Pass *pass, RaytraceAccelerationType _rat, void *geometry, uint32_t rangeCount, void *ranges) {
+  gpu_raytrace_acceleration_type rat = (gpu_raytrace_acceleration_type)_rat; // Rely on enums being identical
+  gpu_raytrace_build(pass->stream, rat, geometry, rangeCount, ranges);
+}

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -34,6 +34,7 @@ typedef struct {
   bool float64;
   bool int64;
   bool int16;
+  bool rayTracing;
 } GraphicsFeatures;
 
 typedef struct {

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -68,6 +68,15 @@ typedef struct {
   uint32_t instances;
   float anisotropy;
   float pointSize;
+  struct { // ALl members of VkPhysicalDeviceRayTracingPipelinePropertiesKHR except shaderGroupHandleCaptureReplaySize
+    uint32_t shaderGroupHandleSize;
+    uint32_t maxRayRecursionDepth;
+    uint32_t maxShaderGroupStride;
+    uint32_t shaderGroupBaseAlignment;
+    uint32_t maxRayDispatchInvocationCount;
+    uint32_t shaderGroupHandleAlignment;
+    uint32_t maxRayHitAttributeSize;
+  } raytrace;
 } GraphicsLimits;
 
 enum {

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -519,3 +519,4 @@ void lovrPassCopyImageToTexture(Pass* pass, struct Image* src, Texture* dst, uin
 void lovrPassCopyTextureToTexture(Pass* pass, Texture* src, Texture* dst, uint32_t srcOffset[4], uint32_t dstOffset[4], uint32_t extent[3]);
 void lovrPassBlit(Pass* pass, Texture* src, Texture* dst, uint32_t srcOffset[4], uint32_t dstOffset[4], uint32_t srcExtent[3], uint32_t dstExtent[3], FilterMode filter);
 void lovrPassMipmap(Pass* pass, Texture* texture, uint32_t base, uint32_t count);
+void lovrPassRaytraceBuild(Pass *pass, RaytraceAccelerationType rat, void *geometry, uint32_t rangeCount, void *ranges);

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -90,6 +90,17 @@ enum {
   TEXTURE_FEATURE_BLIT_DST = (1 << 7)
 };
 
+typedef enum {
+  RAYTRACE_ACCELERATION_TYPE_TOP      = 0,
+  RAYTRACE_ACCELERATION_TYPE_BOTTOM   = 1,
+} RaytraceAccelerationType;
+
+typedef struct {
+  uint32_t resultSize; // TODO make graphics_size
+  uint32_t updateScratchSize;
+  uint32_t buildScratchSize;
+} RaytraceBuildsize;
+
 bool lovrGraphicsInit(bool debug, bool vsync);
 void lovrGraphicsDestroy(void);
 
@@ -104,6 +115,8 @@ Font* lovrGraphicsGetDefaultFont(void);
 
 void lovrGraphicsSubmit(Pass** passes, uint32_t count);
 void lovrGraphicsWait(void);
+
+bool lovrGraphicsRaytraceGetBuildsize(RaytraceAccelerationType rat, uint32_t structCount, uint32_t *structSizes, void *geometry, RaytraceBuildsize *buildsize);
 
 // Buffer
 


### PR DESCRIPTION
This is probably a bad idea.

This is a feature branch in which I'm attempting to add RTX support to the Vulkan branch. Current status is it can check if raytracing is supported, enable it if so, and report back to Lua what it did.

This feature is problematic for reasons including RTX being questionably practical at VR framerates, unlikelihood of support on Android and raytracing being overall simply complex. But, I want to experiment with it. Long term, if we choose to add this feature it should probably have a shader-based fallback implementation for systems that lack RTX.