### PR TITLE
Bound check the number of sphere segments

### DIFF
--- a/src/api/l_graphics_pass.c
+++ b/src/api/l_graphics_pass.c
@@ -869,6 +869,7 @@ static int l_lovrPassSphere(lua_State* L) {
   int index = luax_readmat4(L, 2, transform, 1);
   uint32_t segmentsH = luax_optu32(L, index++, 48);
   uint32_t segmentsV = luax_optu32(L, index++, segmentsH / 2);
+  lovrAssert(segmentsH >= 2 && segmentsV >= 2, "Number of longitudes and latitudes must be >= 2");
   lovrPassSphere(pass, transform, segmentsH, segmentsV);
   return 0;
 }


### PR DESCRIPTION
If the supplied argument is <2, the lovr either shows out-of-memory error or just freezes.