### PR TITLE
add Shape:queryOverlapping to query overlppaing shapes

### DIFF
--- a/src/api/l_physics_shapes.c
+++ b/src/api/l_physics_shapes.c
@@ -312,11 +312,27 @@ static bool queryCallback(Shape* shape, void* userdata) {
   return shouldStop;
 }
 
+/*
+shape:queryOverlapping(function(other) end)
+shape:queryOverlapping(tag_filter)
+shape:queryOverlapping(tag_filter, function(other) end)
+*/
 static int l_lovrShapeQueryOverlapping(lua_State* L) {
   Shape* shape = luax_checkshape(L, 1);
   lovrAssert(lovrShapeGetCollider(shape) != NULL, "Shape must be attached to collider");
-  bool function = lua_type(L, 2) == LUA_TFUNCTION;
-  bool any = lovrShapeQueryOverlapping(shape, function ? queryCallback : NULL, L);
+  bool function, tagFilter;
+  if (lua_gettop(L) == 3) {
+    function = lua_type(L, 3) == LUA_TFUNCTION;
+    tagFilter = lua_toboolean(L, 2);
+  } else if (lua_type(L, 2) == LUA_TFUNCTION) {
+    function = true;
+    tagFilter = true;
+  } else {
+    function = false;
+    tagFilter = lua_toboolean(L, 2);
+  }
+
+  bool any = lovrShapeQueryOverlapping(shape, tagFilter, function ? queryCallback : NULL, L);
   lua_pushboolean(L, any);
   return 1;
 }

--- a/src/api/l_physics_shapes.c
+++ b/src/api/l_physics_shapes.c
@@ -312,27 +312,11 @@ static bool queryCallback(Shape* shape, void* userdata) {
   return shouldStop;
 }
 
-/*
-shape:queryOverlapping(function(other) end)
-shape:queryOverlapping(tag_filter)
-shape:queryOverlapping(tag_filter, function(other) end)
-*/
 static int l_lovrShapeQueryOverlapping(lua_State* L) {
   Shape* shape = luax_checkshape(L, 1);
   lovrAssert(lovrShapeGetCollider(shape) != NULL, "Shape must be attached to collider");
-  bool function, tagFilter;
-  if (lua_gettop(L) == 3) {
-    function = lua_type(L, 3) == LUA_TFUNCTION;
-    tagFilter = lua_toboolean(L, 2);
-  } else if (lua_type(L, 2) == LUA_TFUNCTION) {
-    function = true;
-    tagFilter = true;
-  } else {
-    function = false;
-    tagFilter = lua_toboolean(L, 2);
-  }
-
-  bool any = lovrShapeQueryOverlapping(shape, tagFilter, function ? queryCallback : NULL, L);
+  bool function = lua_type(L, 2) == LUA_TFUNCTION;
+  bool any = lovrShapeQueryOverlapping(shape, function ? queryCallback : NULL, L);
   lua_pushboolean(L, any);
   return 1;
 }

--- a/src/api/l_physics_shapes.c
+++ b/src/api/l_physics_shapes.c
@@ -302,6 +302,25 @@ static int l_lovrShapeGetAABB(lua_State* L) {
   return 6;
 }
 
+static bool queryCallback(Shape* shape, void* userdata) {
+  lua_State* L = userdata;
+  lua_pushvalue(L, -1);
+  luax_pushshape(L, shape);
+  lua_call(L, 1, 1);
+  bool shouldStop = lua_type(L, -1) == LUA_TBOOLEAN && !lua_toboolean(L, -1);
+  lua_pop(L, 1);
+  return shouldStop;
+}
+
+static int l_lovrShapeQueryOverlapping(lua_State* L) {
+  Shape* shape = luax_checkshape(L, 1);
+  lovrAssert(lovrShapeGetCollider(shape) != NULL, "Shape must be attached to collider");
+  bool function = lua_type(L, 2) == LUA_TFUNCTION;
+  bool any = lovrShapeQueryOverlapping(shape, function ? queryCallback : NULL, L);
+  lua_pushboolean(L, any);
+  return 1;
+}
+
 #define lovrShape \
   { "destroy", l_lovrShapeDestroy }, \
   { "getType", l_lovrShapeGetType }, \
