### PR TITLE
Add piston joint to physics

### DIFF
--- a/src/api/l_physics.c
+++ b/src/api/l_physics.c
@@ -18,6 +18,7 @@ StringEntry lovrJointType[] = {
   [JOINT_DISTANCE] = ENTRY("distance"),
   [JOINT_HINGE] = ENTRY("hinge"),
   [JOINT_SLIDER] = ENTRY("slider"),
+  [JOINT_PISTON] = ENTRY("piston"),
   { 0 }
 };
 
@@ -122,6 +123,17 @@ static int l_lovrPhysicsNewSliderJoint(lua_State* L) {
   return 1;
 }
 
+static int l_lovrPhysicsNewPistonJoint(lua_State* L) {
+  Collider* a = luax_checktype(L, 1, Collider);
+  Collider* b = luax_checktype(L, 2, Collider);
+  float axis[4];
+  luax_readvec3(L, 3, axis, NULL);
+  PistonJoint* joint = lovrPistonJointCreate(a, b, axis[0], axis[1], axis[2]);
+  luax_pushtype(L, PistonJoint, joint);
+  lovrRelease(joint, lovrJointDestroy);
+  return 1;
+}
+
 static int l_lovrPhysicsNewSphereShape(lua_State* L) {
   float radius = luax_optfloat(L, 1, 1.f);
   SphereShape* sphere = lovrSphereShapeCreate(radius);
@@ -139,6 +151,7 @@ static const luaL_Reg lovrPhysics[] = {
   { "newDistanceJoint", l_lovrPhysicsNewDistanceJoint },
   { "newHingeJoint", l_lovrPhysicsNewHingeJoint },
   { "newSliderJoint", l_lovrPhysicsNewSliderJoint },
+  { "newPistonJoint", l_lovrPhysicsNewPistonJoint },
   { "newSphereShape", l_lovrPhysicsNewSphereShape },
   { NULL, NULL }
 };
@@ -149,6 +162,7 @@ extern const luaL_Reg lovrBallJoint[];
 extern const luaL_Reg lovrDistanceJoint[];
 extern const luaL_Reg lovrHingeJoint[];
 extern const luaL_Reg lovrSliderJoint[];
+extern const luaL_Reg lovrPistonJoint[];
 extern const luaL_Reg lovrSphereShape[];
 extern const luaL_Reg lovrBoxShape[];
 extern const luaL_Reg lovrCapsuleShape[];
@@ -164,6 +178,7 @@ int luaopen_lovr_physics(lua_State* L) {
   luax_registertype(L, DistanceJoint);
   luax_registertype(L, HingeJoint);
   luax_registertype(L, SliderJoint);
+  luax_registertype(L, PistonJoint);
   luax_registertype(L, SphereShape);
   luax_registertype(L, BoxShape);
   luax_registertype(L, CapsuleShape);

--- a/src/api/l_physics_joints.c
+++ b/src/api/l_physics_joints.c
@@ -11,6 +11,7 @@ void luax_pushjoint(lua_State* L, Joint* joint) {
     case JOINT_DISTANCE: luax_pushtype(L, DistanceJoint, joint); break;
     case JOINT_HINGE: luax_pushtype(L, HingeJoint, joint); break;
     case JOINT_SLIDER: luax_pushtype(L, SliderJoint, joint); break;
+    case JOINT_PISTON: luax_pushtype(L, PistonJoint, joint); break;
     default: lovrThrow("Unreachable");
   }
 }
@@ -23,7 +24,8 @@ Joint* luax_checkjoint(lua_State* L, int index) {
       hash64("BallJoint", strlen("BallJoint")),
       hash64("DistanceJoint", strlen("DistanceJoint")),
       hash64("HingeJoint", strlen("HingeJoint")),
-      hash64("SliderJoint", strlen("SliderJoint"))
+      hash64("SliderJoint", strlen("SliderJoint")),
+      hash64("PistonJoint", strlen("PistonJoint"))
     };
 
     for (size_t i = 0; i < COUNTOF(hashes); i++) {
@@ -425,5 +427,68 @@ const luaL_Reg lovrSliderJoint[] = {
   { "setUpperLimit", l_lovrSliderJointSetUpperLimit },
   { "getLimits", l_lovrSliderJointGetLimits },
   { "setLimits", l_lovrSliderJointSetLimits },
+  { NULL, NULL }
+};
+
+static int l_lovrPistonJointGetAxis(lua_State* L) {
+  PistonJoint* joint = luax_checktype(L, 1, PistonJoint);
+  float x, y, z;
+  lovrPistonJointGetAxis(joint, &x, &y, &z);
+  lua_pushnumber(L, x);
+  lua_pushnumber(L, y);
+  lua_pushnumber(L, z);
+  return 3;
+}
+
+static int l_lovrPistonJointSetAxis(lua_State* L) {
+  PistonJoint* joint = luax_checktype(L, 1, PistonJoint);
+  float axis[4];
+  luax_readvec3(L, 2, axis, NULL);
+  lovrPistonJointSetAxis(joint, axis[0], axis[1], axis[2]);
+  return 0;
+}
+
+static int l_lovrPistonJointGetPosition(lua_State* L) {
+  PistonJoint* joint = luax_checktype(L, 1, PistonJoint);
+  lua_pushnumber(L, lovrPistonJointGetPosition(joint));
+  return 1;
+}
+
+static int l_lovrPistonJointGetAnchors(lua_State* L) {
+  PistonJoint* joint = luax_checktype(L, 1, PistonJoint);
+  float x1, y1, z1, x2, y2, z2;
+  lovrPistonJointGetAnchors(joint, &x1, &y1, &z1, &x2, &y2, &z2);
+  lua_pushnumber(L, x1);
+  lua_pushnumber(L, y1);
+  lua_pushnumber(L, z1);
+  lua_pushnumber(L, x2);
+  lua_pushnumber(L, y2);
+  lua_pushnumber(L, z2);
+  return 6;
+}
+
+static int l_lovrPistonJointSetAnchor(lua_State* L) {
+  PistonJoint* joint = luax_checktype(L, 1, PistonJoint);
+  float anchor[4];
+  luax_readvec3(L, 2, anchor, NULL);
+  lovrPistonJointSetAnchor(joint, anchor[0], anchor[1], anchor[2]);
+  return 0;
+}
+
+static int l_lovrPistonJointApplyForce(lua_State* L) {
+  PistonJoint* joint = luax_checktype(L, 1, PistonJoint);
+  float force = luax_checkfloat(L, 2);
+  lovrPistonJointApplyForce(joint, force);
+  return 0;
+}
+
+const luaL_Reg lovrPistonJoint[] = {
+  lovrJoint,
+  { "getAxis", l_lovrPistonJointGetAxis },
+  { "setAxis", l_lovrPistonJointSetAxis },
+  { "getAnchors", l_lovrPistonJointGetAnchors },
+  { "setAnchor", l_lovrPistonJointSetAnchor },
+  { "getPosition", l_lovrPistonJointGetPosition },
+  { "applyForce", l_lovrPistonJointApplyForce },
   { NULL, NULL }
 };

--- a/src/modules/physics/physics.c
+++ b/src/modules/physics/physics.c
@@ -1299,3 +1299,57 @@ float lovrSliderJointGetUpperLimit(SliderJoint* joint) {
 void lovrSliderJointSetUpperLimit(SliderJoint* joint, float limit) {
   dJointSetSliderParam(joint->id, dParamHiStop, limit);
 }
+
+PistonJoint* lovrPistonJointCreate(Collider* a, Collider* b, float ax, float ay, float az) {
+  lovrAssert(a->world == b->world, "Joint bodies must exist in the same world");
+  PistonJoint* joint = calloc(1, sizeof(PistonJoint));
+  lovrAssert(joint, "Out of memory");
+  joint->ref = 1;
+  joint->type = JOINT_PISTON;
+  joint->id = dJointCreatePiston(a->world->id, 0);
+  dJointSetData(joint->id, joint);
+  dJointAttach(joint->id, a->body, b->body);
+  lovrPistonJointSetAxis(joint, ax, ay, az);
+  lovrRetain(joint);
+  return joint;
+}
+
+void lovrPistonJointGetAnchors(PistonJoint* joint, float* x1, float* y1, float* z1, float* x2, float* y2, float* z2) {
+  dReal anchor[4];
+  dJointGetPistonAnchor(joint->id, anchor);
+  *x1 = anchor[0];
+  *y1 = anchor[1];
+  *z1 = anchor[2];
+  dJointGetPistonAnchor2(joint->id, anchor);
+  *x2 = anchor[0];
+  *y2 = anchor[1];
+  *z2 = anchor[2];
+}
+
+void lovrPistonJointSetAnchor(PistonJoint* joint, float x, float y, float z) {
+  dJointSetPistonAnchor(joint->id, x, y, z);
+}
+
+void lovrPistonJointGetAxis(PistonJoint* joint, float* x, float* y, float* z) {
+  dReal axis[4];
+  dJointGetPistonAxis(joint->id, axis);
+  *x = axis[0];
+  *y = axis[1];
+  *z = axis[2];
+}
+
+void lovrPistonJointSetAxis(PistonJoint* joint, float x, float y, float z) {
+  dJointSetPistonAxis(joint->id, x, y, z);
+}
+
+float lovrPistonJointGetPosition(PistonJoint* joint) {
+  return dJointGetPistonPosition(joint->id);
+}
+
+float lovrPistonJointGetAngle(PistonJoint* joint) {
+  return dJointGetPistonAngle(joint->id);
+}
+
+void lovrPistonJointApplyForce(PistonJoint* joint, float force) {
+  dJointAddPistonForce(joint->id, force);
+}

--- a/src/modules/physics/physics.h
+++ b/src/modules/physics/physics.h
@@ -23,6 +23,7 @@ typedef Joint BallJoint;
 typedef Joint DistanceJoint;
 typedef Joint HingeJoint;
 typedef Joint SliderJoint;
+typedef Joint PistonJoint;
 
 typedef void (*CollisionResolver)(World* world, void* userdata);
 typedef void (*RaycastCallback)(Shape* shape, float x, float y, float z, float nx, float ny, float nz, void* userdata);
@@ -185,7 +186,8 @@ typedef enum {
   JOINT_BALL,
   JOINT_DISTANCE,
   JOINT_HINGE,
-  JOINT_SLIDER
+  JOINT_SLIDER,
+  JOINT_PISTON
 } JointType;
 
 void lovrJointDestroy(void* ref);
@@ -239,8 +241,18 @@ void lovrSliderJointSetLowerLimit(SliderJoint* joint, float limit);
 float lovrSliderJointGetUpperLimit(SliderJoint* joint);
 void lovrSliderJointSetUpperLimit(SliderJoint* joint, float limit);
 
+PistonJoint* lovrPistonJointCreate(Collider* a, Collider* b, float ax, float ay, float az);
+void lovrPistonJointGetAnchors(PistonJoint* joint, float* x1, float* y1, float* z1, float* x2, float* y2, float* z2);
+void lovrPistonJointSetAnchor(PistonJoint* joint, float x, float y, float z);
+void lovrPistonJointGetAxis(PistonJoint* joint, float* x, float* y, float* z);
+void lovrPistonJointSetAxis(PistonJoint* joint, float x, float y, float z);
+float lovrPistonJointGetPosition(PistonJoint* joint);
+float lovrPistonJointGetAngle(PistonJoint* joint);
+void lovrPistonJointApplyForce(PistonJoint* joint, float force);
+
 // These tokens need to exist for Lua bindings
 #define lovrBallJointDestroy lovrJointDestroy
 #define lovrDistanceJointDestroy lovrJointDestroy
 #define lovrHingeJointDestroy lovrJointDestroy
 #define lovrSliderJointDestroy lovrJointDestroy
+#define lovrPistonJointDestroy lovrJointDestroy


### PR DESCRIPTION
The piston is similar to slider joint, but it allows rotation around the joint axis.

I noticed that the slider joint behaves erratically and unstable when colliders are far from each other. I hoped that piston joint would not have that behavior. It turns out that piston joint is slightly better, but still not perfect. The way to properly fix this is avoiding quickStep, or increasing iteration count.

Maybe having both slider joint and piston joint would confuse new users? To me piston is slightly more versatile, with some torque applied it can be made to work like slider joint. Anyway, the code is working so I'm archiving it as a PR.