### PR TITLE
Fix setMass; correct terrain sampling

### DIFF
--- a/src/api/l_physics_shapes.c
+++ b/src/api/l_physics_shapes.c
@@ -114,8 +114,8 @@ Shape* luax_newterrainshape(lua_State* L, int index) {
     uint32_t n = luax_optu32(L, index + 1, 100);
     float* vertices = lovrMalloc(sizeof(float) * n * n);
     for (uint32_t i = 0; i < n * n; i++) {
-      float x = scaleXZ * (-.5f + ((float) (i % n)) / n);
-      float z = scaleXZ * (-.5f + ((float) (i / n)) / n);
+      float x = scaleXZ * (-.5f + ((float) (i % n)) / (n - 1));
+      float z = scaleXZ * (-.5f + ((float) (i / n)) / (n - 1));
       lua_pushvalue(L, index);
       lua_pushnumber(L, x);
       lua_pushnumber(L, z);

--- a/src/modules/physics/physics_jolt.c
+++ b/src/modules/physics/physics_jolt.c
@@ -623,10 +623,10 @@ float lovrColliderGetMass(Collider* collider) {
 void lovrColliderSetMass(Collider* collider, float mass) {
   JPH_MotionProperties* motionProperties = JPH_Body_GetMotionProperties(collider->body);
   Shape* shape = collider->shape;
-  JPH_MassProperties* massProperties;
-  JPH_Shape_GetMassProperties(shape->shape, massProperties);
-  JPH_MassProperties_ScaleToMass(massProperties, mass);
-  JPH_MotionProperties_SetMassProperties(motionProperties, JPH_AllowedDOFs_All, massProperties);
+  JPH_MassProperties massProperties;
+  JPH_Shape_GetMassProperties(shape->shape, &massProperties);
+  JPH_MassProperties_ScaleToMass(&massProperties, mass);
+  JPH_MotionProperties_SetMassProperties(motionProperties, JPH_AllowedDOFs_All, &massProperties);
 }
 
 void lovrColliderGetMassData(Collider* collider, float centerOfMass[3], float* mass, float inertia[6]) {

--- a/src/modules/physics/physics_jolt.c
+++ b/src/modules/physics/physics_jolt.c
@@ -964,9 +964,9 @@ TerrainShape* lovrTerrainShapeCreate(float* vertices, uint32_t n, float scaleXZ,
     .z = -.5f * scaleXZ
   };
   const JPH_Vec3 scale = {
-    .x = scaleXZ / n,
+    .x = scaleXZ / (n - 1),
     .y = scaleY,
-    .z = scaleXZ / n
+    .z = scaleXZ / (n - 1)
   };
 
   JPH_HeightFieldShapeSettings* shape_settings = JPH_HeightFieldShapeSettings_Create(vertices, &offset, &scale, n);


### PR DESCRIPTION
For terrain sampling fix, this is the before and after.

![image](https://github.com/bjornbytes/lovr/assets/17770782/f07fb683-2afa-4177-aedc-96d01b7fcb04)

![image](https://github.com/bjornbytes/lovr/assets/17770782/bb09aee3-3353-409a-88e7-293696f3fd29)

```Lua
world = lovr.physics.newWorld()
collider = world:newTerrainCollider(4, function(x, z) return 1 end, 128)

function lovr.draw(pass)
  pass:setProjection(1, mat4():orthographic(-3, 3, 3, -3, 0.01, 100))
  pass:plane(0, 0, 0,  4, 4, -math.pi/2, 1,0,0, 'line')
  for x = -5, 5, 0.2 do
    for z = -5, 5, 0.2 do
      o = vec3(x,  100, z)
      t = vec3(x, -100, z)
      world:raycast(o, t,
        function(shape, x, y, z, nx, ny, nz)
         pass:sphere(x, y, z, 0.05)
         pass:line(x, y, z, x+nx, y+ny, z+nz)
        end)
    end
  end
end
```