### PR TITLE
Add support for setting the display refresh-rate.

### DIFF
--- a/src/api/l_headset.c
+++ b/src/api/l_headset.c
@@ -143,6 +143,41 @@ static int l_lovrHeadsetGetDisplayFrequency(lua_State* L) {
   return 1;
 }
 
+static int l_lovrHeadsetGetDisplayFrequencies(lua_State* L) {
+  if (!lovrHeadsetInterface->getDisplayFrequencies) {
+    lua_pushnil(L);
+    return 1;
+  }
+
+  uint32_t count = 0;
+  float* frequencies = lovrHeadsetInterface->getDisplayFrequencies(&count);
+  if (!frequencies) {
+    lua_pushnil(L);
+    return 1;
+  }
+
+  lua_settop(L, 0);
+  lua_createtable(L, count, 0);
+  for (uint32_t i = 0; i < count; ++i) {
+    lua_pushnumber(L, frequencies[i]);
+    lua_rawseti(L, 1, i + 1);
+  }
+
+  free(frequencies);
+
+  return 1;
+}
+
+static int l_lovrHeadsetSetDisplayFrequency(lua_State* L) {
+  float frequency = luax_checkfloat(L, 1);
+  bool res = false;
+  if (lovrHeadsetInterface->setDisplayFrequency) {
+    res = lovrHeadsetInterface->setDisplayFrequency(frequency);
+  }
+  lua_pushboolean(L, res);
+  return 1;
+}
+
 static int l_lovrHeadsetGetViewCount(lua_State* L) {
   lua_pushinteger(L, lovrHeadsetInterface->getViewCount());
   return 1;
@@ -570,6 +605,8 @@ static const luaL_Reg lovrHeadset[] = {
   { "getDisplayHeight", l_lovrHeadsetGetDisplayHeight },
   { "getDisplayDimensions", l_lovrHeadsetGetDisplayDimensions },
   { "getDisplayFrequency", l_lovrHeadsetGetDisplayFrequency },
+  { "getDisplayFrequencies", l_lovrHeadsetGetDisplayFrequencies },
+  { "setDisplayFrequency", l_lovrHeadsetSetDisplayFrequency },
   { "getViewCount", l_lovrHeadsetGetViewCount },
   { "getViewPose", l_lovrHeadsetGetViewPose },
   { "getViewAngles", l_lovrHeadsetGetViewAngles },

--- a/src/modules/headset/headset.h
+++ b/src/modules/headset/headset.h
@@ -114,6 +114,8 @@ typedef struct HeadsetInterface {
   HeadsetOrigin (*getOriginType)(void);
   void (*getDisplayDimensions)(uint32_t* width, uint32_t* height);
   float (*getDisplayFrequency)(void);
+  float* (*getDisplayFrequencies)(uint32_t* count);
+  bool (*setDisplayFrequency)(float);
   double (*getDisplayTime)(void);
   double (*getDeltaTime)(void);
   uint32_t (*getViewCount)(void);

--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -114,7 +114,9 @@ EGLConfig os_get_egl_config(void);
   X(xrDestroyHandTrackerEXT)\
   X(xrLocateHandJointsEXT)\
   X(xrGetHandMeshFB)\
-  X(xrGetDisplayRefreshRateFB)
+  X(xrGetDisplayRefreshRateFB) \
+  X(xrEnumerateDisplayRefreshRatesFB) \
+  X(xrRequestDisplayRefreshRateFB)
 
 #define XR_DECLARE(fn) static PFN_##fn fn;
 #define XR_LOAD(fn) xrGetInstanceProcAddr(state.instance, #fn, (PFN_xrVoidFunction*) &fn);
@@ -1019,6 +1021,20 @@ static float openxr_getDisplayFrequency(void) {
   return frequency;
 }
 
+static float* openxr_getDisplayFrequencies(uint32_t* count) {
+  if (!state.features.refreshRate || !count) return NULL;
+  XR(xrEnumerateDisplayRefreshRatesFB(state.session, 0, count, NULL));
+  float *frequencies = malloc(*count * sizeof(float));
+  lovrAssert(frequencies, "Out of Memory");
+  XR(xrEnumerateDisplayRefreshRatesFB(state.session, *count, count, frequencies));
+  return frequencies;
+}
+
+static bool openxr_setDisplayFrequency(float frequency) {
+  if (!state.features.refreshRate) return false;
+  XR(xrRequestDisplayRefreshRateFB(state.session, frequency));
+  return true;
+}
 static double openxr_getDisplayTime(void) {
   return state.frameState.predictedDisplayTime / 1e9;
 }
@@ -1809,6 +1825,8 @@ HeadsetInterface lovrHeadsetOpenXRDriver = {
   .getOriginType = openxr_getOriginType,
   .getDisplayDimensions = openxr_getDisplayDimensions,
   .getDisplayFrequency = openxr_getDisplayFrequency,
+  .getDisplayFrequencies = openxr_getDisplayFrequencies,
+  .setDisplayFrequency = openxr_setDisplayFrequency,
   .getDisplayTime = openxr_getDisplayTime,
   .getDeltaTime = openxr_getDeltaTime,
   .getViewCount = openxr_getViewCount,

--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -1031,16 +1031,10 @@ static float* openxr_getDisplayFrequencies(uint32_t* count) {
 }
 
 static bool openxr_setDisplayFrequency(float frequency) {
-  if (!state.features.refreshRate) {
-    return false;
-  }
-
+  if (!state.features.refreshRate) return false;
   XrResult res = xrRequestDisplayRefreshRateFB(state.session, frequency);
-  if (res == XR_ERROR_DISPLAY_REFRESH_RATE_UNSUPPORTED_FB) {
-    return false;
-  }
+  if (res == XR_ERROR_DISPLAY_REFRESH_RATE_UNSUPPORTED_FB) return false;
   XR(res);
-
   return true;
 }
 

--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -1031,10 +1031,19 @@ static float* openxr_getDisplayFrequencies(uint32_t* count) {
 }
 
 static bool openxr_setDisplayFrequency(float frequency) {
-  if (!state.features.refreshRate) return false;
-  XR(xrRequestDisplayRefreshRateFB(state.session, frequency));
+  if (!state.features.refreshRate) {
+    return false;
+  }
+
+  XrResult res = xrRequestDisplayRefreshRateFB(state.session, frequency);
+  if (res == XR_ERROR_DISPLAY_REFRESH_RATE_UNSUPPORTED_FB) {
+    return false;
+  }
+  XR(res);
+
   return true;
 }
+
 static double openxr_getDisplayTime(void) {
   return state.frameState.predictedDisplayTime / 1e9;
 }


### PR DESCRIPTION
## Details

OpenXR provides APIs to enumerate the list of supported refresh-rates, and
selecting a new refresh-rate. This is useful on Quest 2 because the headset
supports 60/72/80/90Hz.

This patch adds two new APIs to the lovr.headset module:
  - `lovr.headset.getDisplayFrequencies()`:
	This function returns a table containing the supported refresh-rates on
	success; nil otherwise.
  - `lovr.headset.setDisplayFrequency(refreshRate:number)`:
	This function takes the new refresh-rate to select as an argument and returns
        true on success, false otherwise.

Only the OpenXR backend has support for this feature and it is gated by the
"refreshRate" OpenXR feature flag, similarly to what the `getDisplayFrequency()`
API does.

## Testing

```lua
function lovr.load()
  supportedFrequencies = lovr.headset.getDisplayFrequencies()
  if supportedFrequencies ~= nil then
    selectedFrequency = math.max(unpack(supportedFrequencies))
  else
    selectedFrequency = 0.0
  end

  print('selected frequency: ' .. selectedFrequency)
  print(lovr.headset.setDisplayFrequency(0.0))
end

function lovr.update(dt)
  print(dt)
end
```
- On Quest 2, `lovr.headset.getDisplayFrequencies()` returns `{60,72,80,90}`
  and `lovr.update(dt)` is called every ~11ms, as expected since the code
  select 90Hz.
- On Linux, `lovr.headset.getDisplayFrequencies()` returns `nil` and the call
  to `lovr.headset.setDisplayFrequency(0.0)` returns `false`. 