### PR TITLE
Surface Improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Update Packages
         run: sudo apt update
       - name: Install Packages
-        run: sudo apt install -y xorg-dev libxcb-glx0-dev libfuse2 libcurl4-openssl-dev libssl-dev
+        run: sudo apt install -y xorg-dev libxcb-glx0-dev libx11-xcb-dev libfuse2 libcurl4-openssl-dev libssl-dev
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -853,6 +853,7 @@ elseif(ANDROID)
   endif()
 elseif(UNIX)
   target_sources(lovr PRIVATE src/core/os_linux.c)
+  target_link_libraries(lovr X11 xcb X11-xcb)
   set_target_properties(lovr PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
     BUILD_WITH_INSTALL_RPATH TRUE

--- a/Tupfile.lua
+++ b/Tupfile.lua
@@ -141,6 +141,7 @@ if target == 'linux' then
   cflags += '-D_DEFAULT_SOURCE'
   lflags += '-lm -lpthread -ldl'
   lflags += '-Wl,-rpath,\\$ORIGIN'
+  lflags += '-lX11 -lxcb -lX11-xcb'
 end
 
 if target == 'wasm' then

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -1,16 +1,19 @@
 #include "gpu.h"
 #include <string.h>
 
-#if defined(_WIN32)
-#define VK_USE_PLATFORM_WIN32_KHR
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+#if defined(_WIN32)
+#define VK_USE_PLATFORM_WIN32_KHR
 #elif defined(__APPLE__)
 #define VK_USE_PLATFORM_METAL_EXT
-#include <dlfcn.h>
 #elif defined(__linux__) && !defined(__ANDROID__)
 #define VK_USE_PLATFORM_XCB_KHR
-#include <dlfcn.h>
 #endif
 
 #define VK_NO_PROTOTYPES

--- a/src/core/os.h
+++ b/src/core/os.h
@@ -179,3 +179,11 @@ void os_get_mouse_position(double* x, double* y);
 void os_set_mouse_mode(os_mouse_mode mode);
 bool os_is_mouse_down(os_mouse_button button);
 bool os_is_key_down(os_key key);
+
+uintptr_t os_get_win32_window(void);
+uintptr_t os_get_win32_instance(void);
+
+uintptr_t os_get_ca_metal_layer(void);
+
+uintptr_t os_get_xcb_connection(void);
+uintptr_t os_get_xcb_window(void);

--- a/src/core/os_glfw.h
+++ b/src/core/os_glfw.h
@@ -102,19 +102,19 @@ uintptr_t os_get_xcb_window(void) {
 
 #ifdef _WIN32
 #define GLFW_EXPOSE_NATIVE_WIN32
-#include <GLFW/glfw3native.h>
 #endif
 
 #ifdef __APPLE__
 #define GLFW_EXPOSE_NATIVE_COCOA
-#include <GLFW/glfw3native.h>
+#include <QuartzCore/CAMetalLayer.h>
 #endif
 
 #ifdef __linux__
 #define GLFW_EXPOSE_NATIVE_X11
 #include <X11/Xlib-xcb.h>
-#include <GLFW/glfw3native.h>
 #endif
+
+#include <GLFW/glfw3native.h>
 
 static struct {
   GLFWwindow* window;
@@ -459,7 +459,14 @@ uintptr_t os_get_win32_instance(void) {
 }
 #elif defined(__APPLE__)
 uintptr_t os_get_ca_metal_layer(void) {
-  return 0; // TODO
+  id window = glfwGetCocoaWindow(glfwState.window);
+  id view = msg(id, window, "contentView");
+  id layer = msg(id, cls(CAMetalLayer), "layer");
+  CGFloat scale = msg(CGFloat, window, "backingScaleFactor");
+  msg1(void, layer, "setContentsScale:", CGFloat, scale);
+  msg1(void, view, "setLayer:", id, layer);
+  msg1(void, view, "setWantsLayer:", BOOL, YES);
+  return (uintptr_t) layer;
 }
 #elif defined(__linux__) && !defined(__ANDROID__)
 uintptr_t os_get_xcb_connection(void) {

--- a/src/modules/headset/headset_simulator.c
+++ b/src/modules/headset/headset_simulator.c
@@ -255,7 +255,7 @@ static Texture* simulator_getTexture(void) {
 }
 
 static Pass* simulator_getPass(void) {
-  if (!state.pass) {
+  if (!state.pass || !os_window_is_open()) {
     return NULL;
   }
 


### PR DESCRIPTION
Restores ability to open window after initializing graphics module.

Surface is created lazily instead of being required upfront.

Use native platorm handles instead of GLFW callbacks.

Some minor reorganization around core/gpu present API and xr transitions.

Linux links against libxcb/libX11/libX11-xcb for XGetXCBConnection.

Still filling in and testing esp macOS.