### PR TITLE
HTTP(S)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,6 +517,10 @@ if(LOVR_ENABLE_HTTP)
     src/api/l_http.c
     src/modules/http/http.c
   )
+
+  if(WIN32)
+    target_link_libraries(lovr wininet)
+  endif()
 else()
   target_compile_definitions(lovr PRIVATE LOVR_DISABLE_HTTP)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(LOVR_ENABLE_EVENT "Enable the event module" ON)
 option(LOVR_ENABLE_FILESYSTEM "Enable the filesystem module" ON)
 option(LOVR_ENABLE_GRAPHICS "Enable the graphics module" ON)
 option(LOVR_ENABLE_HEADSET "Enable the headset module" ON)
+option(LOVR_ENABLE_HTTP "Enable the http module" ON)
 option(LOVR_ENABLE_MATH "Enable the math module" ON)
 option(LOVR_ENABLE_PHYSICS "Enable the physics module" ON)
 option(LOVR_ENABLE_SYSTEM "Enable the system module" ON)
@@ -509,6 +510,15 @@ if(LOVR_ENABLE_HEADSET)
   endif()
 else()
   target_compile_definitions(lovr PRIVATE LOVR_DISABLE_HEADSET)
+endif()
+
+if(LOVR_ENABLE_HTTP)
+  target_sources(lovr PRIVATE
+    src/api/l_http.c
+    src/modules/http/http.c
+  )
+else()
+  target_compile_definitions(lovr PRIVATE LOVR_DISABLE_HTTP)
 endif()
 
 if(LOVR_ENABLE_MATH)

