### PR TITLE
Make lovrAssert act like a function

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -37,7 +37,7 @@
 typedef void errorFn(void*, const char*, va_list);
 void lovrSetErrorCallback(errorFn* callback, void* userdata);
 LOVR_NORETURN void lovrThrow(const char* format, ...);
-#define lovrAssert(c, ...) if (!(c)) { lovrThrow(__VA_ARGS__); }
+#define lovrAssert(c, ...) do { if (!(c)) { lovrThrow(__VA_ARGS__); } } while(0)
 #define lovrUnreachable() lovrThrow("Unreachable")
 
 #ifdef LOVR_UNCHECKED


### PR DESCRIPTION
`do {} while(0)` is the perfect way to make function-like macro act like a real function (require ;, encapsulate local variables)