### PR TITLE
Boot rework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -779,11 +779,7 @@ elseif(ANDROID)
   if(LOVR_BUILD_EXE)
     set(ANDROID_JAR "${ANDROID_SDK}/platforms/${ANDROID_PLATFORM}/android.jar")
     set(ANDROID_TOOLS "${ANDROID_SDK}/build-tools/${ANDROID_BUILD_TOOLS_VERSION}")
-
-    # If assets are included in the apk then add '-A assets' to aapt, otherwise don't add any flags
-    if(ANDROID_ASSETS)
-      set(ANDROID_ASSETS -A ${ANDROID_ASSETS})
-    endif()
+    set(ANDROID_ASSETS "${CMAKE_CURRENT_SOURCE_DIR}/etc/nogame" CACHE STRING "The project folder to include in the APK")
 
     if(LOVR_USE_OPENXR)
       add_custom_command(TARGET move_files POST_BUILD
@@ -825,7 +821,7 @@ elseif(ANDROID)
         -M AndroidManifest.xml
         -I ${ANDROID_JAR}
         -F lovr.unaligned.apk
-        ${ANDROID_ASSETS}
+        -A ${ANDROID_ASSETS}
         raw
       COMMAND ${ANDROID_TOOLS}/zipalign -f -p 4 lovr.unaligned.apk lovr.unsigned.apk
       COMMAND ${ANDROID_TOOLS}/apksigner

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 cmake_policy(SET CMP0063 NEW)
 cmake_policy(SET CMP0079 NEW)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum macOS deployment version")
@@ -628,6 +628,13 @@ foreach(path ${LOVR_RESOURCES})
   # Write some xxd-compatible C code!
   file(WRITE ${output} "const unsigned char ${identifier}[] = {${data}};\nconst unsigned int ${identifier}_len = sizeof(${identifier});\n")
 endforeach()
+
+add_custom_command(TARGET lovr POST_BUILD
+  DEPENDS "etc/nogame"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/etc/nogame"
+  COMMAND ${CMAKE_COMMAND} -E tar c "${CMAKE_CURRENT_BINARY_DIR}/nogame.zip" --format=zip arg.lua conf.lua main.lua
+  COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_CURRENT_BINARY_DIR}/nogame.zip" >> $<TARGET_FILE:lovr>
+)
 
 # Add a custom target that is always out of date so libraries are always moved
 add_custom_target(move_files ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -629,12 +629,19 @@ foreach(path ${LOVR_RESOURCES})
   file(WRITE ${output} "const unsigned char ${identifier}[] = {${data}};\nconst unsigned int ${identifier}_len = sizeof(${identifier});\n")
 endforeach()
 
-add_custom_command(TARGET lovr POST_BUILD
-  DEPENDS "etc/nogame"
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/etc/nogame"
-  COMMAND ${CMAKE_COMMAND} -E tar c "${CMAKE_CURRENT_BINARY_DIR}/nogame.zip" --format=zip arg.lua conf.lua main.lua
-  COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_CURRENT_BINARY_DIR}/nogame.zip" >> $<TARGET_FILE:lovr>
-)
+if(NOT ANDROID)
+  if(APPLE AND LOVR_BUILD_BUNDLE)
+    set(NOGAME_BUNDLE "${CMAKE_CURRENT_BINARY_DIR}/lovr.app/Contents/Resources/nogame.lovr")
+  else()
+    set(NOGAME_BUNDLE "$<TARGET_FILE:lovr>")
+  endif()
+  add_custom_command(TARGET lovr POST_BUILD
+    DEPENDS "etc/nogame"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/etc/nogame"
+    COMMAND ${CMAKE_COMMAND} -E tar c "${CMAKE_CURRENT_BINARY_DIR}/nogame.zip" --format=zip arg.lua conf.lua main.lua
+    COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_CURRENT_BINARY_DIR}/nogame.zip" >> ${NOGAME_BUNDLE}
+  )
+endif()
 
 # Add a custom target that is always out of date so libraries are always moved
 add_custom_target(move_files ALL)

--- a/Tupfile.lua
+++ b/Tupfile.lua
@@ -450,7 +450,7 @@ src += config.modules.math and 'src/lib/noise/*.c' or nil
 
 -- embed resource files with xxd
 