--- a/Tupfile.lua
+++ b/Tupfile.lua
@@ -16,6 +16,7 @@ config = {
     filesystem = true,
     graphics = true,
     headset = true,
+    http = true,
     math = true,
     physics = true,
     system = true,

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -12,6 +12,7 @@ function lovr.boot()
       event = true,
       graphics = true,
       headset = true,
+      http = true,
       math = true,
       physics = true,
       system = true,

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -27,6 +27,7 @@ LOVR_EXPORT int luaopen_lovr_event(lua_State* L);
 LOVR_EXPORT int luaopen_lovr_filesystem(lua_State* L);
 LOVR_EXPORT int luaopen_lovr_graphics(lua_State* L);
 LOVR_EXPORT int luaopen_lovr_headset(lua_State* L);
+LOVR_EXPORT int luaopen_lovr_http(lua_State* L);
 LOVR_EXPORT int luaopen_lovr_math(lua_State* L);
 LOVR_EXPORT int luaopen_lovr_physics(lua_State* L);
 LOVR_EXPORT int luaopen_lovr_system(lua_State* L);
@@ -104,6 +105,9 @@ void luax_preload(lua_State* L) {
 #endif
 #ifndef LOVR_DISABLE_HEADSET
     { "lovr.headset", luaopen_lovr_headset },
+#endif
+#ifndef LOVR_DISABLE_HTTP
+    { "lovr.http", luaopen_lovr_http },
 #endif
 #ifndef LOVR_DISABLE_MATH
     { "lovr.math", luaopen_lovr_math },

--- a/src/api/l_http.c
+++ b/src/api/l_http.c
@@ -99,10 +99,6 @@ static int l_lovrHttpRequest(lua_State* L) {
       }
     }
     lua_pop(L, 1);
-
-    lua_getfield(L, 2, "timeout");
-    if (!lua_isnil(L, -1)) request.timeout = lua_tointeger(L, -1);
-    lua_pop(L, 1);
   }
 
   Response response = {

--- a/src/api/l_http.c
+++ b/src/api/l_http.c
@@ -113,8 +113,9 @@ static int l_lovrHttpRequest(lua_State* L) {
   arr_free(&body);
 
   if (!success) {
-    lua_pushinteger(L, 0);
-    return 1;
+    lua_pushnil(L);
+    lua_pushstring(L, response.error);
+    return 2;
   }
 
   lua_pushinteger(L, response.status);

--- a/src/api/l_http.c
+++ b/src/api/l_http.c
@@ -1,0 +1,142 @@
+#include "api.h"
+#include "http/http.h"
+#include "data/blob.h"
+#include "util.h"
+#include <stdlib.h>
+
+static bool isunreserved(char c) {
+  switch (c) {
+    case 'a': case 'b': case 'c': case 'd': case 'e': case 'f': case 'g': case 'h': case 'i':
+    case 'j': case 'k': case 'l': case 'm': case 'n': case 'o': case 'p': case 'q': case 'r':
+    case 's': case 't': case 'u': case 'v': case 'w': case 'x': case 'y': case 'z':
+    case 'A': case 'B': case 'C': case 'D': case 'E': case 'F': case 'G': case 'H': case 'I':
+    case 'J': case 'K': case 'L': case 'M': case 'N': case 'O': case 'P': case 'Q': case 'R':
+    case 'S': case 'T': case 'U': case 'V': case 'W': case 'X': case 'Y': case 'Z':
+    case '1': case '2': case '3': case '4': case '5': case '6': case '7': case '8': case '9': case '0':
+    case '-': case '_': case '.': case '~':
+      return true;
+    default:
+      return false;
+  }
+}
+
+static size_t urlencode(char* dst, const char* str, size_t len) {
+  size_t res = 0;
+  for (size_t i = 0; i < len; i++, str++) {
+    if (isunreserved(*str)) {
+      dst[res++] = *str;
+    } else {
+      dst[res++] = '%';
+      dst[res++] = '0' + *str / 16;
+      dst[res++] = '0' + *str % 16;
+    }
+  }
+  return res;
+}
+
+static void onHeader(void* userdata, const char* name, size_t nameLength, const char* value, size_t valueLength) {
+  lua_State* L = userdata;
+  lua_pushlstring(L, name, nameLength);
+  lua_pushlstring(L, value, valueLength);
+  lua_settable(L, 3);
+}
+
+static int l_lovrHttpRequest(lua_State* L) {
+  Request request = { 0 };
+  Blob* blob = NULL;
+
+  arr_t(char) body;
+  arr_init(&body, arr_alloc);
+
+  request.url = luaL_checkstring(L, 1);
+
+  if (lua_istable(L, 2)) {
+    lua_getfield(L, 2, "data");
+    if (lua_type(L, -1) == LUA_TSTRING) {
+      request.data = lua_tolstring(L, -1, &request.size);
+    } else if (lua_type(L, -1) == LUA_TTABLE) {
+      lua_pushnil(L);
+      while (lua_next(L, -2) != 0) {
+        if (lua_type(L, -2) == LUA_TSTRING && lua_isstring(L, -1)) {
+          size_t keyLength, valLength;
+          const char* key = lua_tolstring(L, -2, &keyLength);
+          const char* val = lua_tolstring(L, -1, &valLength);
+          arr_expand(&body, 3 * keyLength + 1 + 3 * valLength + 1);
+          body.length += urlencode(body.data, key, keyLength);
+          arr_push(&body, '=');
+          body.length += urlencode(body.data, val, valLength);
+          arr_push(&body, '&');
+        }
+        lua_pop(L, 1);
+      }
+      request.data = body.data;
+      request.size = body.length - 1;
+    } else if ((blob = luax_totype(L, -1, Blob)) != NULL) {
+      request.data = blob->data;
+      request.size = blob->size;
+    } else if (!lua_isnil(L, -1)) {
+      lovrThrow("Expected string, table, or Blob for request data");
+      return 0;
+    }
+    lua_pop(L, 1);
+
+    lua_getfield(L, 2, "method");
+    if (!lua_isnil(L, -1)) request.method = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
+    lua_getfield(L, 2, "headers");
+    if (lua_istable(L, -1)) {
+      lua_pushnil(L);
+      while (lua_next(L, -2) != 0) {
+        if (lua_type(L, -2) == LUA_TSTRING && lua_isstring(L, -1)) {
+          request.headers = realloc(request.headers, (request.headerCount + 1) * 2 * sizeof(char*));
+          lovrAssert(request.headers, "Out of memory");
+          request.headers[request.headerCount * 2 + 0] = lua_tostring(L, -2);
+          request.headers[request.headerCount * 2 + 1] = lua_tostring(L, -1);
+          request.headerCount++;
+        }
+        lua_pop(L, 1);
+      }
+    }
+    lua_pop(L, 1);
+
+    lua_getfield(L, 2, "timeout");
+    if (!lua_isnil(L, -1)) request.timeout = lua_tointeger(L, -1);
+    lua_pop(L, 1);
+  }
+
+  Response response = {
+    .onHeader = onHeader,
+    .userdata = L
+  };
+
+  lua_settop(L, 2);
+  lua_newtable(L);
+  bool success = lovrHttpRequest(&request, &response);
+  free(request.headers);
+  arr_free(&body);
+
+  if (!success) {
+    lua_pushinteger(L, 0);
+    return 1;
+  }
+
+  lua_pushinteger(L, response.status);
+  lua_pushlstring(L, response.data, response.size);
+  lua_pushvalue(L, -3);
+  return 3;
+}
+
+static const luaL_Reg lovrHttp[] = {
+  { "request", l_lovrHttpRequest },
+  { NULL, NULL }
+};
+
+int luaopen_lovr_http(lua_State* L) {
+  lua_newtable(L);
+  luax_register(L, lovrHttp);
+  if (lovrHttpInit()) {
+    luax_atexit(L, lovrHttpDestroy);
+  }
+  return 1;
+}

--- a/src/api/l_http.c
+++ b/src/api/l_http.c
@@ -124,6 +124,7 @@ static int l_lovrHttpRequest(lua_State* L) {
   lua_pushinteger(L, response.status);
   lua_pushlstring(L, response.data, response.size);
   lua_pushvalue(L, -3);
+  free(response.data);
   return 3;
 }
 

--- a/src/modules/http/http.c
+++ b/src/modules/http/http.c
@@ -1,0 +1,164 @@
+#include "http/http.h"
+#include "util.h"
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_WIN32)
+
+#elif defined(__linux__)
+#include <curl/curl.h>
+#include <dlfcn.h>
+
+typedef CURLcode fn_global_init(long flags);
+typedef void fn_global_cleanup(void);
+typedef CURL* fn_easy_init(void);
+typedef CURLcode fn_easy_setopt(CURL *curl, CURLoption option, ...);
+typedef CURLcode fn_easy_perform(CURL *curl);
+typedef void fn_easy_cleanup(CURL* curl);
+typedef CURLcode fn_easy_getinfo(CURL* curl, CURLINFO info, ...);
+typedef struct curl_slist *fn_slist_append(struct curl_slist *list, const char *string);
+typedef void fn_slist_free_all(struct curl_slist *list);
+
+#define FN_DECLARE(f) fn_##f* f;
+#define FN_LOAD(f) curl.f = (fn_##f*) dlsym(state.library, "curl_"#f);
+#define FN_FOREACH(X)\
+  X(global_init)\
+  X(global_cleanup)\
+  X(easy_init)\
+  X(easy_setopt)\
+  X(easy_perform)\
+  X(easy_cleanup)\
+  X(easy_getinfo)\
+  X(slist_append)\
+  X(slist_free_all)
+
+static struct {
+  FN_FOREACH(FN_DECLARE)
+} curl;
+
+static struct {
+  bool initialized;
+  void* library;
+} state;
+
+bool lovrHttpInit(void) {
+  if (state.initialized) return false;
+
+  state.library = dlopen("libcurl.so", RTLD_LAZY);
+  if (!state.library) return false;
+
+  FN_FOREACH(FN_LOAD)
+
+  if (curl.global_init(CURL_GLOBAL_DEFAULT)) {
+    dlclose(state.library);
+    state.library = NULL;
+    return false;
+  }
+
+  state.initialized = true;
+  return true;
+}
+
+void lovrHttpDestroy(void) {
+  if (!state.initialized) return;
+  curl.global_cleanup();
+  dlclose(state.library);
+  memset(&state, 0, sizeof(state));
+}
+
+static size_t reader(char* buffer, size_t size, size_t count, void* userdata) {
+  char** data = userdata;
+  memcpy(buffer, *data, size * count);
+  *data += size * count;
+  return size * count;
+}
+
+static size_t writer(void* buffer, size_t size, size_t count, void* userdata) {
+  Response* response = userdata;
+  response->data = realloc(response->data, response->size + size * count);
+  lovrAssert(response->data, "Out of memory");
+  memcpy(response->data + response->size, buffer, size * count);
+  response->size += size * count;
+  return size * count;
+}
+
+// would rather use curl_easy_nextheader, but it's too new right now
+static size_t onHeader(char* buffer, size_t size, size_t count, void* userdata) {
+  Response* response = userdata;
+  char* colon = memchr(buffer, ':', size * count);
+  if (colon) {
+    char* name = buffer;
+    char* value = colon + 1;
+    size_t nameLength = colon - buffer;
+    size_t valueLength = size * count - (nameLength + 1);
+    while (valueLength > 0 && (*value == ' ' || *value == '\t')) value++, valueLength--;
+    while (valueLength > 0 && (value[valueLength - 1] == '\n' || value[valueLength - 1] == '\r')) valueLength--;
+    response->onHeader(response->userdata, name, nameLength, value, valueLength);
+  }
+  return size * count;
+}
+
+bool lovrHttpRequest(Request* request, Response* response) {
+  CURL* handle = curl.easy_init();
+  if (!handle) return false;
+
+  curl.easy_setopt(handle, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+  curl.easy_setopt(handle, CURLOPT_URL, request->url);
+
+  if (request->method) {
+    curl.easy_setopt(handle, CURLOPT_CUSTOMREQUEST, request->method);
+    if (!strcmp(request->method, "HEAD")) curl.easy_setopt(handle, CURLOPT_NOBODY, 1);
+  }
+
+  if (request->data && (!request->method || (strcmp(request->method, "HEAD") && strcmp(request->method, "GET")))) {
+    const char* data = request->data;
+    curl_off_t size = request->size;
+    curl.easy_setopt(handle, CURLOPT_POST, 1);
+    curl.easy_setopt(handle, CURLOPT_READDATA, &data);
+    curl.easy_setopt(handle, CURLOPT_READFUNCTION, reader);
+    curl.easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE, size);
+  }
+
+  struct curl_slist* headers = NULL;
+  if (request->headerCount > 0) {
+    arr_t(char) header;
+    arr_init(&header, arr_alloc);
+    for (uint32_t i = 0; i < request->headerCount; i++) {
+      const char* name = *request->headers++;
+      const char* value = *request->headers++;
+      arr_clear(&header);
+      arr_append(&header, name, strlen(name));
+      arr_append(&header, ": ", 2);
+      arr_append(&header, value, strlen(value));
+      arr_push(&header, '\0');
+      headers = curl.slist_append(headers, header.data);
+    }
+    curl.easy_setopt(handle, CURLOPT_HTTPHEADER, headers);
+    arr_free(&header);
+  }
+
+  curl.easy_setopt(handle, CURLOPT_TIMEOUT, request->timeout);
+  curl.easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1);
+
+  response->size = 0;
+  response->data = NULL;
+  curl.easy_setopt(handle, CURLOPT_WRITEDATA, response);
+  curl.easy_setopt(handle, CURLOPT_WRITEFUNCTION, writer);
+
+  curl.easy_setopt(handle, CURLOPT_HEADERDATA, response);
+  curl.easy_setopt(handle, CURLOPT_HEADERFUNCTION, onHeader);
+
+  curl.easy_perform(handle);
+
+  long status;
+  curl.easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &status);
+  response->status = status;
+
+  curl.easy_cleanup(handle);
+  curl.slist_free_all(headers);
+  return true;
+}
+
+#else
+#error "Unsupported HTTP platform"
+#endif

