### PR TITLE
Fix/minutia

### DIFF
--- a/etc/shaders/cubemap.vert
+++ b/etc/shaders/cubemap.vert
@@ -16,7 +16,7 @@ vec4 lovrmain() {
 
   vec2 uv = uvs[VertexIndex % 6];
   vec3 ray = vec3(uv, -1.);
-  mat3 inverseViewOrientation = transpose(mat3(View));
+  mat3 inverseViewOrientation = transpose(mat3(ViewFromLocal));
   Normal = normalize(inverseViewOrientation * (InverseProjection * vec4(ray, 1.)).xyz);
   return vec4(uv, 0, 1);
 }

--- a/src/api/l_data.c
+++ b/src/api/l_data.c
@@ -107,7 +107,7 @@ static int l_lovrDataNewImage(lua_State* L) {
   if (lua_type(L, 1) == LUA_TNUMBER) {
     uint32_t width = luax_checku32(L, 1);
     uint32_t height = luax_checku32(L, 2);
-    TextureFormat format = luax_checkenum(L, 3, TextureFormat, "rgba");
+    TextureFormat format = luax_checkenum(L, 3, TextureFormat, "rgba8");
     image = lovrImageCreateRaw(width, height, format);
     if (lua_gettop(L) >= 4) {
       Blob* blob = luax_checktype(L, 4, Blob);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -5023,9 +5023,13 @@ void lovrPassSkybox(Pass* pass, Texture* texture) {
 }
 
 void lovrPassFill(Pass* pass, Texture* texture) {
+  DefaultShader shader = SHADER_FILL;
+  if (texture && texture->info.layers == 2) {
+    shader = SHADER_STEREOBLIT;
+  }
   lovrPassDraw(pass, &(Draw) {
     .mode = MESH_TRIANGLES,
-    .shader = texture->info.layers == 2 ? SHADER_STEREOBLIT : SHADER_FILL,
+    .shader = shader,
     .material = texture ? lovrTextureGetMaterial(texture) : NULL,
     .vertex.format = VERTEX_EMPTY,
     .count = 3


### PR DESCRIPTION
skybox isn't affected by pass:transform()

newImage() format defaults to missing rgba

pass:fill() segfaults when no texture is set