### PR TITLE
Writable Archives

### DIFF
--- a/src/api/l_filesystem.c
+++ b/src/api/l_filesystem.c
@@ -5,6 +5,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+StringEntry lovrMountMode[] = {
+  [MOUNT_READ] = ENTRY("read"),
+  [MOUNT_READWRITE] = ENTRY("readwrite"),
+  { 0 }
+};
+
 StringEntry lovrOpenMode[] = {
   [OPEN_READ] = ENTRY("r"),
   [OPEN_WRITE] = ENTRY("w"),
@@ -289,9 +295,17 @@ static int l_lovrFilesystemLoad(lua_State* L) {
 static int l_lovrFilesystemMount(lua_State* L) {
   const char* path = luaL_checkstring(L, 1);
   const char* mountpoint = luaL_optstring(L, 2, NULL);
-  bool append = lua_toboolean(L, 3);
-  const char* root = luaL_optstring(L, 4, NULL);
-  lua_pushboolean(L, lovrFilesystemMount(path, mountpoint, append, root));
+  if (lua_type(L, 3) == LUA_TSTRING) {
+    MountMode mode = luax_checkenum(L, 3, MountMode, "read");
+    bool append = lua_toboolean(L, 4);
+    const char* root = luaL_optstring(L, 5, NULL);
+    lua_pushboolean(L, lovrFilesystemMount(path, mountpoint, mode, append, root));
+  } else { // Deprecated
+    MountMode mode = MOUNT_READ;
+    bool append = lua_toboolean(L, 3);
+    const char* root = luaL_optstring(L, 4, NULL);
+    lua_pushboolean(L, lovrFilesystemMount(path, mountpoint, mode, append, root));
+  }
   return 1;
 }
 

--- a/src/modules/filesystem/filesystem.h
+++ b/src/modules/filesystem/filesystem.h
@@ -9,12 +9,17 @@
 typedef struct Archive Archive;
 typedef struct File File;
 
+typedef enum {
+  MOUNT_READ,
+  MOUNT_READWRITE
+} MountMode;
+
 bool lovrFilesystemInit(void);
 void lovrFilesystemDestroy(void);
 void lovrFilesystemSetSource(const char* source);
 const char* lovrFilesystemGetSource(void);
 bool lovrFilesystemIsFused(void);
-bool lovrFilesystemMount(const char* path, const char* mountpoint, bool append, const char *root);
+bool lovrFilesystemMount(const char* path, const char* mountpoint, MountMode mode, bool append, const char *root);
 bool lovrFilesystemUnmount(const char* path);
 const char* lovrFilesystemGetRealDirectory(const char* path);
 bool lovrFilesystemIsFile(const char* path);
@@ -22,13 +27,13 @@ bool lovrFilesystemIsDirectory(const char* path);
 uint64_t lovrFilesystemGetSize(const char* path);
 uint64_t lovrFilesystemGetLastModified(const char* path);
 void* lovrFilesystemRead(const char* path, size_t* size);
+bool lovrFilesystemWrite(const char* path, const char* content, size_t size, bool append);
 void lovrFilesystemGetDirectoryItems(const char* path, void (*callback)(void* context, const char* path), void* context);
+bool lovrFilesystemCreateDirectory(const char* path);
+bool lovrFilesystemRemove(const char* path);
 const char* lovrFilesystemGetIdentity(void);
 bool lovrFilesystemSetIdentity(const char* identity, bool precedence);
 const char* lovrFilesystemGetSaveDirectory(void);
-bool lovrFilesystemCreateDirectory(const char* path);
-bool lovrFilesystemRemove(const char* path);
-bool lovrFilesystemWrite(const char* path, const char* content, size_t size, bool append);
 size_t lovrFilesystemGetAppdataDirectory(char* buffer, size_t size);
 size_t lovrFilesystemGetBundlePath(char* buffer, size_t size, const char** root);
 size_t lovrFilesystemGetExecutablePath(char* buffer, size_t size);
@@ -39,7 +44,7 @@ void lovrFilesystemSetRequirePath(const char* requirePath);
 
 // Archive
 
-Archive* lovrArchiveCreate(const char* path, const char* mountpoint, const char* root);
+Archive* lovrArchiveCreate(const char* path, const char* mountpoint, MountMode mode, const char* root);
 void lovrArchiveDestroy(void* ref);
 
 // File


### PR DESCRIPTION
Adds the ability to mount an archive for writing.  This means LÖVR can write anywhere on the filesystem, instead of only the save directory.

How it works: `lovr.filesystem.mount` takes a `MountMode` after the mountpoint.  The mount mode can be either `read` (the default) or `readwrite`.

Filesystem functions that previously targeted the save directory (`write`, `createDirectory`, `remove`) will now use the virtual filesystem: they search through the mounted archives, find the first one in `readwrite` mode with a mountpoint that contains the input path, and write to that archive.

The save directory isn't special anymore -- its archive is just `readwrite` instead of `read` now.

I haven't tested this code very well yet.