### PR TITLE
Fix acos domain error in angle between two Vec3

### DIFF
--- a/src/core/maf.h
+++ b/src/core/maf.h
@@ -127,7 +127,10 @@ MAF float vec3_angle(const vec3 v, const vec3 u) {
   if (denom == 0.f) {
     return (float) M_PI / 2.f;
   } else {
-    return acosf(vec3_dot(v, u) / denom);
+    float cos = vec3_dot(v, u) / denom;
+    cos = cos < -1 ? -1 : cos;
+    cos = cos > 1 ? 1 : cos;
+    return acosf(cos);
   }
 }
 


### PR DESCRIPTION
A reproduction:

`print(vec3(3.0253329277039, -2.000001, -0.79650980234146):angle(vec3(3.0253329277039, -2, -0.79650980234146)))`