### PR TITLE
Add physics heightfield shape

### DIFF
--- a/src/api/l_physics.c
+++ b/src/api/l_physics.c
@@ -10,6 +10,7 @@ StringEntry lovrShapeType[] = {
   [SHAPE_CAPSULE] = ENTRY("capsule"),
   [SHAPE_CYLINDER] = ENTRY("cylinder"),
   [SHAPE_MESH] = ENTRY("mesh"),
+  [SHAPE_TERRAIN] = ENTRY("terrain"),
   { 0 }
 };
 

--- a/src/api/l_physics_shapes.c
+++ b/src/api/l_physics_shapes.c
@@ -13,6 +13,7 @@ void luax_pushshape(lua_State* L, Shape* shape) {
     case SHAPE_CAPSULE: luax_pushtype(L, CapsuleShape, shape); break;
     case SHAPE_CYLINDER: luax_pushtype(L, CylinderShape, shape); break;
     case SHAPE_MESH: luax_pushtype(L, MeshShape, shape); break;
+    case SHAPE_TERRAIN: luax_pushtype(L, TerrainShape, shape); break;
     default: lovrUnreachable();
   }
 }

--- a/src/modules/physics/physics.c
+++ b/src/modules/physics/physics.c
@@ -798,6 +798,9 @@ void lovrShapeDestroyData(Shape* shape) {
       dGeomTriMeshDataDestroy(dataID);
       free(shape->vertices);
       free(shape->indices);
+    } else if (shape->type == SHAPE_TERRAIN) {
+      dHeightfieldDataID dataID = dGeomHeightfieldGetHeightfieldData(shape->id);
+      dGeomHeightfieldDataDestroy(dataID);
     }
     dGeomDestroy(shape->id);
     shape->id = NULL;
@@ -1047,6 +1050,20 @@ MeshShape* lovrMeshShapeCreate(int vertexCount, float* vertices, int indexCount,
   mesh->indices = indices;
   dGeomSetData(mesh->id, mesh);
   return mesh;
+}
+
+TerrainShape* lovrTerrainShapeCreate(float* vertices, int widthSamples, int depthSamples, float horizontalScale, float verticalScale) {
+  const float thickness = 10.f;
+  TerrainShape* terrain = calloc(1, sizeof(TerrainShape));
+  lovrAssert(terrain, "Out of memory");
+  terrain->ref = 1;
+  dHeightfieldDataID dataID = dGeomHeightfieldDataCreate();
+  dGeomHeightfieldDataBuildSingle(dataID, vertices, 1, horizontalScale, horizontalScale,
+                                  widthSamples, depthSamples, verticalScale, 0.f, thickness, 0);
+  terrain->id = dCreateHeightfield(0, dataID, 1);
+  terrain->type = SHAPE_TERRAIN;
+  dGeomSetData(terrain->id, terrain);
+  return terrain;
 }
 
 void lovrJointDestroy(void* ref) {

--- a/src/modules/physics/physics.h
+++ b/src/modules/physics/physics.h
@@ -18,6 +18,7 @@ typedef Shape BoxShape;
 typedef Shape CapsuleShape;
 typedef Shape CylinderShape;
 typedef Shape MeshShape;
+typedef Shape TerrainShape;
 
 typedef Joint BallJoint;
 typedef Joint DistanceJoint;
@@ -131,6 +132,7 @@ typedef enum {
   SHAPE_CAPSULE,
   SHAPE_CYLINDER,
   SHAPE_MESH,
+  SHAPE_TERRAIN,
 } ShapeType;
 
 void lovrShapeDestroy(void* ref);
@@ -171,6 +173,7 @@ float lovrCylinderShapeGetLength(CylinderShape* cylinder);
 void lovrCylinderShapeSetLength(CylinderShape* cylinder, float length);
 
 MeshShape* lovrMeshShapeCreate(int vertexCount, float vertices[], int indexCount, uint32_t indices[]);
+TerrainShape* lovrTerrainShapeCreate(float* vertices, int widthSamples, int depthSamples, float horizontalScale, float verticalScale);
 
 // These tokens need to exist for Lua bindings
 #define lovrSphereShapeDestroy lovrShapeDestroy
@@ -178,6 +181,7 @@ MeshShape* lovrMeshShapeCreate(int vertexCount, float vertices[], int indexCount
 #define lovrCapsuleShapeDestroy lovrShapeDestroy
 #define lovrCylinderShapeDestroy lovrShapeDestroy
 #define lovrMeshShapeDestroy lovrShapeDestroy
+#define lovrTerrainShapeDestroy lovrShapeDestroy
 
 // Joints
 


### PR DESCRIPTION
This is sitting on my drive for too long. It works, but needs bit more effort before it's ready to merge.

It is not possible to change the pose of heightfield after creating it. I believe the `dGeomSetPosition` needs to be used (need to test), so the `setPose()` would have to be specialized for the heightfield collider case. I also skipped on using the recommended `dGeomHeightfieldDataSetBounds()` as it didn't behave correctly in my tests.

I've only tested on "r32f" heightmap image format as I can store actual terrain height into each pixel. Other formats that support `getPixel()` should be OK to use, with the `verticalScaling` parameter mapping the 0 to 1 pixel value to actual height. Changing the terrain is not implemented at the moment.

I would like to also support the callback mode where ODE constantly queries the Lua side about height at coordinates. Useful for sea with waves, but it could pan out to be too slow to use.