### PR TITLE
Remove Multisample Textures

### DIFF
--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -726,7 +726,6 @@ static int l_lovrGraphicsNewTexture(lua_State* L) {
     .format = FORMAT_RGBA8,
     .layers = 1,
     .mipmaps = ~0u,
-    .samples = 1,
     .usage = TEXTURE_SAMPLE,
     .srgb = true
   };
@@ -815,10 +814,6 @@ static int l_lovrGraphicsNewTexture(lua_State* L) {
       lua_getfield(L, index, "format");
       info.format = lua_isnil(L, -1) ? info.format : (uint32_t) luax_checkenum(L, -1, TextureFormat, NULL);
       lua_pop(L, 1);
-
-      lua_getfield(L, index, "samples");
-      info.samples = lua_isnil(L, -1) ? info.samples : luax_checku32(L, -1);
-      lua_pop(L, 1);
     }
 
     lua_getfield(L, index, "linear");
@@ -832,7 +827,7 @@ static int l_lovrGraphicsNewTexture(lua_State* L) {
     } else if (!lua_isnil(L, -1)) {
       info.mipmaps = lua_toboolean(L, -1) ? ~0u : 1;
     } else {
-      info.mipmaps = (info.samples > 1 || info.imageCount == 0 || !mipmappable) ? 1 : ~0u;
+      info.mipmaps = (info.imageCount == 0 || !mipmappable) ? 1 : ~0u;
     }
     lovrCheck(info.imageCount == 0 || info.mipmaps == 1 || mipmappable, "This texture format does not support blitting, which is required for mipmap generation");
     lua_pop(L, 1);
@@ -1092,7 +1087,6 @@ static Texture* luax_opttexture(lua_State* L, int index) {
     .height = lovrImageGetHeight(image, 0),
     .layers = 1,
     .mipmaps = ~0u,
-    .samples = 1,
     .usage = TEXTURE_SAMPLE,
     .srgb = lovrImageIsSRGB(image),
     .imageCount = 1,

--- a/src/api/l_graphics_texture.c
+++ b/src/api/l_graphics_texture.c
@@ -91,10 +91,8 @@ static int l_lovrTextureGetMipmapCount(lua_State* L) {
   return 1;
 }
 
-static int l_lovrTextureGetSampleCount(lua_State* L) {
-  Texture* texture = luax_checktype(L, 1, Texture);
-  const TextureInfo* info = lovrTextureGetInfo(texture);
-  lua_pushinteger(L, info->samples);
+static int l_lovrTextureGetSampleCount(lua_State* L) { // Deprecated
+  lua_pushinteger(L, 1);
   return 1;
 }
 
@@ -246,7 +244,7 @@ const luaL_Reg lovrTexture[] = {
   { "getLayerCount", l_lovrTextureGetLayerCount },
   { "getDimensions", l_lovrTextureGetDimensions },
   { "getMipmapCount", l_lovrTextureGetMipmapCount },
-  { "getSampleCount", l_lovrTextureGetSampleCount },
+  { "getSampleCount", l_lovrTextureGetSampleCount }, // Deprecated
   { "hasUsage", l_lovrTextureHasUsage },
   { "newReadback", l_lovrTextureNewReadback },
   { "getPixels", l_lovrTextureGetPixels },

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -449,7 +449,7 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
     .extent.depth = texture->layers ? 1 : info->size[2],
     .mipLevels = info->mipmaps,
     .arrayLayers = texture->layers ? texture->layers : 1,
-    .samples = info->samples,
+    .samples = info->samples ? info->samples : 1,
     .usage =
       (((info->usage & GPU_TEXTURE_RENDER) && texture->aspect == VK_IMAGE_ASPECT_COLOR_BIT) ? VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT : 0) |
       (((info->usage & GPU_TEXTURE_RENDER) && texture->aspect != VK_IMAGE_ASPECT_COLOR_BIT) ? VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT : 0) |

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -218,7 +218,6 @@ typedef struct {
   uint32_t height;
   uint32_t layers;
   uint32_t mipmaps;
-  uint32_t samples;
   uint32_t usage;
   bool srgb;
   bool xr;

--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -466,7 +466,6 @@ static void swapchain_init(Swapchain* swapchain, uint32_t width, uint32_t height
       .height = height,
       .layers = 1 << stereo,
       .mipmaps = 1,
-      .samples = 1,
       .usage = TEXTURE_RENDER | (depth ? 0 : TEXTURE_SAMPLE),
       .handle = (uintptr_t) images[i].image,
       .label = "OpenXR Swapchain",

--- a/src/modules/headset/headset_simulator.c
+++ b/src/modules/headset/headset_simulator.c
@@ -382,7 +382,6 @@ static Pass* simulator_getPass(void) {
       .height = height,
       .layers = 1,
       .mipmaps = 1,
-      .samples = 1,
       .usage = TEXTURE_RENDER | TEXTURE_SAMPLE,
     });
 


### PR DESCRIPTION
This removes multisampled textures.  Multisampled rendering via `Pass:setCanvas` still exists.

I think there are 2 good ways to solve #718:

- Remove multisample textures because LÖVR doesn't have the supporting APIs required to make them useful.
- Add the supporting APIs to make multisampled textures useful.

The "supporting APIs" are like:

- `Pass:setCanvas` lets you optionally provide a "resolve" texture for each canvas texture.
- `Pass:setCanvas` lets you optionally specify a "discard" option for each texture, which will discard its contents after rendering.
- Do some validation around binding multisampled textures to shader variables.

Adding that stuff to `Pass:setCanvas` would mean that you can do everything you'd wanna do with multisampled textures: do render passes with them, use them with `clear=false`, resolve them to single-sampled textures in the final render pass (and optionally save or discard the contents at that time), send them to shaders to do a custom resolve, etc. etc.

The drawbacks of doing this are:

- Any kind of multisampled texture that gets written out at the end of a render pass is very slow on mobile GPUs. 
 LÖVR would heavily discourage using these multisampled textures for anything that wants to run on Android GPUs.
- It complicates `Pass:setCanvas`.  Instead of a list of textures, it has to also take a table with `{ texture = t1, resolve = t2, discard = true }`.  Not insurmountable, but just a lot of complexity for a somewhat niche feature that is a bit of a performance footgun.

We can add the resolve/discard stuff at any time really, but until then removing the multisampled textures makes sense.

> Aside: Also, idk, having the option to store MSAA at all feels kinda broken.  You'd want to do something like subpasses/tile shaders/sample-rate shading if you were accessing samples, and maybe an API design incorporating that somehow would be a better direction?

---

There's another way to solve #718 where a Texture with samples > 1 actually stores 2 textures: the single-sampled one and the MSAA one.  It can be pretty convenient but after thinking about it for a while I don't think this is a good design.

- There is too much ambiguity around which texture handle you're talking about when you refer to the Texture object.
- LÖVR has to do too much magical texture usage tracking and render pass merging/discarding logic.  This tracking can't be perfect because LÖVR doesn't know how you're gonna use the texture in the future, so you either end up with a weird "temporary multisample" flag or LÖVR has to pessimize and store out the MSAA contents more than it should.