### PR TITLE
Make 0.16 util.h compile correctly when included from a C++ file 

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -15,6 +15,12 @@
 #define LOVR_THREAD_LOCAL __thread
 #endif
 
+#ifdef __cplusplus
+#define LOVR_NORETURN [[noreturn]]
+#else
+#define LOVR_NORETURN _Noreturn
+#endif
+
 #ifndef M_PI
 #define M_PI 3.14159265358979
 #endif
@@ -30,7 +36,7 @@
 // Error handling
 typedef void errorFn(void*, const char*, va_list);
 void lovrSetErrorCallback(errorFn* callback, void* userdata);
-_Noreturn void lovrThrow(const char* format, ...);
+LOVR_NORETURN void lovrThrow(const char* format, ...);
 #define lovrAssert(c, ...) if (!(c)) { lovrThrow(__VA_ARGS__); }
 #define lovrUnreachable() lovrThrow("Unreachable")
 


### PR DESCRIPTION
Something I did not know until today is that in 2011 C and C++ both added a "no return" attribute, but the respective C11 and C++11 attributes are not compatible. C went with `_Noreturn` and C++ went with `[[noreturn]]`. C23 will fix this, but only by adopting `[[noreturn]]` and deprecating `_Noreturn`, so that will in some ways only make things more confusing.

I hate this, but I do need to be able to include lovr headers from C++ files, so here is a patch to use a LOVR_NORETURN on our one no-return function (`lovrThrow`) which defines to the appropriate attribute for the current language. In my tests the C and C++ files both compile fine with this change.