### PR TITLE
Make window resizable by default

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -45,7 +45,7 @@ function lovr.boot()
       width = 720,
       height = 800,
       fullscreen = false,
-      resizable = false,
+      resizable = true,
       title = 'LÖVR',
       icon = nil
     }


### PR DESCRIPTION
I prefer flexible windows during development, and the `conf` can still set it to false on rare occasions it's needed. To me resizable by default makes most sense.

But when we change the default value we kind of break the API, which is not nice.