### PR TITLE
Support table vector

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -579,7 +579,8 @@ int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCou
 }
 
 void luax_readobjarr(lua_State* L, int index, int n, float* out, const char* name) {
-  lovrCheck(lua_objlen(L, index) >= n, "length of %s table must >= %i", name, n);
+  lovrCheck(luax_len(L, index) >= n, "length of %s table must >= %i", name, n);
+  if (index < 0) index = lua_gettop(L) + index + 1;
   for (int i = 0; i < n; i++) {
     lua_rawgeti(L, index, i + 1);
     out[i] = lua_tonumber(L, -1);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -577,3 +577,12 @@ int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCou
 
   return luaL_argerror(L, index, "table, Mesh, or Model");
 }
+
+void luax_readobjarr(lua_State* L, int index, int n, float* out, const char* name) {
+  lovrCheck(lua_objlen(L, index) >= n, "length of %s table must >= %i", name, n);
+  for (int i = 0; i < n; i++) {
+    lua_rawgeti(L, index, i + 1);
+    out[i] = lua_tonumber(L, -1);
+  }
+  lua_pop(L, n);
+}

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -180,6 +180,7 @@ struct ColoredString* luax_checkcoloredstrings(lua_State* L, int index, uint32_t
 float* luax_tovector(lua_State* L, int index, VectorType* type);
 float* luax_checkvector(lua_State* L, int index, VectorType type, const char* expected);
 float* luax_newtempvector(lua_State* L, VectorType type);
+inline void luax_readobjarr(lua_State* L, int index, size_t n, float* out, const char* name);
 int luax_readvec2(lua_State* L, int index, float* v, const char* expected);
 int luax_readvec3(lua_State* L, int index, float* v, const char* expected);
 int luax_readvec4(lua_State* L, int index, float* v, const char* expected);

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -129,6 +129,7 @@ uint32_t _luax_optu32(lua_State* L, int index, uint32_t fallback);
 void luax_readcolor(lua_State* L, int index, float color[4]);
 void luax_optcolor(lua_State* L, int index, float color[4]);
 int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCount, uint32_t** indices, uint32_t* indexCount, bool* shouldFree);
+void luax_readobjarr(lua_State* L, int index, int n, float* out, const char* name);
 
 // Module helpers
 
@@ -180,7 +181,6 @@ struct ColoredString* luax_checkcoloredstrings(lua_State* L, int index, uint32_t
 float* luax_tovector(lua_State* L, int index, VectorType* type);
 float* luax_checkvector(lua_State* L, int index, VectorType type, const char* expected);
 float* luax_newtempvector(lua_State* L, VectorType type);
-inline void luax_readobjarr(lua_State* L, int index, size_t n, float* out, const char* name);
 int luax_readvec2(lua_State* L, int index, float* v, const char* expected);
 int luax_readvec3(lua_State* L, int index, float* v, const char* expected);
 int luax_readvec4(lua_State* L, int index, float* v, const char* expected);

--- a/src/api/l_graphics_buffer.c
+++ b/src/api/l_graphics_buffer.c
@@ -248,6 +248,8 @@ void luax_checkdatatuples(lua_State* L, int index, int start, uint32_t count, co
       const DataField* field = &format->fields[f];
       if (lua_isuserdata(L, -1)) {
         luax_checkfieldv(L, -1, field->type, data + field->offset);
+      } else if (lua_istable(L, -1)) {
+        luax_checkfieldt(L, -1, field->type, data + field->offset);
       } else {
         while (n < (int) typeComponents[field->type]) {
           lua_rawgeti(L, -n - 1, subindex + n);

--- a/src/api/l_math_vectors.c
+++ b/src/api/l_math_vectors.c
@@ -142,18 +142,18 @@ int luax_readscale(lua_State* L, int index, vec3 v, int components, const char* 
 }
 
 int luax_readquat(lua_State* L, int index, quat q, const char* expected) {
-  float v[4];
+  float angle, ax, ay, az;
   switch (lua_type(L, index)) {
     case LUA_TNIL:
     case LUA_TNONE:
       quat_identity(q);
       return ++index;
     case LUA_TNUMBER:
-      v[0] = luax_optfloat(L, index++, 0.f);
-      v[1] = luax_optfloat(L, index++, 0.f);
-      v[2] = luax_optfloat(L, index++, 1.f);
-      v[3] = luax_optfloat(L, index++, 0.f);
-      quat_fromAngleAxis(q, v[0], v[1], v[2], v[3]);
+      angle = luax_optfloat(L, index++, 0.f);
+      ax = luax_optfloat(L, index++, 0.f);
+      ay = luax_optfloat(L, index++, 1.f);
+      az = luax_optfloat(L, index++, 0.f);
+      quat_fromAngleAxis(q, angle, ax, ay, az);
       return index;
     case LUA_TTABLE:
       luax_readobjarr(L, index, 4, q, "quat");
@@ -185,8 +185,7 @@ int luax_readmat4(lua_State* L, int index, mat4 m, int scaleComponents) {
     case LUA_TTABLE:
       if (lua_type(L, index) == LUA_TTABLE && lua_objlen(L, index) >= 16) {
         luax_readobjarr(L, index, 16, m, "mat4");
-        index++;
-        return index;
+        return index + 1;
       }
       // Fall through
 

--- a/src/api/l_math_vectors.c
+++ b/src/api/l_math_vectors.c
@@ -183,7 +183,7 @@ int luax_readmat4(lua_State* L, int index, mat4 m, int scaleComponents) {
     } // Fall through
 
     case LUA_TTABLE:
-      if (lua_type(L, index) == LUA_TTABLE && lua_objlen(L, index) >= 16) {
+      if (lua_istable(L, index) && luax_len(L, index) >= 16) {
         luax_readobjarr(L, index, 16, m, "mat4");
         return index + 1;
       }

--- a/src/api/l_math_vectors.c
+++ b/src/api/l_math_vectors.c
@@ -42,15 +42,6 @@ static const uint32_t* swizzles[5] = {
 
 // Helpers
 
-inline void luax_readobjarr(lua_State* L, int index, size_t n, float* out, const char* name) {
-  lovrCheck(lua_objlen(L, index) >= n, "length of %s table must >= %i", name, n);
-  for (int i = 0; i < n; i++) {
-    lua_rawgeti(L, index, i + 1);
-    out[i] = lua_tonumber(L, -1);
-    lua_pop(L, 1);
-  }
-}
-
 int luax_readvec2(lua_State* L, int index, vec2 v, const char* expected) {
   switch (lua_type(L, index)) {
     case LUA_TNIL:
@@ -165,8 +156,7 @@ int luax_readquat(lua_State* L, int index, quat q, const char* expected) {
       quat_fromAngleAxis(q, v[0], v[1], v[2], v[3]);
       return index;
     case LUA_TTABLE:
-      luax_readobjarr(L, index, 4, v, "quat");
-      quat_init(q, v);
+      luax_readobjarr(L, index, 4, q, "quat");
       return index + 1;
     default:
       quat_init(q, luax_checkvector(L, index++, V_QUAT, expected ? expected : "quat or number"));

--- a/src/api/l_math_vectors.c
+++ b/src/api/l_math_vectors.c
@@ -44,7 +44,7 @@ static const uint32_t* swizzles[5] = {
 
 inline void luax_readobjarr(lua_State* L, int index, size_t n, float* out, const char* name) {
   lovrCheck(lua_objlen(L, index) >= n, "length of %s table must >= %i", name, n);
-  for (int i = 0; i < 4; i++) {
+  for (int i = 0; i < n; i++) {
     lua_rawgeti(L, index, i + 1);
     out[i] = lua_tonumber(L, -1);
     lua_pop(L, 1);
@@ -63,8 +63,7 @@ int luax_readvec2(lua_State* L, int index, vec2 v, const char* expected) {
       return index;
     case LUA_TTABLE:
       luax_readobjarr(L, index, 2, v, "vec2");
-      index++;
-      return index;
+      return index + 1;
     default:
       vec2_init(v, luax_checkvector(L, index, V_VEC2, expected ? expected : "vec2 or number"));
       return index + 1;
@@ -84,8 +83,7 @@ int luax_readvec3(lua_State* L, int index, vec3 v, const char* expected) {
       return index;
     case LUA_TTABLE:
       luax_readobjarr(L, index, 3, v, "vec3");
-      index++;
-      return index;
+      return index + 1;
     default:
       vec3_init(v, luax_checkvector(L, index, V_VEC3, expected ? expected : "vec3 or number"));
       return index + 1;
@@ -106,8 +104,7 @@ int luax_readvec4(lua_State* L, int index, vec4 v, const char* expected) {
       return index;
     case LUA_TTABLE:
       luax_readobjarr(L, index, 4, v, "vec4");
-      index++;
-      return index;
+      return index + 1;
     default:
       vec4_init(v, luax_checkvector(L, index, V_VEC4, expected ? expected : "vec4 or number"));
       return index + 1;
@@ -135,8 +132,7 @@ int luax_readscale(lua_State* L, int index, vec3 v, int components, const char* 
       return index;
     case LUA_TTABLE:
       luax_readobjarr(L, index, 3, v, "scale");
-      index++;
-      return index;
+      return index + 1;
     default: {
       VectorType type;
       float* u = luax_tovector(L, index++, &type);
@@ -172,8 +168,7 @@ int luax_readquat(lua_State* L, int index, quat q, const char* expected) {
       float v[4];
       luax_readobjarr(L, index, 4, v, "quat");
       quat_fromAngleAxis(q, v[0], v[1], v[2], v[3]);
-      index++;
-      return index;
+      return index + 1;
     default:
       quat_init(q, luax_checkvector(L, index++, V_QUAT, expected ? expected : "quat or number"));
       return index;

--- a/src/api/l_math_vectors.c
+++ b/src/api/l_math_vectors.c
@@ -103,6 +103,7 @@ int luax_readvec4(lua_State* L, int index, vec4 v, const char* expected) {
 }
 
 int luax_readscale(lua_State* L, int index, vec3 v, int components, const char* expected) {
+  int tlen;
   switch (lua_type(L, index)) {
     case LUA_TNIL:
     case LUA_TNONE:
@@ -122,7 +123,7 @@ int luax_readscale(lua_State* L, int index, vec3 v, int components, const char* 
       }
       return index;
     case LUA_TTABLE:
-      int tlen = luax_len(L, index);
+      tlen = luax_len(L, index);
       if (tlen >= 3) {
         luax_readobjarr(L, index, 3, v, "scale");
       } else if (tlen == 2) {

--- a/src/api/l_math_vectors.c
+++ b/src/api/l_math_vectors.c
@@ -122,7 +122,15 @@ int luax_readscale(lua_State* L, int index, vec3 v, int components, const char* 
       }
       return index;
     case LUA_TTABLE:
-      luax_readobjarr(L, index, components, v, "scale");
+      int tlen = luax_len(L, index);
+      if (tlen >= 3) {
+        luax_readobjarr(L, index, 3, v, "scale");
+      } else if (tlen == 2) {
+        luax_readobjarr(L, index, 2, v, "scale");
+        v[2] = 1.f;
+      } else {
+        return luax_typeerror(L, index, "table length must >= 2");
+      }
       return index + 1;
     default: {
       VectorType type;

--- a/src/api/l_math_vectors.c
+++ b/src/api/l_math_vectors.c
@@ -151,23 +151,22 @@ int luax_readscale(lua_State* L, int index, vec3 v, int components, const char* 
 }
 
 int luax_readquat(lua_State* L, int index, quat q, const char* expected) {
-  float angle, ax, ay, az;
+  float v[4];
   switch (lua_type(L, index)) {
     case LUA_TNIL:
     case LUA_TNONE:
       quat_identity(q);
       return ++index;
     case LUA_TNUMBER:
-      angle = luax_optfloat(L, index++, 0.f);
-      ax = luax_optfloat(L, index++, 0.f);
-      ay = luax_optfloat(L, index++, 1.f);
-      az = luax_optfloat(L, index++, 0.f);
-      quat_fromAngleAxis(q, angle, ax, ay, az);
+      v[0] = luax_optfloat(L, index++, 0.f);
+      v[1] = luax_optfloat(L, index++, 0.f);
+      v[2] = luax_optfloat(L, index++, 1.f);
+      v[3] = luax_optfloat(L, index++, 0.f);
+      quat_fromAngleAxis(q, v[0], v[1], v[2], v[3]);
       return index;
     case LUA_TTABLE:
-      float v[4];
       luax_readobjarr(L, index, 4, v, "quat");
-      quat_fromAngleAxis(q, v[0], v[1], v[2], v[3]);
+      quat_init(q, v);
       return index + 1;
     default:
       quat_init(q, luax_checkvector(L, index++, V_QUAT, expected ? expected : "quat or number"));

--- a/src/api/l_math_vectors.c
+++ b/src/api/l_math_vectors.c
@@ -56,7 +56,7 @@ int luax_readvec2(lua_State* L, int index, vec2 v, const char* expected) {
       luax_readobjarr(L, index, 2, v, "vec2");
       return index + 1;
     default:
-      vec2_init(v, luax_checkvector(L, index, V_VEC2, expected ? expected : "vec2 or number"));
+      vec2_init(v, luax_checkvector(L, index, V_VEC2, expected ? expected : "vec2, table or number"));
       return index + 1;
   }
 }
@@ -76,7 +76,7 @@ int luax_readvec3(lua_State* L, int index, vec3 v, const char* expected) {
       luax_readobjarr(L, index, 3, v, "vec3");
       return index + 1;
     default:
-      vec3_init(v, luax_checkvector(L, index, V_VEC3, expected ? expected : "vec3 or number"));
+      vec3_init(v, luax_checkvector(L, index, V_VEC3, expected ? expected : "vec3, table or number"));
       return index + 1;
   }
 }
@@ -97,7 +97,7 @@ int luax_readvec4(lua_State* L, int index, vec4 v, const char* expected) {
       luax_readobjarr(L, index, 4, v, "vec4");
       return index + 1;
     default:
-      vec4_init(v, luax_checkvector(L, index, V_VEC4, expected ? expected : "vec4 or number"));
+      vec4_init(v, luax_checkvector(L, index, V_VEC4, expected ? expected : "vec4, table or number"));
       return index + 1;
   }
 }
@@ -122,7 +122,7 @@ int luax_readscale(lua_State* L, int index, vec3 v, int components, const char* 
       }
       return index;
     case LUA_TTABLE:
-      luax_readobjarr(L, index, 3, v, "scale");
+      luax_readobjarr(L, index, components, v, "scale");
       return index + 1;
     default: {
       VectorType type;
@@ -134,7 +134,7 @@ int luax_readscale(lua_State* L, int index, vec3 v, int components, const char* 
       } else if (type == V_VEC3) {
         vec3_init(v, u);
       } else {
-        return luax_typeerror(L, index, "vec2, vec3, or number");
+        return luax_typeerror(L, index, "vec2, vec3, table or number");
       }
       return index;
     }
@@ -159,7 +159,7 @@ int luax_readquat(lua_State* L, int index, quat q, const char* expected) {
       luax_readobjarr(L, index, 4, q, "quat");
       return index + 1;
     default:
-      quat_init(q, luax_checkvector(L, index++, V_QUAT, expected ? expected : "quat or number"));
+      quat_init(q, luax_checkvector(L, index++, V_QUAT, expected ? expected : "quat, table or number"));
       return index;
   }
 }
@@ -193,7 +193,7 @@ int luax_readmat4(lua_State* L, int index, mat4 m, int scaleComponents) {
       float S[3];
       float R[4];
       mat4_identity(m);
-      index = luax_readvec3(L, index, m + 12, "mat4, vec3, or number");
+      index = luax_readvec3(L, index, m + 12, "mat4, vec3, table or number");
       index = luax_readscale(L, index, S, scaleComponents, NULL);
       index = luax_readquat(L, index, R, NULL);
       mat4_rotateQuat(m, R);


### PR DESCRIPTION
A simple test
https://gist.github.com/xiejiangzhi/856d3a8b97df84ddd7b85b700284a4e7

In this test, by simply drawing a 40K sphere, the FPS of lua table will be increased by 29% compared to using lovr vector.
Since there are basically no calculations, if there are more calculations, the gap will be larger.
While it would be faster to use numbers directly, using numeric arguments is too much. table will be faster and easier to use and expand