### PR TITLE
Frustum culling;

### DIFF
--- a/etc/monkey.h
+++ b/etc/monkey.h
@@ -1,4 +1,4 @@
-float monkey_size[3] = { 1.367188f, 0.984375f, 0.851563f };
+float monkey_bounds[6] = { 0.000000f, 0.000000f, 0.000000f, 0.683594f, 0.492188f, 0.425781f };
 float monkey_offset[3] = { -0.683594f, -0.492188f, -0.425781f };
 
 uint8_t monkey_vertices[] = {

--- a/etc/monkeycrush.lua
+++ b/etc/monkeycrush.lua
@@ -11,14 +11,16 @@ for i = 1, model:getMeshVertexCount(1) do
   max.x, max.y, max.z = math.max(x, max.x), math.max(y, max.y), math.max(z, max.z)
 end
 
-local size = lovr.math.newVec3(max - min)
 local scale = .5
-
 min:mul(scale)
 max:mul(scale)
-size:mul(scale)
 
-io.write(('float monkey_size[3] = { %ff, %ff, %ff };\n'):format(size:unpack()))
+local center = Vec3(max + min):mul(.5)
+local extent = Vec3(max - min)
+local halfExtent = extent / 2
+local bounds = { center[1], center[2], center[3], halfExtent[1], halfExtent[2], halfExtent[3] }
+
+io.write(('float monkey_bounds[6] = { %ff, %ff, %ff, %ff, %ff, %ff };\n'):format(unpack(bounds)))
 io.write(('float monkey_offset[3] = { %ff, %ff, %ff };\n'):format(min:unpack()))
 io.write('\n')
 
@@ -28,7 +30,7 @@ for i = 1, model:getMeshVertexCount(1) do
   local position = vec3(x, y, z):mul(scale)
   local normal = vec3(nx, ny, nz)
 
-  local qx, qy, qz = ((position - min) / size * 255 + .5):unpack()
+  local qx, qy, qz = ((position - min) / extent * 255 + .5):unpack()
   local qnx, qny, qnz = ((normal / 2 + .5) * 255 + .5):unpack()
 
   qx, qy, qz = math.floor(qx), math.floor(qy), math.floor(qz)

--- a/etc/nogame.lua
+++ b/etc/nogame.lua
@@ -26,7 +26,7 @@ function lovr.draw(pass)
   local titlePosition = 1.5 - padding
   local subtitlePosition = titlePosition - font:getHeight() * .25 - padding
 
-  pass:setCullMode('back')
+  pass:setFaceCull(true)
   pass:setShader(logo)
   pass:plane(0, 2, -3)
   pass:setShader()

--- a/src/core/maf.h
+++ b/src/core/maf.h
@@ -98,6 +98,14 @@ MAF vec3 vec3_lerp(vec3 v, const vec3 u, float t) {
   return v;
 }
 
+MAF vec3 vec3_abs(vec3 v) {
+  v[0] = fabsf(v[0]);
+  v[1] = fabsf(v[1]);
+  v[2] = fabsf(v[2]);
+  v[3] = fabsf(v[3]);
+  return v;
+}
+
 MAF float vec3_angle(const vec3 v, const vec3 u) {
   float denom = vec3_length(v) * vec3_length(u);
   if (denom == 0.f) {

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -478,6 +478,7 @@ struct Image* lovrReadbackGetImage(Readback* readback);
 typedef struct {
   uint32_t draws;
   uint32_t computes;
+  uint32_t drawsCulled;
   size_t memoryReserved;
   size_t memoryUsed;
   double submitTime;
@@ -544,7 +545,7 @@ Pass* lovrPassCreate(void);
 void lovrPassDestroy(void* ref);
 void lovrPassReset(Pass* pass);
 void lovrPassAppend(Pass* pass, Pass* other);
-void lovrPassGetStats(Pass* pass, PassStats* stats);
+const PassStats* lovrPassGetStats(Pass* pass);
 
 void lovrPassGetCanvas(Pass* pass, Texture* color[4], Texture** depthTexture, uint32_t* depthFormat, uint32_t* samples);
 void lovrPassSetCanvas(Pass* pass, Texture* color[4], Texture* depthTexture, uint32_t depthFormat, uint32_t samples);
@@ -576,11 +577,11 @@ void lovrPassSetAlphaToCoverage(Pass* pass, bool enabled);
 void lovrPassSetBlendMode(Pass* pass, uint32_t index, BlendMode mode, BlendAlphaMode alphaMode);
 void lovrPassSetColor(Pass* pass, float color[4]);
 void lovrPassSetColorWrite(Pass* pass, uint32_t index, bool r, bool g, bool b, bool a);
-void lovrPassSetCullMode(Pass* pass, CullMode mode);
 void lovrPassSetDepthTest(Pass* pass, CompareMode test);
 void lovrPassSetDepthWrite(Pass* pass, bool write);
 void lovrPassSetDepthOffset(Pass* pass, float offset, float sloped);
 void lovrPassSetDepthClamp(Pass* pass, bool clamp);
+void lovrPassSetFaceCull(Pass* pass, CullMode mode);
 void lovrPassSetFont(Pass* pass, Font* font);
 void lovrPassSetMaterial(Pass* pass, Material* material, Texture* texture);
 void lovrPassSetMeshMode(Pass* pass, MeshMode mode);
@@ -588,6 +589,7 @@ void lovrPassSetSampler(Pass* pass, Sampler* sampler);
 void lovrPassSetShader(Pass* pass, Shader* shader);
 void lovrPassSetStencilTest(Pass* pass, CompareMode test, uint8_t value, uint8_t mask);
 void lovrPassSetStencilWrite(Pass* pass, StencilAction actions[3], uint8_t value, uint8_t mask);
+void lovrPassSetViewCull(Pass* pass, bool enable);
 void lovrPassSetWinding(Pass* pass, Winding winding);
 void lovrPassSetWireframe(Pass* pass, bool wireframe);
 


### PR DESCRIPTION
- Adds Pass:setViewCull to enable/disable frustum culling.
- Renames Pass:setCullMode to Pass:setFaceCull (with backcompat).
- Adds `drawsCulled` pass stat.

Some stuff currently missing:

- Text is not culled, but should be.
- VR view frusta are not merged yet.

Optimizations I tried that weren't worth it:

- Detecting infiniteZ and reducing plane count to 5 made it slower (branching?)
- Putting transforms and bounds in a separate array from the draws (to avoid ever touching memory for culled draws, and reduce size of Draw struct) did have a measurable impact of 5% in the "hot" loop that actually does draws.  But draw calls are not actually a bottleneck of render pass recording right now, and so this change doesn't seem worth the extra code complexity.
- Pre-transforming bounding boxes by the draw's transform (in `lovrPassDraw`) makes culling twice as fast, but makes overall overhead slightly higher when draws are only submitted once.  This would probably still be a worthwhile optimization, because you get faster pass submission in the case where you're saving a pass and submitting it many times (~20% assuming lots of its draws are culled).