--- a/src/modules/http/http.c
+++ b/src/modules/http/http.c
@@ -28,12 +28,12 @@ void lovrHttpDestroy(void) {
 
 bool lovrHttpRequest(Request* req, Response* res) {
   if (!state.handle) {
-    response->error = "unknown error";
+    res->error = "unknown error";
     return false;
   }
 
   if (req->size > UINT32_MAX) {
-    response->error = "request data too large";
+    res->error = "request data too large";
     return false;
   }
 
@@ -50,12 +50,12 @@ bool lovrHttpRequest(Request* req, Response* res) {
     length -= 7;
     url += 7;
   } else {
-    response->error = "invalid url";
+    res->error = "invalid url";
     return false;
   }
 
   if (strchr(url, '@') || strchr(url, ':')) {
-    response->error = "invalid url";
+    res->error = "invalid url";
     return false;
   }
 
@@ -66,7 +66,7 @@ bool lovrHttpRequest(Request* req, Response* res) {
     memcpy(host, url, hostLength);
     host[hostLength] = '\0';
   } else {
-    response->error = "invalid url";
+    res->error = "invalid url";
     return false;
   }
 
@@ -74,7 +74,7 @@ bool lovrHttpRequest(Request* req, Response* res) {
   INTERNET_PORT port = https ? INTERNET_DEFAULT_HTTPS_PORT : INTERNET_DEFAULT_HTTP_PORT;
   HINTERNET connection = InternetConnectA(state.handle, host, port, NULL, NULL, INTERNET_SERVICE_HTTP, 0, 0);
   if (!connection) {
-    response->error = "system error while setting up request";
+    res->error = "system error while setting up request";
     return false;
   }
 
@@ -89,7 +89,7 @@ bool lovrHttpRequest(Request* req, Response* res) {
   HINTERNET request = HttpOpenRequestA(connection, method, path, NULL, NULL, NULL, flags, 0);
   if (!request) {
     InternetCloseHandle(connection);
-    response->error = "system error while setting up request";
+    res->error = "system error while setting up request";
     return false;
   }
 
@@ -115,7 +115,7 @@ bool lovrHttpRequest(Request* req, Response* res) {
   bool success = HttpSendRequestA(request, NULL, 0, (void*) req->data, (DWORD) req->size);
   if (!success) {
     InternetCloseHandle(connection);
-    response->error = "system error while sending request";
+    res->error = "system error while sending request";
     return false;
   }
 
@@ -143,7 +143,7 @@ bool lovrHttpRequest(Request* req, Response* res) {
       if (buffer != stack) free(buffer);
       InternetCloseHandle(request);
       InternetCloseHandle(connection);
-      response->error = "system error while parsing headers";
+      res->error = "system error while parsing headers";
       return false;
     }
   }
@@ -176,7 +176,7 @@ bool lovrHttpRequest(Request* req, Response* res) {
       free(res->data);
       InternetCloseHandle(request);
       InternetCloseHandle(connection);
-      response->error = "system error while reading response";
+      res->error = "system error while reading response";
       return false;
     }
 
@@ -193,7 +193,7 @@ bool lovrHttpRequest(Request* req, Response* res) {
       free(res->data);
       InternetCloseHandle(request);
       InternetCloseHandle(connection);
-      response->error = "system error while reading response";
+      res->error = "system error while reading response";
       return false;
     }
   }

--- a/src/modules/http/http.h
+++ b/src/modules/http/http.h
@@ -16,6 +16,7 @@ typedef struct {
 } Request;
 
 typedef struct {
+  const char* error;
   uint32_t status;
   char* data;
   size_t size;

--- a/src/modules/http/http.h
+++ b/src/modules/http/http.h
@@ -5,7 +5,6 @@
 #pragma once
 
 typedef void fn_on_header(void* userdata, const char* name, size_t nameLength, const char* value, size_t valueLength);
-typedef void fn_on_data(void* userdata, void* data, size_t length);
 
 typedef struct {
   const char* url;
@@ -14,7 +13,6 @@ typedef struct {
   uint32_t headerCount;
   const char* data;
   size_t size;
-  uint32_t timeout;
 } Request;
 
 typedef struct {

--- a/src/modules/http/http.h
+++ b/src/modules/http/http.h
@@ -1,0 +1,30 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#pragma once
+
+typedef void fn_on_header(void* userdata, const char* name, size_t nameLength, const char* value, size_t valueLength);
+typedef void fn_on_data(void* userdata, void* data, size_t length);
+
+typedef struct {
+  const char* url;
+  const char* method;
+  const char** headers;
+  uint32_t headerCount;
+  const char* data;
+  size_t size;
+  uint32_t timeout;
+} Request;
+
+typedef struct {
+  uint32_t status;
+  char* data;
+  size_t size;
+  fn_on_header* onHeader;
+  void* userdata;
+} Response;
+
+bool lovrHttpInit(void);
+void lovrHttpDestroy(void);
+bool lovrHttpRequest(Request* request, Response* response);


### PR DESCRIPTION
Early draft of an HTTP module (or function/plugin, TBD).  Definitely copying LÖVE's homework a bit for this, (lua-https was too difficult to integrate, especially on Android).

API:

```lua
local status, data, headers = lovr.http.request(url, {
  method = nil, --> nil for auto GET/POST based on whether data is provided
  data = nil, --> string, Blob, or table (table gets url encoded as application/x-www-form-urlencoded)
  headers = {},
  timeout = false --> can be integer for seconds
})
```

Returns 0 on failure.

Request is synchronous, asynchronous requests would require machinery from #274.

Does not support multipart/form-data request bodies.

Does not support folding multiline headers.

Backends:

- [x] linux (curl)
- [x] windows (wininet)
- [x] macos (nsurl)
- [ ] android (java)
- [ ] emscripten (fetch)