### PR TITLE
Allow XR_KHR_android_create_instance to be optional

### DIFF
--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -301,10 +301,14 @@ static bool openxr_init(float supersample, float offset, uint32_t msaa, bool ove
     for (uint32_t i = 0; i < extensionCount; i++) extensionProperties[i].type = XR_TYPE_EXTENSION_PROPERTIES;
     xrEnumerateInstanceExtensionProperties(NULL, extensionCount, &extensionCount, extensionProperties);
 
+#ifdef __ANDROID__
+    bool androidCreateInstanceExtension = false;
+#endif
+
     // Extensions without a feature are required
     struct { const char* name; bool* feature; bool disable; } extensions[] = {
 #ifdef __ANDROID__
-      { "XR_KHR_android_create_instance", NULL, false },
+      { "XR_KHR_android_create_instance", &androidCreateInstanceExtension, false },
 #endif
 #ifdef LOVR_LINUX_EGL
       { "XR_MNDX_egl_enable", NULL, false },
@@ -334,6 +338,7 @@ static bool openxr_init(float supersample, float offset, uint32_t msaa, bool ove
     XrInstanceCreateInfo info = {
       .type = XR_TYPE_INSTANCE_CREATE_INFO,
 #ifdef __ANDROID__
+      // harmless to include even if not available from runtime
       .next = &(XrInstanceCreateInfoAndroidKHR) {
         .type = XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR,
         .applicationVM = activity->vm,


### PR DESCRIPTION
It's essentially replaced by KHR_loader_init_android, and will eventually not be provided by new/updated runtimes, so don't require it.

That said, it's safe to pass its struct even if the extension isn't available, since it will just be ignored if unrecognized.