### PR TITLE
Fix signs for light probe coefficients

### DIFF
--- a/src/api/l_math.c
+++ b/src/api/l_math.c
@@ -132,15 +132,30 @@ static int l_lovrMathNewCurve(lua_State* L) {
 
 static void getPixelEquirect(void* image, uint32_t x, uint32_t y, uint32_t z, float color[4]) {
   lovrImageGetPixel(image, x, y, z, color);
+  if (lovrImageIsSRGB(image)) {
+    color[0] = lovrMathGammaToLinear(color[0]);
+    color[1] = lovrMathGammaToLinear(color[1]);
+    color[2] = lovrMathGammaToLinear(color[2]);
+  }
 }
 
 static void getPixelCubemap(void* image, uint32_t x, uint32_t y, uint32_t z, float color[4]) {
   lovrImageGetPixel(image, x, y, z, color);
+  if (lovrImageIsSRGB(image)) {
+    color[0] = lovrMathGammaToLinear(color[0]);
+    color[1] = lovrMathGammaToLinear(color[1]);
+    color[2] = lovrMathGammaToLinear(color[2]);
+  }
 }
 
 static void getPixelCubemapLayers(void* context, uint32_t x, uint32_t y, uint32_t z, float color[4]) {
   Image** images = context;
   lovrImageGetPixel(images[z], x, y, 0, color);
+  if (lovrImageIsSRGB(images[z])) {
+    color[0] = lovrMathGammaToLinear(color[0]);
+    color[1] = lovrMathGammaToLinear(color[1]);
+    color[2] = lovrMathGammaToLinear(color[2]);
+  }
 }
 
 static int l_lovrMathNewLightProbe(lua_State* L) {

--- a/src/modules/math/math.c
+++ b/src/modules/math/math.c
@@ -304,17 +304,17 @@ void lovrLightProbeAddCubemap(LightProbe* probe, uint32_t size, fn_pixel* getPix
   for (uint32_t face = 0; face < 6; face++) {
     for (uint32_t y = 0; y < size; y++) {
       for (uint32_t x = 0; x < size; x++) {
-        float u = 2.f * x / (float) size - 1.f;
-        float v = 2.f * y / (float) size - 1.f;
+        float u = 2.f * ((float) x + 0.5f) / (float) size - 1.f;
+        float v = 2.f * ((float) y + 0.5f) / (float) size - 1.f;
         float dx, dy, dz;
 
         switch (face) {
-          case 0: dx = 1.f; dy = v; dz = -u; break;
-          case 1: dx = -1.f; dy = v; dz = u; break;
-          case 2: dx = u; dy = 1.f; dz = -v; break;
-          case 3: dx = u; dy = -1.f; dz = v; break;
-          case 4: dx = u; dy = v; dz = 1.f; break;
-          case 5: dx = -u; dy = v; dz = -1.f; break;
+          case 0: dx = -1.f; dy = -v; dz = -u; break;
+          case 1: dx = 1.f; dy = -v; dz = u; break;
+          case 2: dx = -u; dy = 1.f; dz = v; break;
+          case 3: dx = -u; dy = -1.f; dz = -v; break;
+          case 4: dx = -u; dy = -v; dz = 1.f; break;
+          case 5: dx = u; dy = -v; dz = -1.f; break;
         }
 
         float dot = dx * dx + dy * dy + dz * dz;


### PR DESCRIPTION
Light probes are neat!

While testing I noticed the light often came from wrong direction, and traced it down to few wrong signs when converting cubemap UV coordinates to 3D direction vector, and signs for SH coefficients.

I used https://www.ppsloan.org/publications/StupidSH36.pdf as a reference. Testing was done with [this script](https://gist.github.com/jmiskovic/cf2713b6b476f2c49f10e701ae3fe545).

I've also compared results with [three.js implementation](https://threejs.org/examples/?q=probe#webgl_lightprobe_cubecamera), it comes out completely identical to my eye.

![image](https://user-images.githubusercontent.com/17770782/222179806-75fab21b-a812-4d4f-bc1c-be5619fb6feb.png)