-res = { 'etc/boot.lua', 'etc/nogame.lua', 'etc/*.ttf', 'etc/shaders/*.glsl' }
+res = { 'etc/boot.lua', 'etc/*.ttf', 'etc/shaders/*.glsl' }
 tup.foreach_rule(res, '^ XD %b^ xxd -i %f > %o', '%f.h')
 
 for i, pattern in ipairs(res) do

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -289,10 +289,17 @@ lovr.handlers = setmetatable({}, { __index = lovr })
 return coroutine.create(function()
   local function onerror(...)
     onerror = function(...)
-      print('Error:\n\n' .. tostring(...) .. formatTraceback(debug.traceback('', 3)))
+      print('Error:\n\n' .. tostring(...) .. formatTraceback(debug.traceback('', 1)))
       return function() return 1 end
     end
-    return lovr.errhand(...) or function() return 1 end
+
+    local ok, result = pcall(lovr.errhand or onerror, ...)
+
+    if ok then
+      return result or function() return 1 end
+    else
+      return onerror(result)
+    end
   end
 
   local thread = select(2, xpcall(lovr.boot, onerror))

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -1,57 +1,56 @@
 lovr = require 'lovr'
 local lovr = lovr
 
--- Note: Cannot be overloaded
-function lovr.boot()
-  local conf = {
-    version = '0.17.0',
-    identity = 'default',
-    saveprecedence = true,
-    modules = {
-      audio = true,
-      data = true,
-      event = true,
-      graphics = true,
-      headset = true,
-      math = true,
-      physics = true,
-      system = true,
-      thread = true,
-      timer = true
-    },
-    audio = {
-      start = true,
-      spatializer = nil
-    },
-    graphics = {
-      debug = false,
-      vsync = true,
-      stencil = false,
-      antialias = true,
-      shadercache = true
-    },
-    headset = {
-      drivers = { 'openxr', 'webxr', 'desktop' },
-      supersample = false,
-      seated = false,
-      stencil = false,
-      antialias = true,
-      submitdepth = true,
-      overlay = false
-    },
-    math = {
-      globals = true
-    },
-    window = {
-      width = 720,
-      height = 800,
-      fullscreen = false,
-      resizable = false,
-      title = 'LÖVR',
-      icon = nil
-    }
+local conf = {
+  version = '0.17.0',
+  identity = 'default',
+  saveprecedence = true,
+  modules = {
+    audio = true,
+    data = true,
+    event = true,
+    graphics = true,
+    headset = true,
+    math = true,
+    physics = true,
+    system = true,
+    thread = true,
+    timer = true
+  },
+  audio = {
+    start = true,
+    spatializer = nil
+  },
+  graphics = {
+    debug = false,
+    vsync = true,
+    stencil = false,
+    antialias = true,
+    shadercache = true
+  },
+  headset = {
+    drivers = { 'openxr', 'webxr', 'desktop' },
+    supersample = false,
+    seated = false,
+    stencil = false,
+    antialias = true,
+    submitdepth = true,
+    overlay = false
+  },
+  math = {
+    globals = true
+  },
+  window = {
+    width = 720,
+    height = 800,
+    fullscreen = false,
+    resizable = false,
+    title = 'LÖVR',
+    icon = nil
   }
+}
 
+function lovr.boot()
   lovr.filesystem = require('lovr.filesystem')
   local main = arg[0] and arg[0]:match('[^\\/]-%.lua$') or 'main.lua'
   local hasConf, hasMain = lovr.filesystem.isFile('conf.lua'), lovr.filesystem.isFile(main)
@@ -233,7 +232,7 @@ function lovr.log(message, level, tag)
   print(message)
 end
 
-return function()
+return coroutine.create(function()
   local errored = false
 
   local function onerror(...)
@@ -266,4 +265,4 @@ return function()
 
     coroutine.yield()
   end
-end
+end)

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -1,4 +1,5 @@
 lovr = require 'lovr'
+local lovr = lovr
 
 -- Note: Cannot be overloaded
 function lovr.boot()

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -81,8 +81,8 @@ function lovr.boot()
   -- Figure out source archive and main module.  CLI places source at arg[0]
 
   local source, main
-  if cli or not fused then
-    if arg[0] and arg[0]:match('[^/\\]+%.lua$') then
+  if (cli or not fused) and arg[0] then
+    if arg[0]:match('[^/\\]+%.lua$') then
       source = arg[0]:match('[/\\]') and arg[0]:match('(.+)[/\\][^/\\]+$') or '.'
       main = arg[0]:match('[^/\\]+%.lua$')
     else

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -216,7 +216,9 @@ function lovr.errhand(message)
         local font = lovr.graphics.getDefaultFont()
         local wrap = .7 * font:getPixelDensity()
         local lines = font:getLines(message, wrap)
-        local width = math.min(font:getWidth(message), wrap) * scale
+        local maxWidth = 0
+        for i, line in ipairs(lines) do maxWidth = math.max(maxWidth, font:getWidth(line)) end
+        local width = maxWidth * scale
         local height = .8 + #lines * font:getHeight() * scale
         local x = -width / 2
         local y = math.min(height / 2, 10)
@@ -234,12 +236,15 @@ function lovr.errhand(message)
       local pass = lovr.graphics.getWindowPass()
       if pass then
         local w, h = lovr.system.getWindowDimensions()
-        pass:setProjection(1, lovr.math.mat4():orthographic(0, w, 0, h, -1, 1))
+        pass:setProjection(1, lovr.math.mat4():orthographic(w, h))
         font:setPixelDensity(1)
 
         local scale = .6
         local wrap = w * .8 / scale
-        local width = math.min(font:getWidth(message), wrap) * scale
+        local lines = font:getLines(message, wrap)
+        local maxWidth = 0
+        for i, line in ipairs(lines) do maxWidth = math.max(maxWidth, font:getWidth(line)) end
+        local width = maxWidth * scale
         local x = w / 2 - width / 2
 
         pass:setColor(.95, .95, .95)

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -98,10 +98,10 @@ function lovr.boot()
 
   local ok, failure = true, nil
   if source ~= bundle and not lovr.filesystem.mount(source) then
-    failure = ('Failed to load project at %q\nMake sure the path or archive is valid.'):format(source)
+    ok, failure = false, ('Failed to load project at %q\nMake sure the path or archive is valid.'):format(source)
   elseif not lovr.filesystem.isFile(main) then
     local location = source == '.' and '' or (' in %q'):format(source:match('[^/\\]+[/\\]?$'))
-    failure = ('No %s file found%s.\nThe project may be packaged incorrectly.'):format(main, location)
+    ok, failure = false, ('No %s file found%s.\nThe project may be packaged incorrectly.'):format(main, location)
   else
     lovr.filesystem.setSource(source)
     if lovr.filesystem.isFile('conf.lua') then ok, failure = pcall(require, 'conf') end
@@ -140,7 +140,7 @@ function lovr.boot()
     lovr.headset.start()
   end
 
-  if failure then
+  if not ok and failure then
     error(failure)
   end
 

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -52,6 +52,22 @@ local conf = {
 
 function lovr.boot()
   lovr.filesystem = require('lovr.filesystem')
+
+  local bundle, root = lovr.filesystem.getBundlePath()
+  if lovr.filesystem.mount(bundle, nil, true, root) then
+    lovr.filesystem.setSource(bundle)
+  elseif arg[0] then
+    local source = arg[0]
+
+    if arg[0]:match('%.lua$') then
+      source = arg[0]:match('[/\\]') and arg[0]:gsub('[/\\][^/\\]+$', '') or '.'
+    end
+
+    if lovr.filesystem.mount(source) then
+      lovr.filesystem.setSource(source)
+    end
+  end
+
   local main = arg[0] and arg[0]:match('[^\\/]-%.lua$') or 'main.lua'
   local hasConf, hasMain = lovr.filesystem.isFile('conf.lua'), lovr.filesystem.isFile(main)
   if not lovr.filesystem.getSource() or not (hasConf or hasMain) then require('nogame') end

--- a/etc/nogame/arg.lua
+++ b/etc/nogame/arg.lua
@@ -1,0 +1,66 @@
+function lovr.arg(arg)
+  local options = {
+    _help = { short = '-h', long = '--help', help = 'Show help and exit' },
+    _version = { short = '-v', long = '--version', help = 'Show version and exit' },
+    debug = { long = '--debug', help = 'Enable debugging checks and logging' }
+  }
+
+  local shift
+
+  for i, argument in ipairs(arg) do
+    if argument:match('^%-') then
+      for name, option in pairs(options) do
+        if argument == option.short or argument == option.long then
+          arg[name] = true
+          break
+        end
+      end
+    else
+      shift = i
+      break
+    end
+  end
+
+  shift = shift or (#arg + 1)
+
+  for i = 0, #arg do
+    arg[i - shift], arg[i] = arg[i], nil
+  end
+
+  if arg._help then
+    local message = {}
+
+    local list = {}
+    for name, option in pairs(options) do
+      option.name = name
+      table.insert(list, option)
+    end
+
+    table.sort(list, function(a, b) return a.name < b.name end)
+
+    for i, option in ipairs(list) do
+      if option.short and option.long then
+        table.insert(message, ('  %s, %s\t\t%s'):format(option.short, option.long, option.help))
+      else
+        table.insert(message, ('  %s\t\t%s'):format(option.long or option.short, option.help))
+      end
+    end
+
+    table.insert(message, 1, 'usage: lovr [options] [<source>]\n')
+    table.insert(message, 2, 'options:')
+    table.insert(message, '\n<source> can be a Lua file, a folder, or a zip archive')
+    print(table.concat(message, '\n'))
+    os.exit(0)
+  end
+
+  if arg._version then
+    print(('LOVR %d.%d.%d'):format(lovr.getVersion()))
+    os.exit(0)
+  end
+
+  return function(conf)
+    if arg.debug then
+      conf.graphics.debug = true
+    end
+  end
+end

--- a/etc/nogame/conf.lua
+++ b/etc/nogame/conf.lua
@@ -1,0 +1,6 @@
+function lovr.conf(t)
+  t.headset.supersample = true
+  t.modules.audio = false
+  t.modules.physics = false
+  t.modules.thread = false
+end

--- a/etc/nogame/conf.lua
+++ b/etc/nogame/conf.lua
@@ -1,3 +1,7 @@
+if lovr.filesystem.getRealDirectory('main.lua') ~= lovr.filesystem.getExecutablePath() then
+  return -- Only run this conf file if bundled with the executable
+end
+
 function lovr.conf(t)
   t.headset.supersample = true
   t.modules.audio = false

--- a/etc/nogame/main.lua
+++ b/etc/nogame/main.lua
@@ -1,10 +1,3 @@
-function lovr.conf(t)
-  t.headset.supersample = true
-  t.modules.audio = false
-  t.modules.physics = false
-  t.modules.thread = false
-end
-
 function lovr.load()
   if not lovr.graphics then
     print(string.format('LÖVR %d.%d.%d\nNo game', lovr.getVersion()))

--- a/src/api/l_filesystem.c
+++ b/src/api/l_filesystem.c
@@ -592,18 +592,7 @@ int luaopen_lovr_filesystem(lua_State* L) {
   luax_registerloader(L, luaLoader, 2);
   luax_registerloader(L, libLoader, 3);
   luax_registerloader(L, libLoaderAllInOne, 4);
-
-  const char* archive = NULL;
-
-  lua_getglobal(L, "arg");
-  if (lua_istable(L, -1)) {
-    lua_rawgeti(L, -1, 0);
-    archive = lua_tostring(L, -1);
-    lua_pop(L, 1);
-  }
-  lua_pop(L, 1);
-
-  lovrFilesystemInit(archive);
+  lovrFilesystemInit();
   luax_atexit(L, lovrFilesystemDestroy);
   return 1;
 }

--- a/src/api/l_filesystem.c
+++ b/src/api/l_filesystem.c
@@ -149,6 +149,21 @@ static int l_lovrFilesystemGetDirectoryItems(lua_State* L) {
   return 1;
 }
 
+static int l_lovrFilesystemGetBundlePath(lua_State* L) {
+  char buffer[LOVR_PATH_MAX];
+  const char* root;
+
+  if (lovrFilesystemGetBundlePath(buffer, sizeof(buffer), &root)) {
+    lua_pushstring(L, buffer);
+    lua_pushstring(L, root);
+  } else {
+    lua_pushnil(L);
+    lua_pushnil(L);
+  }
+
+  return 2;
+}
+
 static int l_lovrFilesystemGetExecutablePath(lua_State* L) {
   char buffer[LOVR_PATH_MAX];
 
@@ -366,6 +381,7 @@ static const luaL_Reg lovrFilesystem[] = {
   { "append", l_lovrFilesystemAppend },
   { "createDirectory", l_lovrFilesystemCreateDirectory },
   { "getAppdataDirectory", l_lovrFilesystemGetAppdataDirectory },
+  { "getBundlePath", l_lovrFilesystemGetBundlePath },
   { "getDirectoryItems", l_lovrFilesystemGetDirectoryItems },
   { "getExecutablePath", l_lovrFilesystemGetExecutablePath },
   { "getIdentity", l_lovrFilesystemGetIdentity },

--- a/src/api/l_filesystem.c
+++ b/src/api/l_filesystem.c
@@ -450,8 +450,10 @@ extern void* os_get_java_vm();
 static int libLoaderCommon(lua_State* L, bool allInOneFlag) {
 #ifdef _WIN32
   const char* extension = ".dll";
+  const char sep = '\\';
 #else
   const char* extension = ".so";
+  const char sep = '/';
 #endif
 
   const char* module = lua_tostring(L, 1);
@@ -484,14 +486,14 @@ static int libLoaderCommon(lua_State* L, bool allInOneFlag) {
     return 0;
   }
 
-  char* slash = strrchr(path, LOVR_PATH_SEP);
+  char* slash = strrchr(path, sep);
   char* p = slash ? slash + 1 : path;
   length = p - path;
 #endif
 
   for (const char* m = module; *m && length < sizeof(path); m++, length++) {
     if (allInOneFlag && *m == '.') break;
-    *p++ = *m == '.' ? LOVR_PATH_SEP : *m;
+    *p++ = *m == '.' ? sep : *m;
   }
 
   for (const char* e = extension; *e && length < sizeof(path); e++, length++) {

--- a/src/api/l_filesystem.c
+++ b/src/api/l_filesystem.c
@@ -337,6 +337,12 @@ static int l_lovrFilesystemSetRequirePath(lua_State* L) {
   return 0;
 }
 
+static int l_lovrFilesystemSetSource(lua_State* L) {
+  const char* source = luaL_checkstring(L, 1);
+  lovrFilesystemSetSource(source);
+  return 0;
+}
+
 static int l_lovrFilesystemUnmount(lua_State* L) {
   const char* path = luaL_checkstring(L, 1);
   lua_pushboolean(L, lovrFilesystemUnmount(path));
@@ -401,8 +407,9 @@ static const luaL_Reg lovrFilesystem[] = {
   { "newBlob", l_lovrFilesystemNewBlob },
   { "read", l_lovrFilesystemRead },
   { "remove", l_lovrFilesystemRemove },
-  { "setRequirePath", l_lovrFilesystemSetRequirePath },
   { "setIdentity", l_lovrFilesystemSetIdentity },
+  { "setRequirePath", l_lovrFilesystemSetRequirePath },
+  { "setSource", l_lovrFilesystemSetSource },
   { "unmount", l_lovrFilesystemUnmount },
   { "write", l_lovrFilesystemWrite },
   { "newFile", l_lovrFilesystemNewFile },

--- a/src/api/l_lovr.c
+++ b/src/api/l_lovr.c
@@ -5,7 +5,8 @@ static int l_lovrGetVersion(lua_State* L) {
   lua_pushinteger(L, LOVR_VERSION_MAJOR);
   lua_pushinteger(L, LOVR_VERSION_MINOR);
   lua_pushinteger(L, LOVR_VERSION_PATCH);
-  return 3;
+  lua_pushliteral(L, LOVR_VERSION_ALIAS);
+  return 4;
 }
 
 static const luaL_Reg lovr[] = {

--- a/src/core/os_macos.c
+++ b/src/core/os_macos.c
@@ -177,7 +177,8 @@ size_t os_get_bundle_path(char* buffer, size_t size, const char** root) {
   id bundle = msg(id, cls(NSBundle), "mainBundle");
   id path = msg2(id, bundle, "pathForResource:ofType:", id, nil, id, extension);
   if (path == nil) {
-    return 0;
+    *root = NULL;
+    return os_get_executable_path(buffer, size);
   }
 
   const char* cpath = msg(const char*, path, "UTF8String");

--- a/src/main.c
+++ b/src/main.c
@@ -111,10 +111,7 @@ int main(int argc, char** argv) {
       return 1;
     }
 
-    lua_State* T = lua_newthread(L);
-    lua_pushvalue(L, -2);
-    lua_xmove(L, T, 1);
-
+    lua_State* T = lua_tothread(L, -1);
     lovrSetErrorCallback(luax_vthrow, T);
     lovrSetLogCallback(luax_vlog, T);
 

--- a/src/main.c
+++ b/src/main.c
@@ -3,7 +3,6 @@
 #include "core/os.h"
 #include "util.h"
 #include "boot.lua.h"
-#include "nogame.lua.h"
 #include <lua.h>
 #include <lauxlib.h>
 #include <lualib.h>
@@ -11,103 +10,29 @@
 #include <string.h>
 #include <stdlib.h>
 
-#ifdef EMSCRIPTEN
-#include <emscripten.h>
-
-typedef struct {
-  lua_State* L;
-  lua_State* T;
-  int argc;
-  char** argv;
-} lovrEmscriptenContext;
-
-static void emscriptenLoop(void*);
-#endif
-
-static Variant cookie;
-
-static int luaopen_lovr_nogame(lua_State* L) {
-  if (!luaL_loadbuffer(L, (const char*) etc_nogame_lua, etc_nogame_lua_len, "@nogame.lua")) {
-    lua_call(L, 0, 1);
-  }
-
-  return 1;
-}
-
 int main(int argc, char** argv) {
-  if (argc > 1 && (!strcmp(argv[1], "--version") || !strcmp(argv[1], "-v"))) {
-    os_open_console();
-    printf("LOVR %d.%d.%d (%s)\n", LOVR_VERSION_MAJOR, LOVR_VERSION_MINOR, LOVR_VERSION_PATCH, LOVR_VERSION_ALIAS);
-    exit(0);
-  }
+  os_init();
 
-  if (argc > 1 && (!strcmp(argv[1], "--help") || !strcmp(argv[1], "-h"))) {
-    os_open_console();
-    printf(
-      "usage: lovr [options] [<source>]\n\n"
-      "options:\n"
-      "  -h, --help\t\tShow help and exit\n"
-      "  -v, --version\t\tShow version and exit\n"
-      "  --console\t\tAttach Windows console\n"
-      "  --graphics-debug\tEnable graphics debug messages\n\n"
-      "<source> can be a Lua file, a folder, or a zip archive\n"
-    );
-    exit(0);
-  }
-
-  if (!os_init()) {
-    fprintf(stderr, "Failed to initialize platform");
-    exit(1);
-  }
-
-  int status;
-  bool restart;
-
-  do {
+  for (;;) {
     lua_State* L = luaL_newstate();
     luax_setmainthread(L);
     luaL_openlibs(L);
     luax_preload(L);
 
-    const luaL_Reg nogame[] = {
-      { "nogame", luaopen_lovr_nogame },
-      { NULL, NULL }
-    };
-
-    lua_getglobal(L, "package");
-    lua_getfield(L, -1, "preload");
-    luax_register(L, nogame);
-    lua_pop(L, 2);
-
-    // arg table
     lua_newtable(L);
-    lua_pushstring(L, argc > 0 ? argv[0] : "lovr");
-    lua_setfield(L, -2, "exe");
+    static Variant cookie;
     luax_pushvariant(L, &cookie);
     lua_setfield(L, -2, "restart");
-
-    int argOffset = 1;
-    for (int i = 1; i < argc; i++, argOffset++) {
-      if (!strcmp(argv[i], "--console")) {
-        os_open_console();
-      } else if (!strcmp(argv[i], "--graphics-debug")) {
-        lua_pushboolean(L, true);
-        lua_setfield(L, -2, "--graphics-debug");
-      } else {
-        break; // This is the project path
-      }
-    }
-
-    // Now that we know the negative offset to start at, copy all args in the table
     for (int i = 0; i < argc; i++) {
       lua_pushstring(L, argv[i]);
-      lua_rawseti(L, -2, -argOffset + i);
+      lua_rawseti(L, -2, i);
     }
     lua_setglobal(L, "arg");
 
     lua_pushcfunction(L, luax_getstack);
     if (luaL_loadbuffer(L, (const char*) etc_boot_lua, etc_boot_lua_len, "@boot.lua") || lua_pcall(L, 0, 1, -2)) {
       fprintf(stderr, "%s\n", lua_tostring(L, -1));
+      os_destroy();
       return 1;
     }
 
@@ -115,65 +40,20 @@ int main(int argc, char** argv) {
     lovrSetErrorCallback(luax_vthrow, T);
     lovrSetLogCallback(luax_vlog, T);
 
-#ifdef EMSCRIPTEN
-    lovrEmscriptenContext context = { L, T, argc, argv };
-    emscripten_set_main_loop_arg(emscriptenLoop, (void*) &context, 0, 1);
-    return 0;
-#endif
-
     while (luax_resume(T, 0) == LUA_YIELD) {
       os_sleep(0.);
     }
 
-    restart = lua_type(T, 1) == LUA_TSTRING && !strcmp(lua_tostring(T, 1), "restart");
-    status = lua_tonumber(T, 1);
-    luax_checkvariant(T, 2, &cookie);
-    if (cookie.type == TYPE_OBJECT) {
-      cookie.type = TYPE_NIL;
-      memset(&cookie.value, 0, sizeof(cookie.value));
-    }
-    lua_close(L);
-  } while (restart);
-
-  os_destroy();
-
-  return status;
-}
-
-#ifdef EMSCRIPTEN
-// Called by JS, don't delete
-void lovrDestroy(void* arg) {
-  if (arg) {
-    lovrEmscriptenContext* context = arg;
-    lua_State* L = context->L;
-    emscripten_cancel_main_loop();
-    lua_close(L);
-    os_destroy();
-  }
-}
-
-static void emscriptenLoop(void* arg) {
-  lovrEmscriptenContext* context = arg;
-  lua_State* T = context->T;
-
-  if (luax_resume(T, 0) != LUA_YIELD) {
-    bool restart = lua_type(T, 1) == LUA_TSTRING && !strcmp(lua_tostring(T, 1), "restart");
-    int status = lua_tonumber(T, 1);
-    luax_checkvariant(T, 2, &cookie);
-    if (cookie.type == TYPE_OBJECT) {
-      cookie.type = TYPE_NIL;
-      memset(&cookie.value, 0, sizeof(cookie.value));
-    }
-
-    lua_close(context->L);
-    emscripten_cancel_main_loop();
-
-    if (restart) {
-      main(context->argc, context->argv);
+    if (lua_type(T, 1) == LUA_TSTRING && !strcmp(lua_tostring(T, 1), "restart")) {
+      luax_checkvariant(T, 2, &cookie);
+      if (cookie.type == TYPE_OBJECT) memset(&cookie, 0, sizeof(cookie));
+      lua_close(L);
+      continue;
     } else {
+      int status = lua_tointeger(T, 1);
+      lua_close(L);
       os_destroy();
-      exit(status);
+      return status;
     }
   }
 }
-#endif

--- a/src/modules/filesystem/filesystem.c
+++ b/src/modules/filesystem/filesystem.c
@@ -213,6 +213,14 @@ void lovrFilesystemDestroy(void) {
   memset(&state, 0, sizeof(state));
 }
 
+void lovrFilesystemSetSource(const char* source) {
+  lovrAssert(!state.source[0], "Source is already set!");
+  size_t length = strlen(source);
+  lovrAssert(sizeof(state.source) > length, "Source is too long!");
+  memcpy(state.source, source, length);
+  state.source[length] = '\0';
+}
+
 const char* lovrFilesystemGetSource(void) {
   return state.source;
 }

--- a/src/modules/filesystem/filesystem.c
+++ b/src/modules/filesystem/filesystem.c
@@ -479,6 +479,10 @@ size_t lovrFilesystemGetAppdataDirectory(char* buffer, size_t size) {
   return os_get_data_directory(buffer, size);
 }
 
+size_t lovrFilesystemGetBundlePath(char* buffer, size_t size, const char** root) {
+  return os_get_bundle_path(buffer, size, root);
+}
+
 size_t lovrFilesystemGetExecutablePath(char* buffer, size_t size) {
   return os_get_executable_path(buffer, size);
 }

--- a/src/modules/filesystem/filesystem.c
+++ b/src/modules/filesystem/filesystem.c
@@ -8,6 +8,12 @@
 #include <stdlib.h>
 #include <time.h>
 
+#ifdef _WIN32
+#define SLASH '\\'
+#else
+#define SLASH '/'
+#endif
+
 #define FOREACH_ARCHIVE(a) for (Archive* a = state.archives; a; a = a->next)
 
 typedef struct {
@@ -391,14 +397,14 @@ bool lovrFilesystemSetIdentity(const char* identity, bool precedence) {
   }
 
   // Append /LOVR, mkdir
-  state.savePath[cursor++] = LOVR_PATH_SEP;
+  state.savePath[cursor++] = SLASH;
   memcpy(state.savePath + cursor, "LOVR", strlen("LOVR"));
   cursor += strlen("LOVR");
   state.savePath[cursor] = '\0';
   fs_mkdir(state.savePath);
 
   // Append /<identity>, mkdir
-  state.savePath[cursor++] = LOVR_PATH_SEP;
+  state.savePath[cursor++] = SLASH;
   memcpy(state.savePath + cursor, identity, length);
   cursor += length;
   state.savePath[cursor] = '\0';

--- a/src/modules/filesystem/filesystem.h
+++ b/src/modules/filesystem/filesystem.h
@@ -9,7 +9,7 @@
 typedef struct Archive Archive;
 typedef struct File File;
 
-bool lovrFilesystemInit(const char* archive);
+bool lovrFilesystemInit(void);
 void lovrFilesystemDestroy(void);
 void lovrFilesystemSetSource(const char* source);
 const char* lovrFilesystemGetSource(void);

--- a/src/modules/filesystem/filesystem.h
+++ b/src/modules/filesystem/filesystem.h
@@ -6,12 +6,6 @@
 
 #define LOVR_PATH_MAX 1024
 
-#ifdef _WIN32
-#define LOVR_PATH_SEP '\\'
-#else
-#define LOVR_PATH_SEP '/'
-#endif
-
 typedef struct Archive Archive;
 typedef struct File File;
 

--- a/src/modules/filesystem/filesystem.h
+++ b/src/modules/filesystem/filesystem.h
@@ -11,6 +11,7 @@ typedef struct File File;
 
 bool lovrFilesystemInit(const char* archive);
 void lovrFilesystemDestroy(void);
+void lovrFilesystemSetSource(const char* source);
 const char* lovrFilesystemGetSource(void);
 bool lovrFilesystemIsFused(void);
 bool lovrFilesystemMount(const char* path, const char* mountpoint, bool append, const char *root);

--- a/src/modules/filesystem/filesystem.h
+++ b/src/modules/filesystem/filesystem.h
@@ -29,6 +29,7 @@ bool lovrFilesystemCreateDirectory(const char* path);
 bool lovrFilesystemRemove(const char* path);
 bool lovrFilesystemWrite(const char* path, const char* content, size_t size, bool append);
 size_t lovrFilesystemGetAppdataDirectory(char* buffer, size_t size);
+size_t lovrFilesystemGetBundlePath(char* buffer, size_t size, const char** root);
 size_t lovrFilesystemGetExecutablePath(char* buffer, size_t size);
 size_t lovrFilesystemGetUserDirectory(char* buffer, size_t size);
 size_t lovrFilesystemGetWorkingDirectory(char* buffer, size_t size);


### PR DESCRIPTION
This is a complete overhaul of the startup process for LÖVR!  Some of the build system stuff isn't finished yet, but in the meantime I'm gonna write about it here since the design is somewhat stable.

The key points are:

- The nogame screen is distributed as a fused zip instead of being embedded in the C code.
- All CLI behavior is moved into a new file, `arg.lua`.  This is also in the fused zip.  It handles all argument parsing, including finding the project passed in on the command line, --help/--version, etc.

The impact of these changes are:

- The nogame screen and argument handling can be removed entirely when creating a fused project.  This makes projects a little bit smaller and allows the nogame screen and CLI to be as big as they want without bloating every shipped app.
- Fused projects will no longer respond to lovr's development CLI arguments.  It wasn't a *huge* deal, but it always kinda bothered me that you could do `game.exe --help` and see a weird message about lovr.
- Because LÖVR will always be a zip, and that zip will always be mounted, you can do some interesting things:
  - You can edit the nogame screen.
  - You can add your own CLI behavior, and it will work for every app.
  - You can add libraries to the zip and use them in any project (!)