@@ -319,7 +338,8 @@ static int l_lovrShapeGetAABB(lua_State* L) {
   { "getPose", l_lovrShapeGetPose }, \
   { "setPose", l_lovrShapeSetPose }, \
   { "getMass", l_lovrShapeGetMass }, \
-  { "getAABB", l_lovrShapeGetAABB }
+  { "getAABB", l_lovrShapeGetAABB }, \
+  { "queryOverlapping", l_lovrShapeQueryOverlapping }
 
 static int l_lovrSphereShapeGetRadius(lua_State* L) {
   SphereShape* sphere = luax_checktype(L, 1, SphereShape);

--- a/src/modules/physics/physics.c
+++ b/src/modules/physics/physics.c
@@ -1012,9 +1012,9 @@ void lovrShapeGetAABB(Shape* shape, float aabb[6]) {
   dGeomGetAABB(shape->id, aabb);
 }
 
-bool lovrShapeQueryOverlapping(Shape* shape, bool tagFilter, QueryCallback callback, void* userdata) {
+bool lovrShapeQueryOverlapping(Shape* shape, QueryCallback callback, void* userdata) {
   QueryData data = {
-    .callback = callback, .userdata = userdata, .called = false, .shouldStop = false, .tagFilter = tagFilter
+    .callback = callback, .userdata = userdata, .called = false, .shouldStop = false, .tagFilter = true
   };
   dSpaceCollide2(shape->id, (dGeomID) shape->collider->world->space, &data, queryCallback);
   return data.called;

--- a/src/modules/physics/physics.c
+++ b/src/modules/physics/physics.c
@@ -991,6 +991,12 @@ void lovrShapeGetAABB(Shape* shape, float aabb[6]) {
   dGeomGetAABB(shape->id, aabb);
 }
 
+bool lovrShapeQueryOverlapping(Shape* shape, QueryCallback callback, void* userdata) {
+  QueryData data = { .callback = callback, .userdata = userdata, .called = false, .shouldStop = false };
+  dSpaceCollide2(shape->id, (dGeomID) shape->collider->world->space, &data, queryCallback);
+  return data.called;
+}
+
 SphereShape* lovrSphereShapeCreate(float radius) {
   lovrCheck(radius > 0.f, "SphereShape radius must be positive");
   SphereShape* sphere = calloc(1, sizeof(SphereShape));

--- a/src/modules/physics/physics.h
+++ b/src/modules/physics/physics.h
@@ -155,6 +155,7 @@ void lovrShapeGetOrientation(Shape* shape, float* orientation);
 void lovrShapeSetOrientation(Shape* shape, float* orientation);
 void lovrShapeGetMass(Shape* shape, float density, float* cx, float* cy, float* cz, float* mass, float inertia[6]);
 void lovrShapeGetAABB(Shape* shape, float aabb[6]);
+bool lovrShapeQueryOverlapping(Shape* shape, QueryCallback callback, void* userdata);
 
 SphereShape* lovrSphereShapeCreate(float radius);
 float lovrSphereShapeGetRadius(SphereShape* sphere);

--- a/src/modules/physics/physics.h
+++ b/src/modules/physics/physics.h
@@ -155,7 +155,7 @@ void lovrShapeGetOrientation(Shape* shape, float* orientation);
 void lovrShapeSetOrientation(Shape* shape, float* orientation);
 void lovrShapeGetMass(Shape* shape, float density, float* cx, float* cy, float* cz, float* mass, float inertia[6]);
 void lovrShapeGetAABB(Shape* shape, float aabb[6]);
-bool lovrShapeQueryOverlapping(Shape* shape, QueryCallback callback, void* userdata);
+bool lovrShapeQueryOverlapping(Shape* shape, bool tagFilter, QueryCallback callback, void* userdata);
 
 SphereShape* lovrSphereShapeCreate(float radius);
 float lovrSphereShapeGetRadius(SphereShape* sphere);

--- a/src/modules/physics/physics.h
+++ b/src/modules/physics/physics.h
@@ -155,7 +155,7 @@ void lovrShapeGetOrientation(Shape* shape, float* orientation);
 void lovrShapeSetOrientation(Shape* shape, float* orientation);
 void lovrShapeGetMass(Shape* shape, float density, float* cx, float* cy, float* cz, float* mass, float inertia[6]);
 void lovrShapeGetAABB(Shape* shape, float aabb[6]);
-bool lovrShapeQueryOverlapping(Shape* shape, bool tagFilter, QueryCallback callback, void* userdata);
+bool lovrShapeQueryOverlapping(Shape* shape, QueryCallback callback, void* userdata);
 
 SphereShape* lovrSphereShapeCreate(float radius);
 float lovrSphereShapeGetRadius(SphereShape* sphere);


### PR DESCRIPTION
Currently, if we want to get overlapping shapes of a shape, we have to record when `world:update`. This logic is too complicated.

As a sensor, it functions exactly like a tag marked as non-collisionable. This function will allow users to skip the complicated collision resolver logic and get the overlapping shapes directly.