### PR TITLE
Buffer Format Improvements

### DIFF
--- a/src/api/api.h
+++ b/src/api/api.h
@@ -152,10 +152,12 @@ bool luax_writefile(const char* filename, const void* data, size_t size);
 
 #ifndef LOVR_DISABLE_GRAPHICS
 struct Buffer;
+struct BufferField;
 struct ColoredString;
 struct Model;
 struct Buffer* luax_checkbuffer(lua_State* L, int index);
-void luax_readbufferfield(lua_State* L, int index, int type, void* data);
+void luax_checkbufferformat(lua_State* L, int index, struct BufferField* fields, uint32_t* count, uint32_t max);
+void luax_readbufferfield(lua_State* L, int index, const struct BufferField* field, char* data);
 void luax_readbufferdata(lua_State* L, int index, struct Buffer* buffer, char* data);
 uint32_t luax_checkcomparemode(lua_State* L, int index);
 struct ColoredString* luax_checkcoloredstrings(lua_State* L, int index, uint32_t* count, struct ColoredString* stack);

--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -879,7 +879,14 @@ static int l_lovrGraphicsNewBuffer(lua_State* L) {
     } else if (lua_type(L, -1) == LUA_TTABLE) {
       lua_getfield(L, -1, "type");
       if (lua_isnil(L, -1)) {
-        lua_pop(L, 2);
+        lua_pop(L, 1);
+        lua_rawgeti(L, -1, 2);
+        if (lua_type(L, -1) == LUA_TSTRING) {
+          lua_settop(L, 2);
+          lua_insert(L, 1);
+        } else {
+          lua_pop(L, 2);
+        }
       } else {
         lua_settop(L, 2);
         lua_insert(L, 1);

--- a/src/api/l_graphics_buffer.c
+++ b/src/api/l_graphics_buffer.c
@@ -196,7 +196,7 @@ static void luax_readarray(lua_State* L, int index, uint32_t offset, uint32_t co
   } else {
     int n = fieldComponents[field->type];
 
-    if (type == LUA_TUSERDATA) {
+    if (type == LUA_TUSERDATA || type == LUA_TLIGHTUSERDATA) {
       for (uint32_t i = 0; i < count; i++, data += field->stride) {
         lua_rawgeti(L, index, i + offset + 1);
         lovrCheck(lua_isuserdata(L, -1), "Expected vector object for array value (arrays must use the same type for all elements)");

--- a/src/api/l_graphics_buffer.c
+++ b/src/api/l_graphics_buffer.c
@@ -13,6 +13,12 @@ static const uint32_t vectorComponents[MAX_VECTOR_TYPES] = {
   [V_MAT4] = 16
 };
 
+Buffer* luax_checkbuffer(lua_State* L, int index) {
+  Buffer* buffer = luax_checktype(L, index, Buffer);
+  lovrCheck(lovrBufferIsValid(buffer), "Buffers created with getBuffer can only be used for a single frame (unable to use this Buffer again because lovr.graphics.submit has been called since it was created)");
+  return buffer;
+}
+
 static const uint32_t fieldComponents[] = {
   [FIELD_I8x4] = 4,
   [FIELD_U8x4] = 4,
@@ -61,18 +67,12 @@ typedef union {
   float* f32;
 } FieldPointer;
 
-Buffer* luax_checkbuffer(lua_State* L, int index) {
-  Buffer* buffer = luax_checktype(L, index, Buffer);
-  lovrCheck(lovrBufferIsValid(buffer), "Buffers created with getBuffer can only be used for a single frame (unable to use this Buffer again because lovr.graphics.submit has been called since it was created)");
-  return buffer;
-}
-
-void luax_readbufferfield(lua_State* L, int index, int type, void* data) {
+static void luax_readcomponents(lua_State* L, int index, FieldType type, void* data) {
   FieldPointer p = { .raw = data };
   if (lua_isuserdata(L, index)) {
     VectorType vectorType;
     float* v = luax_tovector(L, index, &vectorType);
-    lovrCheck(vectorComponents[vectorType] == fieldComponents[type], "Vector type is incompatible with field type");
+    lovrCheck(vectorComponents[vectorType] == fieldComponents[type], "Vector type is incompatible with field type (expected %d components, got %d)", fieldComponents[type], vectorComponents[vectorType]);
     switch (type) {
       case FIELD_I8x4: for (int i = 0; i < 4; i++) p.i8[i] = (int8_t) v[i]; break;
       case FIELD_U8x4: for (int i = 0; i < 4; i++) p.u8[i] = (uint8_t) v[i]; break;
@@ -145,124 +145,210 @@ void luax_readbufferfield(lua_State* L, int index, int type, void* data) {
   }
 }
 
+static void luax_readstruct(lua_State* L, int index, const BufferField* field, char* data) {
+  lovrCheck(lua_istable(L, index), "Expected table for struct data");
+  index = index > 0 ? index : lua_gettop(L) + 1 + index;
+
+  if (!field->children[0].name || luax_len(L, index) > 0) {
+    for (uint32_t i = 0, j = 1; i < field->childCount; i++) {
+      const BufferField* child = &field->children[i];
+      uint32_t n = 1;
+
+      lua_rawgeti(L, index, j);
+      if (child->length == 0 && child->childCount == 0 && lua_type(L, -1) == LUA_TNUMBER) {
+        for (uint32_t c = fieldComponents[child->type]; c > 1; c--, n++) {
+          lua_rawgeti(L, index, j + n);
+        }
+      }
+
+      luax_readbufferfield(L, -n, child, data + child->offset);
+      lua_pop(L, n);
+      j += n;
+    }
+  } else {
+    for (uint32_t i = 0; i < field->childCount; i++) {
+      const BufferField* child = &field->children[i];
+      lua_pushstring(L, child->name);
+      lua_rawget(L, index);
+      luax_readbufferfield(L, -1, child, data + child->offset);
+      lua_pop(L, 1);
+    }
+  }
+}
+
+static void luax_readarray(lua_State* L, int index, uint32_t offset, uint32_t count, const BufferField* field, char* data) {
+  lovrCheck(lua_istable(L, index), "Expected table for array data");
+
+  if (!count) {
+    count = field->length;
+  }
+
+  lua_rawgeti(L, index, 1);
+  int type = lua_type(L, -1);
+  lua_pop(L, 1);
+
+  if (field->childCount > 0) {
+    for (uint32_t i = 0; i < count; i++, data += field->stride) {
+      lua_rawgeti(L, index, i + offset + 1);
+      luax_readstruct(L, -1, field, data);
+      lua_pop(L, 1);
+    }
+  } else {
+    int n = fieldComponents[field->type];
+
+    if (type == LUA_TUSERDATA) {
+      for (uint32_t i = 0; i < count; i++, data += field->stride) {
+        lua_rawgeti(L, index, i + offset + 1);
+        lovrCheck(lua_isuserdata(L, -1), "Expected vector object for array value (arrays must use the same type for all elements)");
+        luax_readcomponents(L, -1, field->type, data);
+        lua_pop(L, 1);
+      }
+    } else if (type == LUA_TNUMBER) {
+      for (uint32_t i = 0; i < count; i++, data += field->stride) {
+        for (int c = 1; c <= n; c++) {
+          lua_rawgeti(L, index, i * n + offset + c);
+        }
+        luax_readcomponents(L, -n, field->type, data);
+        lua_pop(L, n);
+      }
+    } else if (type == LUA_TTABLE) {
+      for (uint32_t i = 0; i < count; i++, data += field->stride) {
+        lua_rawgeti(L, index, i + offset + 1);
+        lovrCheck(lua_istable(L, -1), "Expected nested table for array value (arrays must use the same type for all elements)");
+        for (int c = 1, j = -1; c <= n; c++, j--) {
+          lua_rawgeti(L, j, c);
+        }
+        luax_readcomponents(L, -n, field->type, data);
+        lua_pop(L, n + 1);
+      }
+    } else {
+      lovrThrow("Expected number, table, or vector for array contents");
+    }
+  }
+}
+
+void luax_readbufferfield(lua_State* L, int index, const BufferField* field, char* data) {
+  if (field->length > 0) {
+    luax_readarray(L, index, 0, 0, field, data);
+  } else if (field->childCount > 0) {
+    luax_readstruct(L, index, field, data);
+  } else if (lua_type(L, index) == LUA_TTABLE) {
+    int n = fieldComponents[field->type];
+    for (int c = 0; c < n; c++) {
+      lua_rawgeti(L, index < 0 ? index - c : index, c + 1);
+    }
+    luax_readcomponents(L, -n, field->type, data);
+    lua_pop(L, n);
+  } else {
+    luax_readcomponents(L, index, field->type, data);
+  }
+}
+
 void luax_readbufferdata(lua_State* L, int index, Buffer* buffer, char* data) {
   const BufferInfo* info = lovrBufferGetInfo(buffer);
-  uint32_t stride = info->stride;
-
   Blob* blob = luax_totype(L, index, Blob);
-  uint32_t srcIndex = luax_optu32(L, index + 1, 1) - 1;
-  uint32_t dstIndex = luax_optu32(L, index + 2, 1) - 1;
 
   if (blob) {
-    lovrCheck(dstIndex <= info->length, "Destination index is %d but buffer can only hold %d things", dstIndex, info->length);
-
-    size_t blobSize = blob->size / stride;
-    lovrCheck(srcIndex <= blobSize, "Source index is %d but blob only contains %d things", srcIndex, (uint32_t) blobSize);
-
-    // Conversion is safe because right side will never exceed size of uint32_t
-    uint32_t limit = (uint32_t) MIN(blobSize - srcIndex, info->length - dstIndex);
-    uint32_t count = luax_optu32(L, index + 3, limit);
-    lovrCheck(srcIndex + count <= blob->size / stride, "Tried to read too many elements from the Blob");
-    lovrCheck(dstIndex + count <= info->length, "Tried to write Buffer elements [%d,%d] but Buffer can only hold %d things", dstIndex + 1, dstIndex + count - 1, info->length);
-    data = data ? data : lovrBufferMap(buffer, dstIndex * stride, count * stride);
-    char* src = (char*) blob->data + srcIndex * stride;
-    memcpy(data, src, count * stride);
+    uint32_t srcOffset = luax_optu32(L, index + 1, 0);
+    uint32_t dstOffset = luax_optu32(L, index + 2, 0);
+    lovrCheck(srcOffset < blob->size, "Source offset is bigger than the size of the Blob");
+    lovrCheck(dstOffset < info->size, "Destination offset is bigger than the size of the Buffer");
+    uint32_t limit = MIN(blob->size - srcOffset, info->size - dstOffset);
+    uint32_t extent = luax_optu32(L, index + 3, limit);
+    lovrCheck(extent <= blob->size - srcOffset, "Buffer copy range exceeds the size of the source Blob");
+    lovrCheck(extent <= info->size - dstOffset, "Buffer copy range exceeds the size of the target Buffer");
+    data = data ? data : lovrBufferMap(buffer, dstOffset, extent);
+    memcpy(data, (char*) blob->data + srcOffset, extent);
     return;
   }
 
   luaL_checktype(L, index, LUA_TTABLE);
-  lua_rawgeti(L, index, 1);
-  bool nested = lua_istable(L, -1);
-  lua_pop(L, 1);
+  lovrCheck(info->fields, "Buffer must be created with format information to copy a table to it");
 
-  uint32_t length = luax_len(L, index);
-  uint32_t limit = nested ? MIN(length - srcIndex, info->length - dstIndex) : info->length - dstIndex;
-  uint32_t count = luax_optu32(L, index + 3, limit);
-  lovrCheck(dstIndex + count <= info->length, "Tried to write Buffer elements [%d,%d] but Buffer can only hold %d things", dstIndex + 1, dstIndex + count - 1, info->length);
-
-  data = data ? data : lovrBufferMap(buffer, dstIndex * stride, count * stride);
-
-  if (nested) {
-    for (uint32_t i = 0; i < count; i++) {
-      lua_rawgeti(L, index, i + srcIndex + 1);
-      lovrCheck(lua_type(L, -1) == LUA_TTABLE, "Expected table of tables");
-      int j = 1;
-      for (uint32_t f = 0; f < info->fieldCount; f++) {
-        int n = 1;
-        lua_rawgeti(L, -1, j);
-        const BufferField* field = &info->fields[f];
-        if (!lua_isuserdata(L, -1)) {
-          n = fieldComponents[field->type];
-          for (int c = 1; c < n; c++) {
-            lua_rawgeti(L, -c - 1, j + c);
-          }
-        }
-        luax_readbufferfield(L, -n, field->type, data + field->offset);
-        lua_pop(L, n);
-        j += n;
-      }
-      data += info->stride;
-      lua_pop(L, 1);
-    }
+  if (info->fields[0].length > 0) {
+    data = data ? data : lovrBufferMap(buffer, 0, info->size);
+    luax_readbufferfield(L, index, info->fields, data);
   } else {
-    for (uint32_t i = 0, j = srcIndex + 1; i < count && j <= length; i++) {
-      for (uint32_t f = 0; f < info->fieldCount; f++) {
-        int n = 1;
-        lua_rawgeti(L, index, j);
-        const BufferField* field = &info->fields[f];
-        if (!lua_isuserdata(L, -1)) {
-          n = fieldComponents[field->type];
-          for (int c = 1; c < n; c++) {
-            lua_rawgeti(L, index, (int) j + c);
-          }
-        }
-        luax_readbufferfield(L, -n, field->type, data + field->offset);
-        lua_pop(L, n);
-        j += n;
-      }
-      data += info->stride;
-    }
+    lua_rawgeti(L, index, 1);
+    bool nested = lua_istable(L, -1);
+    lua_pop(L, 1);
+
+    BufferField* array = &info->fields[0];
+    uint32_t tableLength = luax_len(L, index);
+    uint32_t srcIndex = luax_optu32(L, index + 1, 1) - 1;
+    uint32_t dstIndex = luax_optu32(L, index + 2, 1) - 1;
+    uint32_t limit = nested ? MIN(tableLength - srcIndex, array->length - dstIndex) : array->length - dstIndex;
+    uint32_t count = luax_optu32(L, index + 3, limit);
+
+    lovrCheck(dstIndex + count <= array->length, "Buffer copy range exceeds the length of the target Buffer");
+    data = data ? data : lovrBufferMap(buffer, dstIndex * array->stride, count * array->stride);
+    luax_readarray(L, index, srcIndex, count, array, data);
   }
 }
 
 static int l_lovrBufferGetSize(lua_State* L) {
   Buffer* buffer = luax_checkbuffer(L, 1);
   const BufferInfo* info = lovrBufferGetInfo(buffer);
-  uint32_t size = info->length * MAX(info->stride, 1);
-  lua_pushinteger(L, size);
+  lua_pushinteger(L, info->size);
   return 1;
 }
 
 static int l_lovrBufferGetLength(lua_State* L) {
   Buffer* buffer = luax_checkbuffer(L, 1);
   const BufferInfo* info = lovrBufferGetInfo(buffer);
-  lua_pushinteger(L, info->length);
+  uint32_t length = info->fields ? info->fields[0].length : 0;
+  lua_pushinteger(L, length);
   return 1;
 }
 
 static int l_lovrBufferGetStride(lua_State* L) {
   Buffer* buffer = luax_checkbuffer(L, 1);
   const BufferInfo* info = lovrBufferGetInfo(buffer);
-  lua_pushinteger(L, info->stride);
+  uint32_t stride = info->fields && info->fields[0].length > 0 ? info->fields[0].stride : 0;
+  lua_pushinteger(L, stride);
   return 1;
+}
+
+static void luax_pushbufferformat(lua_State* L, const BufferField* fields, uint32_t count, bool root) {
+  lua_createtable(L, count, 0);
+  for (uint32_t i = 0; i < count; i++) {
+    const BufferField* field = &fields[i];
+    lua_newtable(L);
+    if (field->name) {
+      lua_pushstring(L, field->name);
+      lua_setfield(L, -2, "name");
+    }
+    if (field->location != ~0u) {
+      lua_pushinteger(L, field->location);
+      lua_setfield(L, -2, "location");
+    }
+    if (field->childCount > 0) {
+      luax_pushbufferformat(L, field->children, field->childCount, false);
+    } else {
+      luax_pushenum(L, FieldType, field->type);
+    }
+    lua_setfield(L, -2, "type");
+    lua_pushinteger(L, field->offset);
+    lua_setfield(L, -2, "offset");
+    if (field->length > 0 && !root) {
+      lua_pushinteger(L, field->length);
+      lua_setfield(L, -2, "length");
+      lua_pushinteger(L, field->stride);
+      lua_setfield(L, -2, "stride");
+    }
+    lua_rawseti(L, -2, i + 1);
+  }
 }
 
 static int l_lovrBufferGetFormat(lua_State* L) {
   Buffer* buffer = luax_checkbuffer(L, 1);
   const BufferInfo* info = lovrBufferGetInfo(buffer);
-  lua_createtable(L, info->fieldCount, 0);
-  for (uint32_t i = 0; i < info->fieldCount; i++) {
-    const BufferField* field = &info->fields[i];
-    lua_createtable(L, 0, 3);
-    luax_pushenum(L, FieldType, field->type);
-    lua_setfield(L, -2, "type");
-    lua_pushinteger(L, field->offset);
-    lua_setfield(L, -2, "offset");
-    if (!field->hash) {
-      lua_pushinteger(L, field->location);
-      lua_setfield(L, -2, "location");
-    }
-    lua_rawseti(L, -2, i + 1);
+  if (info->fieldCount == 0) {
+    lua_pushnil(L);
+  } else if (info->fields[0].childCount > 0) {
+    luax_pushbufferformat(L, info->fields[0].children, info->fields[0].childCount, true);
+  } else {
+    luax_pushbufferformat(L, info->fields, 1, true);
   }
   return 1;
 }
@@ -294,9 +380,9 @@ static int l_lovrBufferSetData(lua_State* L) {
 static int l_lovrBufferClear(lua_State* L) {
   Buffer* buffer = luax_checkbuffer(L, 1);
   const BufferInfo* info = lovrBufferGetInfo(buffer);
-  uint32_t index = luax_optu32(L, 2, 1);
-  uint32_t count = luax_optu32(L, 3, info->length - index + 1);
-  lovrBufferClear(buffer, (index - 1) * info->stride, count * info->stride);
+  uint32_t offset = luax_optu32(L, 2, 0);
+  uint32_t extent = luax_optu32(L, 3, info->size - offset);
+  lovrBufferClear(buffer, offset, extent);
   return 0;
 }
 

--- a/src/api/l_graphics_pass.c
+++ b/src/api/l_graphics_pass.c
@@ -438,6 +438,19 @@ static int l_lovrPassSetStencilWrite(lua_State* L) {
   return 0;
 }
 
+static int l_lovrPassSetVertexFormat(lua_State* L) {
+  uint32_t count = 0;
+  BufferField fields[11];
+  Pass* pass = luax_checktype(L, 1, Pass);
+  if (lua_isnil(L, 2)) {
+    lovrPassSetVertexFormat(pass, NULL, 0);
+  } else {
+    luax_checkbufferformat(L, 2, fields, &count, COUNTOF(fields));
+    lovrPassSetVertexFormat(pass, fields, count);
+  }
+  return 0;
+}
+
 static int l_lovrPassSetViewport(lua_State* L) {
   Pass* pass = luax_checktype(L, 1, Pass);
   float viewport[4];
@@ -505,30 +518,10 @@ static int l_lovrPassSend(lua_State* L) {
     return 0;
   }
 
-  if (!name) {
-    return luax_typeerror(L, 3, "Buffer, Texture, or Sampler");
-  }
-
   void* data;
-  FieldType type;
-  lovrPassSendValue(pass, name, length, &data, &type);
-
-  int index = 3;
-
-  // readbufferfield doesn't handle booleans or tables; coerce/unpack
-  if (lua_isboolean(L, 3)) {
-    bool value = lua_toboolean(L, 3);
-    lua_settop(L, 2);
-    lua_pushinteger(L, value);
-  } else if (lua_istable(L, 3)) {
-    int length = luax_len(L, 3);
-    for (int i = 0; i < length && i < 16; i++) {
-      lua_rawgeti(L, 3, i + 1);
-    }
-    index = 4;
-  }
-
-  luax_readbufferfield(L, index, type, data);
+  BufferField* field;
+  lovrPassSendData(pass, name, length, slot, &data, &field);
+  luax_readbufferfield(L, 3, field, data);
   return 0;
 }
 
@@ -794,6 +787,27 @@ static int l_lovrPassDraw(lua_State* L) {
 
 static int l_lovrPassMesh(lua_State* L) {
   Pass* pass = luax_checktype(L, 1, Pass);
+
+  if (lua_istable(L, 2)) {
+    lua_rawgeti(L, 2, 1);
+    lovrCheck(lua_type(L, -1) == LUA_TTABLE, "Vertex data must be provided as a table of tables");
+    lua_pop(L, 1);
+    float transform[16];
+    uint32_t vertexCount = luax_len(L, 2);
+    uint32_t indexCount = lua_istable(L, 3) ? luax_len(L, 3) : 0;
+    luax_readmat4(L, indexCount > 0 ? 4 : 3, transform, 1);
+    BufferField* format;
+    void* vertices;
+    void* indices;
+    lovrPassMeshImmediate(pass, vertexCount, &vertices, &format, indexCount, &indices, transform);
+    luax_readbufferfield(L, 2, format, vertices);
+    if (indexCount > 0) {
+      BufferField indexFormat = { .type = FIELD_INDEX16, .length = indexCount, .stride = 2 };
+      luax_readbufferfield(L, 3, &indexFormat, indices);
+    }
+    return 0;
+  }
+
   Buffer* vertices = (!lua_toboolean(L, 2) || lua_type(L, 2) == LUA_TNUMBER) ? NULL : luax_checkbuffer(L, 2);
   Buffer* indices = luax_totype(L, 3, Buffer);
   Buffer* indirect = luax_totype(L, 4, Buffer);
@@ -839,9 +853,9 @@ static int l_lovrPassClear(lua_State* L) {
 
   if (buffer) {
     const BufferInfo* info = lovrBufferGetInfo(buffer);
-    uint32_t index = luax_optu32(L, 3, 1);
-    uint32_t count = luax_optu32(L, 4, info->length - index + 1);
-    lovrPassClearBuffer(pass, buffer, (index - 1) * info->stride, count * info->stride);
+    uint32_t offset = luax_optu32(L, 3, 0);
+    uint32_t extent = luax_optu32(L, 4, info->size - offset);
+    lovrPassClearBuffer(pass, buffer, offset, extent);
     return 0;
   }
 
@@ -866,20 +880,29 @@ static int l_lovrPassCopy(lua_State* L) {
 
   if (lua_istable(L, 2)) {
     Buffer* buffer = luax_checkbuffer(L, 3);
-    uint32_t srcIndex = luax_optu32(L, 4, 1) - 1;
-    uint32_t dstIndex = luax_optu32(L, 5, 1) - 1;
-
-    lua_rawgeti(L, 2, 1);
-    bool nested = lua_istable(L, -1);
-    lua_pop(L, 1);
-
-    uint32_t length = luax_len(L, 2);
     const BufferInfo* info = lovrBufferGetInfo(buffer);
-    uint32_t limit = nested ? MIN(length - srcIndex, info->length - dstIndex) : info->length - dstIndex;
-    uint32_t count = luax_optu32(L, 6, limit);
+    lovrCheck(info->fields, "Buffer must be created with format information to copy a table to it");
+    const BufferField* array = &info->fields[0];
+    void* data = NULL;
 
-    void* data = lovrPassCopyDataToBuffer(pass, buffer, dstIndex * info->stride, count * info->stride);
-    lua_remove(L, 3); // table, srcIndex, dstIndex, count
+    if (array->length == 0) {
+      data = lovrPassCopyDataToBuffer(pass, buffer, 0, info->size);
+    } else {
+      uint32_t srcIndex = luax_optu32(L, 4, 1) - 1;
+      uint32_t dstIndex = luax_optu32(L, 5, 1) - 1;
+
+      lua_rawgeti(L, 2, 1);
+      bool nested = lua_istable(L, -1);
+      lua_pop(L, 1);
+
+      uint32_t tableLength = luax_len(L, 2);
+      uint32_t limit = nested ? MIN(tableLength - srcIndex, array->length - dstIndex) : array->length - dstIndex;
+      uint32_t count = luax_optu32(L, 6, limit);
+
+      data = lovrPassCopyDataToBuffer(pass, buffer, dstIndex * array->stride, count * array->stride);
+    }
+
+    lua_remove(L, 3); // Remove buffer, leaving (table, srcIndex, dstIndex, count)
     luax_readbufferdata(L, 2, buffer, data);
     return 0;
   }
@@ -891,14 +914,13 @@ static int l_lovrPassCopy(lua_State* L) {
     uint32_t srcOffset = luax_optu32(L, 4, 0);
     uint32_t dstOffset = luax_optu32(L, 5, 0);
     const BufferInfo* info = lovrBufferGetInfo(buffer);
-    uint32_t bufferSize = info->length * info->stride;
     lovrCheck(srcOffset <= blob->size, "Source byte offset is %d but Blob is only %d bytes", srcOffset, (uint32_t) blob->size);
-    lovrCheck(dstOffset <= bufferSize, "Destination byte offset is %d but Buffer is only %d bytes", dstOffset, bufferSize);
+    lovrCheck(dstOffset <= info->size, "Destination byte offset is %d but Buffer is only %d bytes", dstOffset, info->size);
     // Conversion is safe because right side will never exceed size of uint32_t
-    uint32_t limit = (uint32_t) MIN(blob->size - srcOffset, bufferSize - dstOffset);
+    uint32_t limit = (uint32_t) MIN(blob->size - srcOffset, info->size - dstOffset);
     uint32_t extent = luax_optu32(L, 6, limit);
     lovrCheck(extent <= blob->size - srcOffset, "Buffer copy range exceeds Blob size");
-    lovrCheck(extent <= info->length * info->stride - dstOffset, "Buffer copy offset exceeds Buffer size");
+    lovrCheck(extent <= info->size - dstOffset, "Buffer copy range exceeds Buffer size");
     void* data = lovrPassCopyDataToBuffer(pass, buffer, dstOffset, extent);
     memcpy(data, (char*) blob->data + srcOffset, extent);
     return 0;
@@ -912,7 +934,7 @@ static int l_lovrPassCopy(lua_State* L) {
     uint32_t dstOffset = luax_optu32(L, 5, 0);
     const BufferInfo* srcInfo = lovrBufferGetInfo(buffer);
     const BufferInfo* dstInfo = lovrBufferGetInfo(dst);
-    uint32_t limit = MIN(srcInfo->length * srcInfo->stride - srcOffset, dstInfo->length * dstInfo->stride - dstOffset);
+    uint32_t limit = MIN(srcInfo->size - srcOffset, dstInfo->size - dstOffset);
     uint32_t extent = luax_optu32(L, 6, limit);
     lovrPassCopyBufferToBuffer(pass, buffer, dst, srcOffset, dstOffset, extent);
     return 0;
@@ -1016,9 +1038,8 @@ static int l_lovrPassRead(lua_State* L) {
 
   if (buffer) {
     const BufferInfo* info = lovrBufferGetInfo(buffer);
-    uint32_t index = luax_optu32(L, 3, 1) - 1;
-    uint32_t offset = index * info->stride;
-    uint32_t extent = luax_optu32(L, 4, info->length - index) * info->stride;
+    uint32_t offset = luax_optu32(L, 3, 0);
+    uint32_t extent = luax_optu32(L, 4, info->size - offset);
     Readback* readback = lovrPassReadBuffer(pass, buffer, offset, extent);
     luax_pushtype(L, Readback, readback);
     lovrRelease(readback, lovrReadbackDestroy);
@@ -1113,6 +1134,7 @@ const luaL_Reg lovrPass[] = {
   { "setShader", l_lovrPassSetShader },
   { "setStencilTest", l_lovrPassSetStencilTest },
   { "setStencilWrite", l_lovrPassSetStencilWrite },
+  { "setVertexFormat", l_lovrPassSetVertexFormat },
   { "setViewport", l_lovrPassSetViewport },
   { "setWinding", l_lovrPassSetWinding },
   { "setWireframe", l_lovrPassSetWireframe },

--- a/src/api/l_graphics_pass.c
+++ b/src/api/l_graphics_pass.c
@@ -440,7 +440,7 @@ static int l_lovrPassSetStencilWrite(lua_State* L) {
 
 static int l_lovrPassSetVertexFormat(lua_State* L) {
   uint32_t count = 0;
-  BufferField fields[11];
+  BufferField fields[16];
   Pass* pass = luax_checktype(L, 1, Pass);
   if (lua_isnil(L, 2)) {
     lovrPassSetVertexFormat(pass, NULL, 0);

--- a/src/core/spv.c
+++ b/src/core/spv.c
@@ -33,7 +33,10 @@ typedef union {
   } constant;
   struct {
     uint16_t word;
-    uint16_t name;
+    union {
+      uint16_t name;
+      uint16_t arrayStride;
+    };
   } type;
 } spv_cache;
 
@@ -43,6 +46,7 @@ typedef struct {
   size_t wordCount;
   uint32_t bound;
   spv_cache* cache;
+  spv_field* fields;
 } spv_context;
 
 #define OP_CODE(op) (op[0] & 0xffff)
@@ -56,7 +60,7 @@ static spv_result spv_parse_type(spv_context* spv, const uint32_t* op, spv_info*
 static spv_result spv_parse_spec_constant(spv_context* spv, const uint32_t* op, spv_info* info);
 static spv_result spv_parse_constant(spv_context* spv, const uint32_t* op, spv_info* info);
 static spv_result spv_parse_variable(spv_context* spv, const uint32_t* op, spv_info* info);
-static spv_result spv_parse_push_constants(spv_context* spv, const uint32_t* op, spv_info* info);
+static spv_result spv_parse_field(spv_context* spv, const uint32_t* op, spv_field* field, spv_info* info);
 static bool spv_load_type(spv_context* spv, uint32_t id, const uint32_t** op);
 
 spv_result spv_parse(const void* source, size_t size, spv_info* info) {
@@ -65,6 +69,7 @@ spv_result spv_parse(const void* source, size_t size, spv_info* info) {
   spv.words = source;
   spv.wordCount = size / sizeof(uint32_t);
   spv.edge = spv.words + spv.wordCount - 8;
+  spv.fields = info->fields;
 
   if (spv.wordCount < 16 || spv.words[0] != 0x07230203) {
     return SPV_INVALID;
@@ -84,10 +89,9 @@ spv_result spv_parse(const void* source, size_t size, spv_info* info) {
 
   info->featureCount = 0;
   info->specConstantCount = 0;
-  info->pushConstantCount = 0;
-  info->pushConstantSize = 0;
   info->attributeCount = 0;
   info->resourceCount = 0;
+  info->fieldCount = 0;
 
   const uint32_t* op = spv.words + 5;
 
@@ -163,7 +167,7 @@ const char* spv_result_to_string(spv_result result) {
     case SPV_INVALID: return "Invalid SPIR-V";
     case SPV_TOO_BIG: return "SPIR-V contains too many types/variables (max ID is 65534)";
     case SPV_UNSUPPORTED_SPEC_CONSTANT_TYPE: return "This type of specialization constant is not supported";
-    case SPV_UNSUPPORTED_PUSH_CONSTANT_TYPE: return "Push constants must be square matrices, vectors, 32 bit numbers, or bools";
+    case SPV_UNSUPPORTED_DATA_TYPE: return "Struct fields must be square float matrices, float/int/uint vectors, 32 bit numbers, or bools";
     default: return NULL;
   }
 }
@@ -213,10 +217,11 @@ static spv_result spv_parse_decoration(spv_context* spv, const uint32_t* op, spv
   }
 
   switch (decoration) {
+    case 1: spv->cache[id].flag.number = op[3]; break; // SpecID
+    case 6: spv->cache[id].type.arrayStride = op[3]; break; // ArrayStride (overrides name)
+    case 30: spv->cache[id].attribute.location = op[3]; break; // Location
     case 33: spv->cache[id].variable.binding = op[3]; break; // Binding
     case 34: spv->cache[id].variable.set = op[3]; break; // Set
-    case 30: spv->cache[id].attribute.location = op[3]; break; // Location
-    case 1: spv->cache[id].flag.number = op[3]; break; // SpecID
     default: break;
   }
 
@@ -321,8 +326,30 @@ static spv_result spv_parse_variable(spv_context* spv, const uint32_t* op, spv_i
     }
   }
 
+  // Unwrap the pointer
+  const uint32_t* pointer;
+  if (!spv_load_type(spv, pointerId, &pointer) || OP_CODE(pointer) != 32) { // OpTypePointer
+    return SPV_INVALID;
+  }
+
+  // Load the type
+  const uint32_t* type;
+  uint32_t typeId = pointer[3];
+  if (!spv_load_type(spv, typeId, &type)) {
+    return SPV_INVALID;
+  }
+
   if (storageClass == 9) { // PushConstant
-    return spv_parse_push_constants(spv, op, info);
+    if (OP_CODE(type) != 30) { // OpTypeStruct
+      return SPV_INVALID;
+    }
+
+    if (info->fields) {
+      info->pushConstants = spv->fields++;
+    }
+
+    info->fieldCount++;
+    return spv_parse_field(spv, type, info->pushConstants, info);
   }
 
   uint32_t set = spv->cache[variableId].variable.set;
@@ -335,24 +362,20 @@ static spv_result spv_parse_variable(spv_context* spv, const uint32_t* op, spv_i
 
   if (!info->resources) {
     info->resourceCount++;
-    return SPV_OK;
+
+    // If it's a buffer, be sure to count how many struct fields it has
+    if (storageClass == 2 || storageClass == 12) {
+      info->fieldCount++;
+      return spv_parse_field(spv, type, NULL, info);
+    } else {
+      return SPV_OK;
+    }
   }
 
   spv_resource* resource = &info->resources[info->resourceCount++];
 
   resource->set = set;
   resource->binding = binding;
-
-  const uint32_t* pointer;
-  if (!spv_load_type(spv, pointerId, &pointer)) {
-    return SPV_INVALID;
-  }
-
-  const uint32_t* type;
-  uint32_t typeId = pointer[3];
-  if (!spv_load_type(spv, typeId, &type)) {
-    return SPV_INVALID;
-  }
 
   // If it's an array, read the array size and unwrap the inner type
   if (OP_CODE(type) == 28) { // OpTypeArray
@@ -371,9 +394,9 @@ static spv_result spv_parse_variable(spv_context* spv, const uint32_t* op, spv_i
       return SPV_INVALID;
     }
 
-    resource->arraySize = length[3];
+    resource->count = length[3];
   } else {
-    resource->arraySize = 0;
+    resource->count = 0;
   }
 
   // Buffers
@@ -385,7 +408,17 @@ static spv_result spv_parse_variable(spv_context* spv, const uint32_t* op, spv_i
       resource->name = (char*) (spv->words + spv->cache[typeId].type.name);
     }
 
-    return SPV_OK;
+    if (OP_CODE(type) != 30) { // OpTypeStruct
+      return SPV_INVALID;
+    }
+
+    info->fieldCount++;
+    resource->fields = spv->fields++;
+    resource->fields[0].offset = 0;
+    resource->fields[0].name = resource->name;
+    return spv_parse_field(spv, type, resource->fields, info);
+  } else {
+    resource->fields = NULL;
   }
 
   // Sampler and texture variables are named directly
@@ -433,143 +466,174 @@ static spv_result spv_parse_variable(spv_context* spv, const uint32_t* op, spv_i
   }
 }
 
-static spv_result spv_parse_push_constants(spv_context* spv, const uint32_t* op, spv_info* info) {
-  const uint32_t* pointer;
-  if (!spv_load_type(spv, op[1], &pointer) || OP_CODE(pointer) != 32) {
-    return SPV_INVALID;
+static spv_result spv_parse_field(spv_context* spv, const uint32_t* word, spv_field* field, spv_info* info) {
+  if (OP_CODE(word) == 28) { // OpTypeArray
+    uint32_t lengthId = word[3];
+    const uint32_t* lengthWord = spv->words + spv->cache[lengthId].constant.word;
+
+    // Length must be an OpConstant or OpSpecConstant
+    if (lengthId > spv->bound || lengthWord > spv->edge || (OP_CODE(lengthWord) != 43 && OP_CODE(lengthWord) != 50)) {
+      return SPV_INVALID;
+    }
+
+    if (field) {
+      field->arrayLength = lengthWord[3];
+      field->arrayStride = spv->cache[word[1]].type.arrayStride;
+    }
+
+    // Unwrap inner array type and fall through
+    if (!spv_load_type(spv, word[2], &word)) {
+      return SPV_INVALID;
+    }
+  } else if (field) {
+    field->arrayLength = 0;
+    field->arrayStride = 0;
   }
 
-  const uint32_t* structure;
-  if (!spv_load_type(spv, pointer[3], &structure) || OP_CODE(structure) != 30) {
-    return SPV_INVALID;
-  }
+  // If this is the initial scan, just do a recursive count of all the struct fields
+  if (!field) {
+    if (OP_CODE(word) == 30) { // OpTypeStruct
+      uint32_t childCount = OP_LENGTH(word) - 2;
 
-  uint32_t memberCount = OP_LENGTH(structure) - 2;
+      const uint32_t* type;
+      for (uint32_t i = 0; i < childCount; i++) {
+        if (!spv_load_type(spv, word[i + 2], &type)) {
+          return SPV_INVALID;
+        }
 
-  if (!info->pushConstants) {
-    info->pushConstantCount = memberCount;
+        spv_result result = spv_parse_field(spv, type, NULL, info);
+
+        if (result != SPV_OK) {
+          return result;
+        }
+      }
+
+      info->fieldCount += childCount;
+    } else {
+      info->fieldCount++;
+    }
     return SPV_OK;
   }
 
-  const uint32_t* type;
-  for (uint32_t i = 0; i < memberCount; i++) {
-    if (!spv_load_type(spv, structure[i + 2], &type)) {
+  // If it's a struct, recursively parse each member
+  if (OP_CODE(word) == 30) { // OpTypeStruct
+    uint32_t childCount = OP_LENGTH(word) - 2;
+    field->type = SPV_STRUCT;
+    field->elementSize = 0;
+    field->fieldCount = childCount;
+    field->totalFieldCount = childCount;
+    field->fields = spv->fields;
+    info->fieldCount += childCount;
+    spv->fields += childCount;
+
+    for (uint32_t i = 0; i < childCount; i++) {
+      field->fields[i].name = NULL;
+      field->fields[i].offset = 0;
+
+      const uint32_t* type;
+      if (!spv_load_type(spv, word[i + 2], &type)) {
+        return SPV_INVALID;
+      }
+
+      spv_result result = spv_parse_field(spv, type, &field->fields[i], info);
+
+      if (result != SPV_OK) {
+        return result;
+      }
+
+      field->totalFieldCount += field->fields[i].totalFieldCount;
+    }
+
+    // Collect member names and offsets.  Requires a scan over the name/decoration words, which is
+    // kind of sad.  Trying to be fancy resulted in questionable increase in code/branching/storage.
+
+    uint32_t structId = word[1];
+    int32_t namesRemaining = childCount;
+    int32_t offsetsRemaining = childCount;
+
+    for (word = spv->words + 5; word < spv->edge && (namesRemaining > 0 || offsetsRemaining > 0); word += OP_LENGTH(word)) {
+      if (OP_LENGTH(word) == 0 || word + OP_LENGTH(word) > spv->edge) {
+        return SPV_INVALID;
+      }
+
+      if (OP_CODE(word) == 6 && OP_LENGTH(word) >= 4 && word[1] == structId && word[2] < childCount) {
+        field->fields[word[2]].name = (char*) &word[3];
+        namesRemaining--;
+      } else if (OP_CODE(word) == 72 && OP_LENGTH(word) == 5 && word[1] == structId && word[2] < childCount && word[3] == 35) { // Offset
+        spv_field* child = &field->fields[word[2]];
+        uint32_t offset = word[4];
+        child->offset = offset;
+        offsetsRemaining--;
+
+        // Struct size is maximum extent of any of its members
+        uint32_t size = child->arrayLength > 0 ? child->arrayLength * child->arrayStride : child->elementSize;
+        if (offset + size > field->elementSize) {
+          field->elementSize = offset + size;
+        }
+      } else if (OP_CODE(word) == 59) { // OpVariable, can break
+        break;
+      }
+    }
+
+    return SPV_OK;
+  } else {
+    field->fieldCount = 0;
+    field->totalFieldCount = 0;
+    field->fields = NULL;
+  }
+
+  uint32_t columnCount = 1;
+  uint32_t componentCount = 1;
+
+  if (OP_CODE(word) == 24) { // OpTypeMatrix
+    columnCount = word[3];
+    if (!spv_load_type(spv, word[2], &word)) {
       return SPV_INVALID;
     }
+  }
 
-    spv_push_constant* constant = &info->pushConstants[info->pushConstantCount++];
-
-    uint32_t columnCount = 1;
-    uint32_t componentCount = 1;
-
-    if (OP_CODE(type) == 24) { // OpTypeMatrix
-      columnCount = type[3];
-      if (!spv_load_type(spv, type[2], &type)) {
-        return SPV_INVALID;
-      }
+  if (OP_CODE(word) == 23) { // OpTypeVector
+    componentCount = word[3];
+    if (!spv_load_type(spv, word[2], &word)) {
+      return SPV_INVALID;
     }
+  }
 
-    if (OP_CODE(type) == 23) { // OpTypeVector
-      componentCount = type[3];
-      if (!spv_load_type(spv, type[2], &type)) {
-        return SPV_INVALID;
-      }
-    }
-
-    if (OP_CODE(type) == 22 && type[2] == 32) { // OpTypeFloat
-      if (columnCount >= 2 && columnCount <= 4 && componentCount == columnCount) {
-        constant->type = SPV_MAT2 + columnCount - 2;
-      } else if (columnCount == 1 && componentCount >= 2 && componentCount <= 4) {
-        constant->type = SPV_F32x2 + componentCount - 2;
-      } else if (columnCount == 1 && componentCount == 1) {
-        constant->type = SPV_F32;
-      } else {
-        return SPV_UNSUPPORTED_PUSH_CONSTANT_TYPE;
-      }
-    } else if (OP_CODE(type) == 21 && type[2] == 32) { // OpTypeInteger
-      if (type[3] > 0) { // signed
-        if (columnCount == 1 && componentCount >= 2 && componentCount <= 4) {
-          constant->type = SPV_I32x2 + componentCount - 2;
-        } else if (columnCount == 1 && componentCount == 1) {
-          constant->type = SPV_I32;
-        } else {
-          return SPV_UNSUPPORTED_PUSH_CONSTANT_TYPE;
-        }
-      } else {
-        if (columnCount == 1 && componentCount >= 2 && componentCount <= 4) {
-          constant->type = SPV_U32x2 + componentCount - 2;
-        } else if (columnCount == 1 && componentCount == 1) {
-          constant->type = SPV_U32;
-        } else {
-          return SPV_UNSUPPORTED_PUSH_CONSTANT_TYPE;
-        }
-      }
-    } else if (OP_CODE(type) == 20 && columnCount == 1 && componentCount == 1) { // OpTypeBool
-      constant->type = SPV_B32;
+  if (OP_CODE(word) == 22 && word[2] == 32) { // OpTypeFloat
+    if (columnCount >= 2 && columnCount <= 4 && componentCount == columnCount) {
+      field->type = SPV_MAT2 + columnCount - 2;
+    } else if (columnCount == 1 && componentCount >= 2 && componentCount <= 4) {
+      field->type = SPV_F32x2 + componentCount - 2;
+    } else if (columnCount == 1 && componentCount == 1) {
+      field->type = SPV_F32;
     } else {
-      return SPV_UNSUPPORTED_PUSH_CONSTANT_TYPE;
+      return SPV_UNSUPPORTED_DATA_TYPE;
     }
+  } else if (OP_CODE(word) == 21 && word[2] == 32) { // OpTypeInteger
+    if (word[3] > 0) { // signed
+      if (columnCount == 1 && componentCount >= 2 && componentCount <= 4) {
+        field->type = SPV_I32x2 + componentCount - 2;
+      } else if (columnCount == 1 && componentCount == 1) {
+        field->type = SPV_I32;
+      } else {
+        return SPV_UNSUPPORTED_DATA_TYPE;
+      }
+    } else {
+      if (columnCount == 1 && componentCount >= 2 && componentCount <= 4) {
+        field->type = SPV_U32x2 + componentCount - 2;
+      } else if (columnCount == 1 && componentCount == 1) {
+        field->type = SPV_U32;
+      } else {
+        return SPV_UNSUPPORTED_DATA_TYPE;
+      }
+    }
+  } else if (OP_CODE(word) == 20 && columnCount == 1 && componentCount == 1) { // OpTypeBool
+    field->type = SPV_B32;
+  } else {
+    return SPV_UNSUPPORTED_DATA_TYPE;
   }
 
-  // Need to do a second pass to find the name and offset decorations, hard to cache them
-  op = spv->words + 5;
-
-  while (op < spv->words + spv->wordCount) {
-    uint16_t opcode = OP_CODE(op);
-    uint16_t length = OP_LENGTH(op);
-
-    if (OP_LENGTH(op) == 0 || op + OP_LENGTH(op) > spv->words + spv->wordCount) {
-      return SPV_INVALID;
-    }
-
-    switch (opcode) {
-      case 6: // OpMemberName
-        if (length < 4 || op[1] > spv->bound) {
-          return SPV_INVALID;
-        } else if (op[1] == structure[1] && op[2] < info->pushConstantCount) {
-          info->pushConstants[op[2]].name = (char*) &op[3];
-        }
-        break;
-      case 72: // OpMemberDecorate
-        if (op[1] > spv->bound) {
-          return SPV_INVALID;
-        } else if (length == 5 && op[1] == structure[1] && op[2] < info->pushConstantCount && op[3] == 35) { // Offset
-          info->pushConstants[op[2]].offset = op[4];
-
-          uint32_t size = 0;
-          switch (info->pushConstants[op[2]].type) {
-            case SPV_B32: size = 4; break;
-            case SPV_I32: size = 4; break;
-            case SPV_I32x2: size = 8; break;
-            case SPV_I32x3: size = 12; break;
-            case SPV_I32x4: size = 16; break;
-            case SPV_U32: size = 4; break;
-            case SPV_U32x2: size = 8; break;
-            case SPV_U32x3: size = 12; break;
-            case SPV_U32x4: size = 16; break;
-            case SPV_F32: size = 4; break;
-            case SPV_F32x2: size = 8; break;
-            case SPV_F32x3: size = 12; break;
-            case SPV_F32x4: size = 16; break;
-            case SPV_MAT2: size = 16; break;
-            case SPV_MAT3: size = 36; break;
-            case SPV_MAT4: size = 64; break;
-            default: break;
-          }
-
-          if (info->pushConstantSize < op[4] + size) {
-            info->pushConstantSize = op[4] + size;
-          }
-        }
-        break;
-      case 59: // OpVariable, can exit
-        op = spv->words + spv->wordCount;
-        length = 0;
-        break;
-    }
-
-    op += length;
-  }
+  field->elementSize = 4 * componentCount * columnCount;
 
   return SPV_OK;
 }

--- a/src/core/spv.c
+++ b/src/core/spv.c
@@ -485,6 +485,16 @@ static spv_result spv_parse_field(spv_context* spv, const uint32_t* word, spv_fi
     if (!spv_load_type(spv, word[2], &word)) {
       return SPV_INVALID;
     }
+  } else if (OP_CODE(word) == 29) { // OpTypeRuntimeArray
+    if (field) {
+      field->arrayLength = ~0u;
+      field->arrayStride = spv->cache[word[1]].type.arrayStride;
+    }
+
+    // Unwrap inner array type and fall through
+    if (!spv_load_type(spv, word[2], &word)) {
+      return SPV_INVALID;
+    }
   } else if (field) {
     field->arrayLength = 0;
     field->arrayStride = 0;

--- a/src/core/spv.h
+++ b/src/core/spv.h
@@ -19,7 +19,8 @@ typedef enum {
   SPV_F32x4,
   SPV_MAT2,
   SPV_MAT3,
-  SPV_MAT4
+  SPV_MAT4,
+  SPV_STRUCT
 } spv_type;
 
 typedef struct {
@@ -28,11 +29,17 @@ typedef struct {
   spv_type type;
 } spv_spec_constant;
 
-typedef struct {
+typedef struct spv_field {
   const char* name;
-  uint32_t offset;
   spv_type type;
-} spv_push_constant;
+  uint32_t offset;
+  uint32_t arrayLength;
+  uint32_t arrayStride;
+  uint32_t elementSize;
+  uint16_t fieldCount;
+  uint16_t totalFieldCount;
+  struct spv_field* fields;
+} spv_field;
 
 typedef struct {
   const char* name;
@@ -56,7 +63,8 @@ typedef struct {
   uint32_t binding;
   const char* name;
   spv_resource_type type;
-  uint32_t arraySize;
+  uint32_t count;
+  spv_field* fields;
 } spv_resource;
 
 typedef struct {
@@ -64,15 +72,15 @@ typedef struct {
   uint32_t workgroupSize[3];
   uint32_t featureCount;
   uint32_t specConstantCount;
-  uint32_t pushConstantCount;
-  uint32_t pushConstantSize;
   uint32_t attributeCount;
   uint32_t resourceCount;
+  uint32_t fieldCount;
   uint32_t* features;
   spv_spec_constant* specConstants;
-  spv_push_constant* pushConstants;
+  spv_field* pushConstants;
   spv_attribute* attributes;
   spv_resource* resources;
+  spv_field* fields;
 } spv_info;
 
 typedef enum {
@@ -80,7 +88,7 @@ typedef enum {
   SPV_INVALID,
   SPV_TOO_BIG,
   SPV_UNSUPPORTED_SPEC_CONSTANT_TYPE,
-  SPV_UNSUPPORTED_PUSH_CONSTANT_TYPE
+  SPV_UNSUPPORTED_DATA_TYPE
 } spv_result;
 
 spv_result spv_parse(const void* source, size_t size, spv_info* info);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -1782,6 +1782,7 @@ Shader* lovrShaderCreate(const ShaderInfo* info) {
     spv[i].attributes = tempAlloc(spv[i].attributeCount * sizeof(spv_attribute));
     spv[i].resources = tempAlloc(spv[i].resourceCount * sizeof(spv_resource));
     spv[i].fields = tempAlloc(spv[i].fieldCount * sizeof(spv_field));
+    memset(spv[i].fields, 0, spv[i].fieldCount * sizeof(spv_field));
 
     result = spv_parse(info->source[i].code, info->source[i].size, &spv[i]);
     lovrCheck(result == SPV_OK, "Failed to load Shader: %s\n", spv_result_to_string(result));

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -28,6 +28,7 @@ const char** os_vk_get_instance_extensions(uint32_t* count);
 #define MAX_TRANSFORMS 16
 #define MAX_PIPELINES 4
 #define MAX_SHADER_RESOURCES 32
+#define MAX_CUSTOM_ATTRIBUTES 10
 #define FLOAT_BITS(f) ((union { float f; uint32_t u; }) { f }).u
 
 typedef struct {
@@ -4090,8 +4091,8 @@ void lovrPassSetStencilWrite(Pass* pass, StencilAction actions[3], uint8_t value
 
 void lovrPassSetVertexFormat(Pass* pass, BufferField* fields, uint32_t count) {
   if (!pass->pipeline->vertexFormat) { // Vertex formats are huge, allocate it lazily only if needed
-    pass->pipeline->vertexFormat = tempAlloc(11 * sizeof(BufferField));
-    memset(pass->pipeline->vertexFormat, 0, 11 * sizeof(BufferField));
+    pass->pipeline->vertexFormat = tempAlloc((MAX_CUSTOM_ATTRIBUTES + 1) * sizeof(BufferField));
+    memset(pass->pipeline->vertexFormat, 0, (MAX_CUSTOM_ATTRIBUTES + 1) * sizeof(BufferField));
     pass->pipeline->vertexFormat[0].children = &pass->pipeline->vertexFormat[1];
   }
 
@@ -4114,7 +4115,7 @@ void lovrPassSetVertexFormat(Pass* pass, BufferField* fields, uint32_t count) {
     lovrCheck(attribute->length == 0, "Vertex attributes can not be arrays");
   }
 
-  lovrCheck(array->childCount <= 10, "Too many vertex attributes (max is %d)", 10);
+  lovrCheck(array->childCount <= MAX_CUSTOM_ATTRIBUTES, "Too many vertex attributes (max is %d)", MAX_CUSTOM_ATTRIBUTES);
   memcpy(array, fields, count * sizeof(BufferField));
   array->children = array + (fields[0].children - fields);
   alignField(array, LAYOUT_PACKED);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4043,6 +4043,10 @@ void lovrPassSetShader(Pass* pass, Shader* shader) {
   pass->pipeline->shader = shader;
   pass->pipeline->dirty = true;
 
+  if ((shader && shader->hasCustomAttributes) || (previous && previous->hasCustomAttributes)) {
+    pass->pipeline->formatHash = 0;
+  }
+
   // If shaders have different push constant ranges, descriptor sets need to be rebound
   if ((shader ? shader->constantSize : 0) != (previous ? previous->constantSize : 0)) {
     pass->materialDirty = true;

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -151,11 +151,17 @@ typedef enum {
   FIELD_INDEX32
 } FieldType;
 
-typedef struct {
+typedef struct BufferField {
+  struct BufferField* children;
+  uint32_t childCount;
   uint32_t hash;
+  const char* name;
   uint32_t location;
-  uint32_t type;
   uint32_t offset;
+  uint32_t type;
+  uint32_t length;
+  uint32_t stride;
+  uint32_t align;
 } BufferField;
 
 typedef enum {
@@ -165,10 +171,10 @@ typedef enum {
 } BufferLayout;
 
 typedef struct {
-  uint32_t length;
-  uint32_t stride;
+  uint32_t size;
+  BufferLayout layout;
   uint32_t fieldCount;
-  BufferField fields[16];
+  BufferField* fields;
   const char* label;
   uintptr_t handle;
 } BufferInfo;
@@ -322,6 +328,7 @@ const ShaderInfo* lovrShaderGetInfo(Shader* shader);
 bool lovrShaderHasStage(Shader* shader, ShaderStage stage);
 bool lovrShaderHasAttribute(Shader* shader, const char* name, uint32_t location);
 void lovrShaderGetWorkgroupSize(Shader* shader, uint32_t size[3]);
+BufferField* lovrShaderGetBufferFormat(Shader* shader, const char* name, size_t length, uint32_t slot, uint32_t* size, uint32_t* fieldCount);
 
 // Material
 
@@ -622,6 +629,7 @@ void lovrPassSetScissor(Pass* pass, uint32_t scissor[4]);
 void lovrPassSetShader(Pass* pass, Shader* shader);
 void lovrPassSetStencilTest(Pass* pass, CompareMode test, uint8_t value, uint8_t mask);
 void lovrPassSetStencilWrite(Pass* pass, StencilAction actions[3], uint8_t value, uint8_t mask);
+void lovrPassSetVertexFormat(Pass* pass, BufferField* fields, uint32_t count);
 void lovrPassSetViewport(Pass* pass, float viewport[4], float depthRange[2]);
 void lovrPassSetWinding(Pass* pass, Winding winding);
 void lovrPassSetWireframe(Pass* pass, bool wireframe);
@@ -629,7 +637,7 @@ void lovrPassSetWireframe(Pass* pass, bool wireframe);
 void lovrPassSendBuffer(Pass* pass, const char* name, size_t length, uint32_t slot, Buffer* buffer, uint32_t offset, uint32_t extent);
 void lovrPassSendTexture(Pass* pass, const char* name, size_t length, uint32_t slot, Texture* texture);
 void lovrPassSendSampler(Pass* pass, const char* name, size_t length, uint32_t slot, Sampler* sampler);
-void lovrPassSendValue(Pass* pass, const char* name, size_t length, void** data, FieldType* type);
+void lovrPassSendData(Pass* pass, const char* name, size_t length, uint32_t slot, void** data, BufferField** field);
 
 void lovrPassPoints(Pass* pass, uint32_t count, float** vertices);
 void lovrPassLine(Pass* pass, uint32_t count, float** vertices);
@@ -648,6 +656,7 @@ void lovrPassFill(Pass* pass, Texture* texture);
 void lovrPassMonkey(Pass* pass, float* transform);
 void lovrPassDrawModel(Pass* pass, Model* model, float* transform, uint32_t node, bool recurse, uint32_t instances);
 void lovrPassMesh(Pass* pass, Buffer* vertices, Buffer* indices, float* transform, uint32_t start, uint32_t count, uint32_t instances, uint32_t base);
+void lovrPassMeshImmediate(Pass* pass, uint32_t vertexCount, void** vertices, BufferField** format, uint32_t indexCount, void** indices, float* transform);
 void lovrPassMeshIndirect(Pass* pass, Buffer* vertices, Buffer* indices, Buffer* indirect, uint32_t count, uint32_t offset, uint32_t stride);
 
 void lovrPassCompute(Pass* pass, uint32_t x, uint32_t y, uint32_t z, Buffer* indirect, uint32_t offset);


### PR DESCRIPTION
See #631 for initial idea (and also #208)

- `Pass:mesh` accepts tables for vertices/indices, instead of just Buffers
- Add `Pass:setVertexFormat` to set format used for table-based meshes
- `Pass:send` supports sending tables to uniform/storage buffers
- `Pass:send` supports arbitrarily nested structs/arrays for push constants
- Buffer formats support arbitrarily nested structs/arrays
  - Zero-length buffers are valid and represent key/value structs (kinda like Lua tables)
  - Fields can have real names using `name` flag
  - Field types can be tables of other fields (nested structs)
  - Fields can have `length` key to make them an array
- newBuffer syntax has been changed to put format first (old version still works)
- Buffers can be created from shader variables, avoiding the need to carefully declare matching format.
- `Pass:clear`/`Pass:read` use byte offsets instead of indices
- `Pass:copy` uses byte offsets when copying a Buffer to a Buffer
- Deprecate `lovr.graphics.getBuffer` (tables should be used instead)

The implementation is here.  It works, and enables some cool things, but it adds a lot of complexity and there are still a few things that could be added.  Still thinking it over and letting it bake here for a while.

Other things that could be added:

- More validation/checks (when sending stuff to UBO/SSBO variables, we can do pretty good validation now)
- Vertex format fixes found during implementation (`formatHash` isn't cleared when changing shader/vertexformat)
- Dynamic-length SSBO arrays might not work properly, need to test

Examples:

```lua
function lovr.draw(pass)
  pass:setVertexFormat({
    { 'VertexPosition', 'vec3' },
    { 'VertexColor', 'vec4' }
  })

  local triangle = {
    { vec3(  0,  .4, 0), vec4(1, 0, 0, 1) },
    { vec3(-.5, -.4, 0), vec4(0, 1, 0, 1) },
    { vec3( .5, -.4, 0), vec4(0, 0, 1, 1) }
  }

  pass:mesh(triangle, 0, 1.7, -1)
end
```

```lua
-- shader has: Constants { vec3 gradient[2]; };
pass:setShader(shader)
pass:send('gradient', { vec3(1, 1, 0), vec3(0, 0, 1) })
```

```lua
data = {
  lights = {},
  count = n
}

buffer = lovr.graphics.newBuffer({
  { 'lights', { { 'position', 'vec3' }, { 'color', 'vec4' } }, length = 10 },
  { 'count', 'int' }
}, data)
```