### PR TITLE
Implement mousearm simulator controls;

### DIFF
--- a/src/core/maf.h
+++ b/src/core/maf.h
@@ -391,6 +391,12 @@ MAF mat4 mat4_fromQuat(mat4 m, quat q) {
   return m;
 }
 
+MAF mat4 mat4_fromPose(mat4 m, vec3 v, quat q) {
+  mat4_fromQuat(m, q);
+  memcpy(m + 12, v, 3 * sizeof(float));
+  return m;
+}
+
 MAF mat4 mat4_identity(mat4 m) {
   m[0] = 1.f;
   m[1] = 0.f;

--- a/src/core/os_glfw.h
+++ b/src/core/os_glfw.h
@@ -283,6 +283,8 @@ static int convertKey(os_key key) {
     case KEY_DOWN: return GLFW_KEY_DOWN;
     case KEY_LEFT: return GLFW_KEY_LEFT;
     case KEY_RIGHT: return GLFW_KEY_RIGHT;
+    case KEY_LEFT_SHIFT: return GLFW_KEY_LEFT_SHIFT;
+    case KEY_RIGHT_SHIFT: return GLFW_KEY_RIGHT_SHIFT;
     case KEY_ESCAPE: return GLFW_KEY_ESCAPE;
     case KEY_F5: return GLFW_KEY_F5;
     default: return GLFW_KEY_UNKNOWN;

--- a/src/modules/headset/headset_simulator.c
+++ b/src/modules/headset/headset_simulator.c
@@ -2,6 +2,7 @@
 #include "data/image.h"
 #include "event/event.h"
 #include "graphics/graphics.h"
+#include "system/system.h"
 #include "core/maf.h"
 #include "core/os.h"
 #include "util.h"
@@ -24,6 +25,7 @@ static struct {
   Pass* pass;
   float pitch;
   float yaw;
+  float distance;
   float velocity[4];
   float headPosition[4];
   float headOrientation[4];
@@ -52,6 +54,7 @@ static bool simulator_init(HeadsetConfig* config) {
   state.epoch = os_get_time();
   state.clipNear = .01f;
   state.clipFar = 0.f;
+  state.distance = .5f;
 
   if (!state.initialized) {
     vec3_set(state.headPosition, 0.f, 0.f, 0.f);
@@ -362,8 +365,10 @@ static double simulator_update(void) {
     quat_rotate(state.headOrientation, ray);
     vec3_normalize(ray);
 
+    state.distance = CLAMP(state.distance * (1.f + lovrSystemGetScrollDelta() * .05f), .05f, 10.f);
+
     vec3_init(state.handPosition, ray);
-    vec3_scale(state.handPosition, .5f);
+    vec3_scale(state.handPosition, state.distance);
     vec3_add(state.handPosition, state.headPosition);
     state.handPosition[1] += OFFSET;
 

--- a/src/modules/headset/headset_simulator.c
+++ b/src/modules/headset/headset_simulator.c
@@ -198,7 +198,9 @@ static bool simulator_getPose(Device device, vec3 position, quat orientation) {
 }
 
 static bool simulator_getVelocity(Device device, vec3 velocity, vec3 angularVelocity) {
-  return false; // TODO
+  memcpy(velocity, state.velocity, 4 * sizeof(float));
+  memset(angularVelocity, 0, 4 * sizeof(float));
+  return device == DEVICE_HEAD;
 }
 
 static bool simulator_isDown(Device device, DeviceButton button, bool* down, bool* changed) {

--- a/src/modules/system/system.c
+++ b/src/modules/system/system.c
@@ -12,6 +12,7 @@ static struct {
   bool mouseState[8];
   double mouseX;
   double mouseY;
+  double scrollDelta;
 } state;
 
 static void onKey(os_button_action action, os_key key, uint32_t scancode, bool repeat) {
@@ -58,6 +59,7 @@ static void onMouseMove(double x, double y) {
 }
 
 static void onWheelMove(double deltaX, double deltaY) {
+  state.scrollDelta += deltaY;
   lovrEventPush((Event) {
     .type = EVENT_MOUSEWHEELMOVED,
     .data.wheel.x = deltaX,
@@ -132,6 +134,7 @@ float lovrSystemGetWindowDensity(void) {
 
 void lovrSystemPollEvents(void) {
   memcpy(state.prevKeyState, state.keyState, sizeof(state.keyState));
+  state.scrollDelta = 0.;
   os_poll_events();
 }
 
@@ -163,4 +166,9 @@ void lovrSystemGetMousePosition(double* x, double* y) {
 bool lovrSystemIsMouseDown(int button) {
   if ((size_t) button > COUNTOF(state.mouseState)) return false;
   return state.mouseState[button];
+}
+
+// This is kind of a hacky thing for the simulator, since we're kinda bad at event dispatch
+float lovrSystemGetScrollDelta(void) {
+  return state.scrollDelta;
 }

--- a/src/modules/system/system.h
+++ b/src/modules/system/system.h
@@ -26,3 +26,4 @@ bool lovrSystemHasKeyRepeat(void);
 void lovrSystemSetKeyRepeat(bool repeat);
 void lovrSystemGetMousePosition(double* x, double* y);
 bool lovrSystemIsMouseDown(int button);
+float lovrSystemGetScrollDelta(void);


### PR DESCRIPTION
Updates simulator controls:

- Use [mousearm](https://github.com/jmiskovic/lovr-mousearm)-style hand pose, where the controller is positioned based on the mouse
- Improved smoothing behavior, fixes slight stuttering
- Adds sprint (hold shift to move 5x faster)

~~Still need to add back velocity and make scroll change hand distance.~~

Not yet sure how to handle the discontinuity in the cursor position when releasing the mouse button.  It causes a jump in the hand position which is a bit jarring.

- Current approach is to cause the controller to lose tracking while mouse button is held.  It's slightly better, but might make testing more difficult and is still a little distracting for experiences that draw hands.
- I also tried some kind of solution where the controller stays in a fixed spot in the world while the mouse button is held down, and then interpolates towards the new position when the mouse is released.  It felt weird to have the hand zooming all over the place as you're looking around the scene.
- One alternative is to just use a normal mouse cursor for the mouselook instead of using GLFW's hidden cursor.  I think this is too annoying, because you tend to click outside the window after moving the mouse too far.