### PR TITLE
[WIP] enable cross-compiling from Windows to Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,8 +745,9 @@ elseif(ANDROID)
   )
 
   if(LOVR_BUILD_EXE)
-    set(ANDROID_JAR "${ANDROID_SDK}/platforms/${ANDROID_PLATFORM}/android.jar")
-    set(ANDROID_TOOLS "${ANDROID_SDK}/build-tools/${ANDROID_BUILD_TOOLS_VERSION}")
+    find_package(Java)
+    cmake_path(CONVERT "${ANDROID_SDK}/platforms/${ANDROID_PLATFORM}/android.jar" TO_NATIVE_PATH_LIST ANDROID_JAR) # For Windows
+    cmake_path(CONVERT "${ANDROID_SDK}/build-tools/${ANDROID_BUILD_TOOLS_VERSION}" TO_NATIVE_PATH_LIST ANDROID_TOOLS) # For Windows
 
     # If assets are included in the apk then add '-A assets' to aapt, otherwise don't add any flags
     if(ANDROID_ASSETS)
@@ -784,12 +785,13 @@ elseif(ANDROID)
     endif()
 
     # Make an apk
+    cmake_path(CONVERT "${ANDROID_PACKAGE_JAVA}/Activity.class" TO_NATIVE_PATH_LIST LOVR_ACTIVITY_CLASS_PATH) # For Windows
     add_custom_target(
       buildAPK ALL
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       COMMAND ${CMAKE_COMMAND} -E copy "${ANDROID_MANIFEST}" AndroidManifest.xml
       COMMAND ${Java_JAVAC_EXECUTABLE} -classpath "${ANDROID_JAR}" -d . Activity.java
-      COMMAND ${ANDROID_TOOLS}/d8 --min-api ${ANDROID_NATIVE_API_LEVEL} --output raw ${ANDROID_PACKAGE_JAVA}/Activity.class
+      COMMAND ${ANDROID_TOOLS}/d8 --min-api ${ANDROID_NATIVE_API_LEVEL} --output raw ${LOVR_ACTIVITY_CLASS_PATH}
       COMMAND
         ${ANDROID_TOOLS}/aapt
         package -f

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -815,10 +815,13 @@ elseif(ANDROID)
     add_dependencies(buildAPK lovr)
 
     if(CMAKE_BUILD_TYPE STREQUAL Release)
+      # Get list of shared objects to strip
+      file(GLOB LOVR_ANDROID_TARGETS_TO_STRIP RELATIVE ${CMAKE_CURRENT_BINARY_DIR} CONFIGURE_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/raw/lib/${ANDROID_ABI}/*.so")
+      # Invoke strip command
       add_custom_target(
         strip ALL
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMAND ${CMAKE_STRIP} raw/lib/${ANDROID_ABI}/*.so
+        COMMAND ${CMAKE_STRIP} ${LOVR_ANDROID_TARGETS_TO_STRIP}
       )
       add_dependencies(strip lovr)
       add_dependencies(buildAPK strip)


### PR DESCRIPTION
We have not supported building the Android version on Windows in a while. Yesterday I attempted to set up a Windows build. It went… rough.

The closest I got is attached. I am not sure these changes are correct. Three things were necessary for me to build an APK and **the APK is still not usable**. Here's what I saw:

(This is all CMake— I did not test with tup, sorry)

1. **Problem**: `raw/lib/${ANDROID_ABI}/*.so` input was not accepted by android strip executable.

    **Solution**: I *think* what went wrong here was that the fileglob is normally processed with the help of the UNIX shell or something else not present on Windows. Instead of using the fileglob, I used a CMake tool to manually expand a fileglob (41d30f1). This is better anyway because theoretically it means CMake has better build product freshness tracking.

    **Solution is not good enough**: Since adding this line, these three lines print at the start of every CMake invocation, always:

        [0/2] Re-checking globbed directories...
        -- GLOB mismatch!
        [1/2] Re-running CMake...

    I'm missing something.

2. **Problem**: Cryptic failures with d8 tool

    **Incorrect solution:** Although CMake is happy to accept either \ or / file paths, command line tools may not be so friendly. I filtered all paths passed to external tools as arguments through a path conversion (9c667fe). This had no effect whatsoever.

   **Correct solution:** Upgrade from Android build tools 33.0.1 to 34.0.0-rc2. Apparently 33.0.1 had a problem on Windows.

   **Solution is not good enough**: So… should 9c667fe be backed out (because it does nothing) or kept (because it's technically "correct"?

3. **Problem**: Luajit does not build because the windows-build-tools step places minilua.exe and buildvm.exe helper tools in a different place than the android-cross-compile step expects them (https://github.com/WohlSoft/LuaJIT/issues/22)

    **Solution**: Build three times. Each time you get a failure, copy the missing file to the correct place manually:

       copy C:\Users\Andi\work\g\lovr\build-apk\luajit\src\minilua\Debug\minilua.exe C:\Users\Andi\work\g\lovr\build-apk\luajit\src\minilua\minilua.exe
       copy C:\Users\Andi\work\g\lovr\build-apk\luajit\src\buildvm\Debug\buildvm.exe C:\Users\Andi\work\g\lovr\build-apk\luajit\src\buildvm\buildvm.exe

    … this workaround unblocks me, but is not a "shipping solution" for Lovr. The WohlSoft developer attempted a fix but it is not working yet.

**Final problem**: Once the APK is built, it cannot be installed. It prints this cryptic error:

    adb: failed to install skategirl_hotswap.apk: Failure [INSTALL_FAILED_INVALID_APK: Failed to extract native libraries, res=-2]

Google/stackoverflow suggest this can happen for a variety of reasons, such as zipalign not executing properly.

This failure is not caused by the changes in this PR, I tried testing this PR on mac and it worked fine.

**Should this be merged?**

The changes in these commits are "correct"— they in theory do the right thing (aside from the worrying stray message the glob patch prints). However, they give us no benefit, in that they do not achieve the goal of building on Windows…