### PR TITLE
Add mousewheel callback

### DIFF
--- a/src/api/l_event.c
+++ b/src/api/l_event.c
@@ -17,6 +17,7 @@ StringEntry lovrEventType[] = {
   [EVENT_MOUSEPRESSED] = ENTRY("mousepressed"),
   [EVENT_MOUSERELEASED] = ENTRY("mousereleased"),
   [EVENT_MOUSEMOVED] = ENTRY("mousemoved"),
+  [EVENT_MOUSEWHEELMOVED] = ENTRY("wheelmoved"),
 #ifndef LOVR_DISABLE_THREAD
   [EVENT_THREAD_ERROR] = ENTRY("threaderror"),
 #endif
@@ -189,6 +190,11 @@ static int nextEvent(lua_State* L) {
       lua_pushnumber(L, event.data.mouse.dx);
       lua_pushnumber(L, event.data.mouse.dy);
       return 5;
+
+    case EVENT_MOUSEWHEELMOVED:
+      lua_pushnumber(L, event.data.wheel.x);
+      lua_pushnumber(L, event.data.wheel.y);
+      return 3;
 
 #ifndef LOVR_DISABLE_THREAD
     case EVENT_THREAD_ERROR:

--- a/src/core/os.h
+++ b/src/core/os.h
@@ -133,6 +133,7 @@ typedef void fn_key(os_button_action action, os_key key, uint32_t scancode, bool
 typedef void fn_text(uint32_t codepoint);
 typedef void fn_mouse_button(int button, bool pressed);
 typedef void fn_mouse_move(double x, double y);
+typedef void fn_mousewheel_move(double deltaX, double deltaY);
 typedef void fn_permission(os_permission permission, bool granted);
 
 bool os_init(void);
@@ -157,6 +158,7 @@ void os_on_key(fn_key* callback);
 void os_on_text(fn_text* callback);
 void os_on_mouse_button(fn_mouse_button* callback);
 void os_on_mouse_move(fn_mouse_move* callback);
+void os_on_mousewheel_move(fn_mousewheel_move* callback);
 void os_on_permission(fn_permission* callback);
 
 bool os_window_open(const os_window_config* config);

--- a/src/core/os_android.c
+++ b/src/core/os_android.c
@@ -334,6 +334,10 @@ void os_on_mouse_move(fn_mouse_move* callback) {
   //
 }
 
+void os_on_mousewheel_move(fn_mousewheel_move* callback) {
+  //
+}
+
 void os_on_permission(fn_permission* callback) {
   state.onPermissionEvent = callback;
 }

--- a/src/core/os_glfw.h
+++ b/src/core/os_glfw.h
@@ -52,6 +52,11 @@ void os_on_mouse_move(fn_mouse_move* callback) {
   //
 }
 
+void os_on_mousewheel_move(fn_wheel_move* callback)
+{
+  //
+}
+
 void os_get_mouse_position(double* x, double* y) {
   *x = *y = 0.;
 }
@@ -105,6 +110,7 @@ static struct {
   fn_text* onTextEvent;
   fn_mouse_button* onMouseButton;
   fn_mouse_move* onMouseMove;
+  fn_mousewheel_move* onMouseWheelMove;
 } glfwState;
 
 static void onError(int code, const char* description) {
@@ -250,6 +256,13 @@ static void onMouseMove(GLFWwindow* window, double x, double y) {
   }
 }
 
+static void onMouseWheelMove(GLFWwindow* window, double deltaX, double deltaY) {
+  if (glfwState.onMouseWheelMove) {
+    deltaX = (deltaX == 0.0) ? 0.0 : -deltaX;
+    glfwState.onMouseWheelMove(deltaX, deltaY);
+  }
+}
+
 static int convertMouseButton(os_mouse_button button) {
   switch (button) {
     case MOUSE_LEFT: return GLFW_MOUSE_BUTTON_LEFT;
@@ -338,6 +351,7 @@ bool os_window_open(const os_window_config* config) {
   glfwSetCharCallback(glfwState.window, onTextEvent);
   glfwSetMouseButtonCallback(glfwState.window, onMouseButton);
   glfwSetCursorPosCallback(glfwState.window, onMouseMove);
+  glfwSetScrollCallback(glfwState.window, onMouseWheelMove);
   return true;
 }
 
@@ -394,6 +408,10 @@ void os_on_mouse_button(fn_mouse_button* callback) {
 
 void os_on_mouse_move(fn_mouse_move* callback) {
   glfwState.onMouseMove = callback;
+}
+
+void os_on_mousewheel_move(fn_mousewheel_move* callback) {
+  glfwState.onMouseWheelMove = callback;
 }
 
 void os_get_mouse_position(double* x, double* y) {

--- a/src/core/os_wasm.c
+++ b/src/core/os_wasm.c
@@ -16,6 +16,7 @@ static struct {
   fn_key* onKeyboardEvent;
   fn_mouse_button* onMouseButton;
   fn_mouse_move* onMouseMove;
+  fn_mousewheel_move* onMouseWheelMove;
   bool keyMap[KEY_COUNT];
   bool mouseMap[2];
   os_mouse_mode mouseMode;
@@ -84,6 +85,13 @@ static EM_BOOL onMouseMove(int type, const EmscriptenMouseEvent* data, void* use
   }
   if (state.onMouseMove) {
     state.onMouseMove(state.mouseX, state.mouseY);
+  }
+  return false;
+}
+
+static EM_BOOL onMouseWheelMove(int type, const EmscriptenWheelEvent* data, void* userdata) {
+  if (state.onMouseWheelMove) {
+    state.onMouseWheelMove(data->deltaX, -data->deltaY);
   }
   return false;
 }
@@ -197,6 +205,7 @@ bool os_init(void) {
   emscripten_set_mousedown_callback(CANVAS, NULL, true, onMouseButton);
   emscripten_set_mouseup_callback(CANVAS, NULL, true, onMouseButton);
   emscripten_set_mousemove_callback(CANVAS, NULL, true, onMouseMove);
+  emscripten_set_wheel_callback(CANVAS, NULL, true, onMouseWheelMove);
   emscripten_set_keydown_callback(CANVAS, NULL, true, onKeyEvent);
   emscripten_set_keyup_callback(CANVAS, NULL, true, onKeyEvent);
   return true;
@@ -343,6 +352,10 @@ void os_on_mouse_button(fn_mouse_button* callback) {
 
 void os_on_mouse_move(fn_mouse_move* callback) {
   state.onMouseMove = callback;
+}
+
+void os_on_mousewheel_move(fn_mousewheel_move* callback) {
+  state.onMouseWheelMove = callback;
 }
 
 void os_get_mouse_position(double* x, double* y) {

--- a/src/modules/event/event.h
+++ b/src/modules/event/event.h
@@ -20,6 +20,7 @@ typedef enum {
   EVENT_MOUSEPRESSED,
   EVENT_MOUSERELEASED,
   EVENT_MOUSEMOVED,
+  EVENT_MOUSEWHEELMOVED,
 #ifndef LOVR_DISABLE_THREAD
   EVENT_THREAD_ERROR,
 #endif
@@ -103,6 +104,11 @@ typedef struct {
 } MouseEvent;
 
 typedef struct {
+  double x;
+  double y;
+} MouseWheelEvent;
+
+typedef struct {
   struct Thread* thread;
   char* error;
 } ThreadEvent;
@@ -125,6 +131,7 @@ typedef union {
   KeyEvent key;
   TextEvent text;
   MouseEvent mouse;
+  MouseWheelEvent wheel;
   ThreadEvent thread;
   CustomEvent custom;
   PermissionEvent permission;

--- a/src/modules/system/system.c
+++ b/src/modules/system/system.c
@@ -55,6 +55,14 @@ static void onMouseMove(double x, double y) {
   state.mouseY = y;
 }
 
+static void onWheelMove(double deltaX, double deltaY) {
+  lovrEventPush((Event) {
+    .type = EVENT_MOUSEWHEELMOVED,
+    .data.wheel.x = deltaX,
+    .data.wheel.y = deltaY,
+  });
+}
+
 static void onPermission(os_permission permission, bool granted) {
   lovrEventPush((Event) {
     .type = EVENT_PERMISSION,
@@ -76,6 +84,7 @@ bool lovrSystemInit(void) {
   os_on_text(onText);
   os_on_mouse_button(onMouseButton);
   os_on_mouse_move(onMouseMove);
+  os_on_mousewheel_move(onWheelMove);
   os_on_permission(onPermission);
   state.initialized = true;
   os_get_mouse_position(&state.mouseX, &state.mouseY);


### PR DESCRIPTION
Added `lovr.wheelmoved(x, y)` callback. Scrolling right gives positive  x, scrolling up gives positive y values. This is same callback name and sign convention as LOVE2D.

GLFW implementation is tested on linux & windows. Emscripten implementation is best effort; it compiles and tries to set correct signs based on docs. xcb is not implemented.