### PR TITLE
Address various MSVC warnings (casts, comparisons, function pointers)

### DIFF
--- a/src/api/l_graphics_buffer.c
+++ b/src/api/l_graphics_buffer.c
@@ -157,10 +157,10 @@ void luax_readbufferdata(lua_State* L, int index, Buffer* buffer, char* data) {
     lovrCheck(dstIndex <= info->length, "Destination index is %d but buffer can only hold %d things", dstIndex, info->length);
 
     size_t blobSize = blob->size / stride;
-    lovrCheck(srcIndex <= blobSize, "Source index is %d but blob only contains %d things", srcIndex, (uint32_t)blobSize);
+    lovrCheck(srcIndex <= blobSize, "Source index is %d but blob only contains %d things", srcIndex, (uint32_t) blobSize);
 
     // Conversion is safe because right side will never exceed size of uint32_t
-    uint32_t limit = (uint32_t)MIN(blobSize - srcIndex, info->length - dstIndex);
+    uint32_t limit = (uint32_t) MIN(blobSize - srcIndex, info->length - dstIndex);
     uint32_t count = luax_optu32(L, index + 3, limit);
     lovrCheck(srcIndex + count <= blob->size / stride, "Tried to read too many elements from the Blob");
     lovrCheck(dstIndex + count <= info->length, "Tried to write Buffer elements [%d,%d] but Buffer can only hold %d things", dstIndex + 1, dstIndex + count - 1, info->length);

--- a/src/api/l_graphics_buffer.c
+++ b/src/api/l_graphics_buffer.c
@@ -154,7 +154,13 @@ void luax_readbufferdata(lua_State* L, int index, Buffer* buffer, char* data) {
   uint32_t dstIndex = luax_optu32(L, index + 2, 1) - 1;
 
   if (blob) {
-    uint32_t limit = MIN(blob->size / stride - srcIndex, info->length - dstIndex);
+    lovrCheck(dstIndex <= info->length, "Destination index is %d but buffer can only hold %d things", dstIndex, info->length);
+
+    size_t blobSize = blob->size / stride;
+    lovrCheck(srcIndex <= blobSize, "Source index is %d but blob only contains %d things", srcIndex, (uint32_t)blobSize);
+
+    // Conversion is safe because right side will never exceed size of uint32_t
+    uint32_t limit = (uint32_t)MIN(blobSize - srcIndex, info->length - dstIndex);
     uint32_t count = luax_optu32(L, index + 3, limit);
     lovrCheck(srcIndex + count <= blob->size / stride, "Tried to read too many elements from the Blob");
     lovrCheck(dstIndex + count <= info->length, "Tried to write Buffer elements [%d,%d] but Buffer can only hold %d things", dstIndex + 1, dstIndex + count - 1, info->length);

--- a/src/api/l_graphics_pass.c
+++ b/src/api/l_graphics_pass.c
@@ -891,7 +891,12 @@ static int l_lovrPassCopy(lua_State* L) {
     uint32_t srcOffset = luax_optu32(L, 4, 0);
     uint32_t dstOffset = luax_optu32(L, 5, 0);
     const BufferInfo* info = lovrBufferGetInfo(buffer);
-    uint32_t limit = MIN(blob->size - srcOffset, info->length * info->stride - dstOffset);
+    uint32_t bufferSize = info->length * info->stride;
+    lovrCheck(bufferSize==0 || bufferSize/info->stride == info->length, "Buffer size exceeds supported limits. This is a bug in Lovr.");    
+    lovrCheck(srcOffset <= blob->size, "Source index is %d but blob is only %d bytes", srcOffset, (uint32_t)blob->size);
+    lovrCheck(dstOffset <= bufferSize, "Destination index is %d but buffer is only %d bytes", dstOffset, bufferSize);
+    // Conversion is safe because right side will never exceed size of uint32_t
+    uint32_t limit = (uint32_t)MIN(blob->size - srcOffset, bufferSize - dstOffset);
     uint32_t extent = luax_optu32(L, 6, limit);
     lovrCheck(extent <= blob->size - srcOffset, "Buffer copy range exceeds Blob size");
     lovrCheck(extent <= info->length * info->stride - dstOffset, "Buffer copy offset exceeds Buffer size");

--- a/src/api/l_graphics_pass.c
+++ b/src/api/l_graphics_pass.c
@@ -892,11 +892,10 @@ static int l_lovrPassCopy(lua_State* L) {
     uint32_t dstOffset = luax_optu32(L, 5, 0);
     const BufferInfo* info = lovrBufferGetInfo(buffer);
     uint32_t bufferSize = info->length * info->stride;
-    lovrCheck(bufferSize==0 || bufferSize/info->stride == info->length, "Buffer size exceeds supported limits. This is a bug in Lovr.");    
-    lovrCheck(srcOffset <= blob->size, "Source index is %d but blob is only %d bytes", srcOffset, (uint32_t)blob->size);
+    lovrCheck(srcOffset <= blob->size, "Source index is %d but blob is only %d bytes", srcOffset, (uint32_t) blob->size);
     lovrCheck(dstOffset <= bufferSize, "Destination index is %d but buffer is only %d bytes", dstOffset, bufferSize);
     // Conversion is safe because right side will never exceed size of uint32_t
-    uint32_t limit = (uint32_t)MIN(blob->size - srcOffset, bufferSize - dstOffset);
+    uint32_t limit = (uint32_t) MIN(blob->size - srcOffset, bufferSize - dstOffset);
     uint32_t extent = luax_optu32(L, 6, limit);
     lovrCheck(extent <= blob->size - srcOffset, "Buffer copy range exceeds Blob size");
     lovrCheck(extent <= info->length * info->stride - dstOffset, "Buffer copy offset exceeds Buffer size");

--- a/src/api/l_graphics_pass.c
+++ b/src/api/l_graphics_pass.c
@@ -892,8 +892,8 @@ static int l_lovrPassCopy(lua_State* L) {
     uint32_t dstOffset = luax_optu32(L, 5, 0);
     const BufferInfo* info = lovrBufferGetInfo(buffer);
     uint32_t bufferSize = info->length * info->stride;
-    lovrCheck(srcOffset <= blob->size, "Source index is %d but blob is only %d bytes", srcOffset, (uint32_t) blob->size);
-    lovrCheck(dstOffset <= bufferSize, "Destination index is %d but buffer is only %d bytes", dstOffset, bufferSize);
+    lovrCheck(srcOffset <= blob->size, "Source byte offset is %d but Blob is only %d bytes", srcOffset, (uint32_t) blob->size);
+    lovrCheck(dstOffset <= bufferSize, "Destination byte offset is %d but Buffer is only %d bytes", dstOffset, bufferSize);
     // Conversion is safe because right side will never exceed size of uint32_t
     uint32_t limit = (uint32_t) MIN(blob->size - srcOffset, bufferSize - dstOffset);
     uint32_t extent = luax_optu32(L, 6, limit);

--- a/src/modules/audio/spatializer_phonon.c
+++ b/src/modules/audio/spatializer_phonon.c
@@ -131,7 +131,7 @@ static struct {
 
 static void phonon_destroy(void);
 
-bool phonon_init() {
+bool phonon_init(void) {
   state.library = phonon_dlopen(PHONON_LIBRARY);
   if (!state.library) return false;
 

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4527,7 +4527,8 @@ void lovrPassRoundrect(Pass* pass, float* transform, float r, uint32_t segments)
   float z = .5f;
   float nz = 1.f;
 
-  for (uint32_t side = 0; side <= thicc; side++, z *= -1.f, nz *= -1.f, angle = 0.f) {
+  // If the rounded rectangle is thick, loop twice (front and back), otherwise do only a single side
+  for (uint32_t side = 0; side <= (uint32_t)thicc; side++, z *= -1.f, nz *= -1.f, angle = 0.f) {
     for (uint32_t i = 0; i < n; i++, angle += step) {
       float c = cosf(angle);
       float s = sinf(angle);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4528,7 +4528,7 @@ void lovrPassRoundrect(Pass* pass, float* transform, float r, uint32_t segments)
   float nz = 1.f;
 
   // If the rounded rectangle is thick, loop twice (front and back), otherwise do only a single side
-  for (uint32_t side = 0; side <= (uint32_t)thicc; side++, z *= -1.f, nz *= -1.f, angle = 0.f) {
+  for (uint32_t side = 0; side <= (uint32_t) thicc; side++, z *= -1.f, nz *= -1.f, angle = 0.f) {
     for (uint32_t i = 0; i < n; i++, angle += step) {
       float c = cosf(angle);
       float s = sinf(angle);

--- a/src/modules/math/math.c
+++ b/src/modules/math/math.c
@@ -241,7 +241,7 @@ void lovrPoolDestroy(void* ref) {
 
 void lovrPoolGrow(Pool* pool, size_t count) {
   lovrAssert(count <= (1 << 24), "Temporary vector space exhausted.  Try using lovr.math.drain to drain the vector pool periodically.");
-  pool->count = count;
+  pool->count = (uint32_t)count; // Assert guarantees safe
   pool->data = realloc(pool->data, pool->count * sizeof(float));
   lovrAssert(pool->data, "Out of memory");
 }
@@ -264,7 +264,7 @@ Vector lovrPoolAllocate(Pool* pool, VectorType type, float** data) {
   };
 
   *data = pool->data + pool->cursor;
-  pool->cursor += count;
+  pool->cursor += (uint32_t)count; // Cast safe because vectorComponents members are known
   return v;
 }
 

--- a/src/modules/math/math.c
+++ b/src/modules/math/math.c
@@ -241,7 +241,7 @@ void lovrPoolDestroy(void* ref) {
 
 void lovrPoolGrow(Pool* pool, size_t count) {
   lovrAssert(count <= (1 << 24), "Temporary vector space exhausted.  Try using lovr.math.drain to drain the vector pool periodically.");
-  pool->count = (uint32_t)count; // Assert guarantees safe
+  pool->count = (uint32_t) count; // Assert guarantees safe
   pool->data = realloc(pool->data, pool->count * sizeof(float));
   lovrAssert(pool->data, "Out of memory");
 }
@@ -264,7 +264,7 @@ Vector lovrPoolAllocate(Pool* pool, VectorType type, float** data) {
   };
 
   *data = pool->data + pool->cursor;
-  pool->cursor += (uint32_t)count; // Cast safe because vectorComponents members are known
+  pool->cursor += (uint32_t) count; // Cast safe because vectorComponents members are known
   return v;
 }
 


### PR DESCRIPTION
Address size_t narrowing warnings in MSVC by adding casts. Also adds some asserts to make sure the casts are safe.

I have not tested this patch beyond compiling it because I'm not sure how.