### PR TITLE
Fixed nogame.zip creatrion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,7 +663,7 @@ if(NOT ANDROID)
   add_custom_command(TARGET lovr POST_BUILD
     DEPENDS "etc/nogame"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/etc/nogame"
-    COMMAND ${CMAKE_COMMAND} -E tar c "${CMAKE_CURRENT_BINARY_DIR}/nogame.zip" --format=zip arg.lua conf.lua main.lua
+    COMMAND ${CMAKE_COMMAND} -E tar c "${CMAKE_CURRENT_BINARY_DIR}/nogame.zip" --format=zip .
     COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_CURRENT_BINARY_DIR}/nogame.zip" >> ${NOGAME_BUNDLE}
   )
 endif()


### PR DESCRIPTION
`logo.spv` wasn't packed in `nogame.zip`, therefore nogame is failed to start. Now all files (maybe, other files will be added in the future) in nogame folder are packed.
This affects only PC version.