### PR TITLE
GLTF fixes

### DIFF
--- a/src/api/l_graphics_model.c
+++ b/src/api/l_graphics_model.c
@@ -30,7 +30,12 @@ static uint32_t luax_checkanimation(lua_State* L, int index, Model* model) {
       lovrCheck(animationIndex != MAP_NIL, "ModelData has no animation named '%s'", name);
       return (uint32_t) animationIndex;
     }
-    case LUA_TNUMBER: return lua_tointeger(L, index) - 1;
+    case LUA_TNUMBER: {
+      uint32_t animation = luax_checku32(L, index) - 1;
+      ModelData* data = lovrModelGetInfo(model)->data;
+      lovrCheck(animation < data->animationCount, "Invalid animation index '%d'", animation + 1);
+      return animation;
+    }
     default: return luax_typeerror(L, index, "number or string"), ~0u;
   }
 }
@@ -45,7 +50,12 @@ uint32_t luax_checknodeindex(lua_State* L, int index, Model* model) {
       lovrCheck(nodeIndex != MAP_NIL, "ModelData has no node named '%s'", name);
       return (uint32_t) nodeIndex;
     }
-    case LUA_TNUMBER: return lua_tointeger(L, index) - 1;
+    case LUA_TNUMBER: {
+      uint32_t node = luax_checku32(L, index) - 1;
+      ModelData* data = lovrModelGetInfo(model)->data;
+      lovrCheck(node < data->nodeCount, "Invalid node index '%d'", node + 1);
+      return node;
+    }
     default: return luax_typeerror(L, index, "number or string"), ~0u;
   }
 }

--- a/src/api/l_graphics_model.c
+++ b/src/api/l_graphics_model.c
@@ -143,14 +143,12 @@ static int l_lovrModelGetNodeScale(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
   uint32_t node = luax_checknodeindex(L, 2, model);
   OriginType origin = luax_checkenum(L, 3, OriginType, "root");
-  float position[4], scale[4], rotation[4], angle, ax, ay, az;
+  float position[4], scale[4], rotation[4];
   lovrModelGetNodeTransform(model, node, position, scale, rotation, origin);
-  quat_getAngleAxis(rotation, &angle, &ax, &ay, &az);
-  lua_pushnumber(L, angle);
-  lua_pushnumber(L, ax);
-  lua_pushnumber(L, ay);
-  lua_pushnumber(L, az);
-  return 4;
+  lua_pushnumber(L, scale[0]);
+  lua_pushnumber(L, scale[1]);
+  lua_pushnumber(L, scale[2]);
+  return 3;
 }
 
 static int l_lovrModelSetNodeScale(lua_State* L) {

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -888,7 +888,7 @@ ModelData* lovrModelDataInitGltf(ModelData* model, Blob* source, ModelDataIO* io
           scale[2] = NOM_FLOAT(json, token);
         } else if (STR_EQ(key, "name")) {
           gltfString name = NOM_STR(json, token);
-          map_set(&model->nodeMap, hash64(name.data, name.length), model->nodeCount - i);
+          map_set(&model->nodeMap, hash64(name.data, name.length), node - model->nodes);
           memcpy(model->chars, name.data, name.length);
           node->name = model->chars;
           model->chars += name.length + 1;

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -2797,13 +2797,11 @@ const ModelInfo* lovrModelGetInfo(Model* model) {
 
 uint32_t lovrModelGetNodeDrawCount(Model* model, uint32_t node) {
   ModelData* data = model->info.data;
-  lovrCheck(node < data->nodeCount, "Invalid model node index %d", node + 1);
   return data->nodes[node].primitiveCount;
 }
 
 void lovrModelGetNodeDraw(Model* model, uint32_t node, uint32_t index, ModelDraw* mesh) {
   ModelData* data = model->info.data;
-  lovrCheck(node < data->nodeCount, "Invalid model node index %d", node + 1);
   lovrCheck(index < data->nodes[node].primitiveCount, "Invalid model node draw index %d", index + 1);
   Draw* draw = &model->draws[data->nodes[node].primitiveIndex + index];
   mesh->mode = draw->mode;


### PR DESCRIPTION
from matrix chat:

> I've noticed some off-by-ones with GLTF model node indices
> but I'm not sure which is the right place to fix it:
> * the GLTF model parser puts its nodes into the modelData->nodes array starting at zero (of course) and the root node last, but in modelData->nodeMap the indices that are stored start counting from 1
> * luax_checknode in l_data_modelData.c doesn't account for this and therefore all getNode...() APIs from there are off-by-one when using strings to access the nodes
>
>the question is, should the map in the GLTF model parser be fixed or should the map output be used - 1 for indexing model->nodes[] (and if so, why?)
> also: the animation & material maps have the same map_set call / index logic, so they might be off-by-one as well? Haven't checked their Lua APIs yet to see if there is proper conversion happening here
>
> ah, model->materialCount - i starts from 0, and I'm guessing this is true for animations too
> for model->nodeCount - i this is probably off-by-one because the rootNode (with highest index) is not accounted for