### PR TITLE
Fix constrained rendering in windowed mode on macOS #620

### DIFF
--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -649,7 +649,7 @@ bool lovrGraphicsInit(GraphicsConfig* config) {
       .srgb = true
     };
 
-    os_window_get_size(&state.window->info.width, &state.window->info.height);
+    os_window_get_fbsize(&state.window->info.width, &state.window->info.height);
 
     state.depthFormat = config->stencil ? FORMAT_D32FS8 : FORMAT_D32F;
 


### PR DESCRIPTION
Fixes #620

Desktop rendering on macOS in windowed mode was previously constrained to 25% of the view. This was caused by using the initial window size rather than the framebuffer size when setting the viewport.

This issue has been fixed by using `os_window_get_fbsize` instead of `os_window_get_size` when setting the viewport. This ensures that the viewport is correctly set based on the framebuffer size, which takes DPI into account.

Tested on macOS 13.1 ARM64.