### PR TITLE
BMFont

### DIFF
--- a/src/api/l_data.c
+++ b/src/api/l_data.c
@@ -161,7 +161,7 @@ static int l_lovrDataNewRasterizer(lua_State* L) {
     lovrDeferRelease(blob, lovrBlobDestroy);
   }
 
-  Rasterizer* rasterizer = lovrRasterizerCreate(blob, size);
+  Rasterizer* rasterizer = lovrRasterizerCreate(blob, size, luax_readfile);
   luax_pushtype(L, Rasterizer, rasterizer);
   lovrRelease(rasterizer, lovrRasterizerDestroy);
   lovrDeferPop(defer);

--- a/src/api/l_data_rasterizer.c
+++ b/src/api/l_data_rasterizer.c
@@ -186,7 +186,7 @@ static int l_lovrRasterizerGetCurves(lua_State* L) {
 static int l_lovrRasterizerNewImage(lua_State* L) {
   Rasterizer* rasterizer = luax_checktype(L, 1, Rasterizer);
   uint32_t codepoint = luax_checkcodepoint(L, 2);
-  double spread = luaL_optnumber(L, 3, 4.);
+  double spread = lovrRasterizerGetType(rasterizer) == RASTERIZER_TTF ? luaL_optnumber(L, 3, 4.) : 0.;
   uint32_t padding = (uint32_t) ceil(spread / 2.);
   float box[4];
   lovrRasterizerGetGlyphBoundingBox(rasterizer, codepoint, box);

--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -1326,7 +1326,7 @@ static int l_lovrGraphicsNewFont(lua_State* L) {
       lovrDeferRelease(blob, lovrBlobDestroy);
     }
 
-    info.rasterizer = lovrRasterizerCreate(blob, size);
+    info.rasterizer = lovrRasterizerCreate(blob, size, luax_readfile);
     lovrDeferRelease(info.rasterizer, lovrRasterizerDestroy);
   } else {
     info.spread = luaL_optnumber(L, 2, info.spread);

--- a/src/api/l_graphics_font.c
+++ b/src/api/l_graphics_font.c
@@ -89,9 +89,10 @@ static int l_lovrFontGetHeight(lua_State* L) {
 
 static int l_lovrFontGetKerning(lua_State* L) {
   Font* font = luax_checktype(L, 1, Font);
+  Rasterizer* rasterizer = lovrFontGetInfo(font)->rasterizer;
   uint32_t first = luax_checkcodepoint(L, 2);
   uint32_t second = luax_checkcodepoint(L, 3);
-  float kerning = lovrFontGetKerning(font, first, second);
+  float kerning = lovrRasterizerGetKerning(rasterizer, first, second);
   float density = lovrFontGetPixelDensity(font);
   lua_pushnumber(L, kerning / density);
   return 1;

--- a/src/modules/data/rasterizer.c
+++ b/src/modules/data/rasterizer.c
@@ -155,9 +155,13 @@ static Rasterizer* lovrRasterizerCreateBMF(Blob* blob, RasterizerIO* io) {
         Blob* atlasBlob = lovrBlobCreate(atlasData, atlasSize, "BMFont atlas");
         rasterizer->atlas = lovrImageCreateFromFile(atlasBlob);
       } else if (!memcmp(tag, "char", tagLength)) {
-        //uint32_t codepoint = getNumber(&map, "id");
+        //uint32_t codepoint = parseNumber(&map, "id");
       } else if (!memcmp(tag, "kerning", tagLength)) {
-        //
+        uint32_t first = parseNumber(&map, "first");
+        uint32_t second = parseNumber(&map, "second");
+        int32_t kerning = parseNumber(&map, "amount");
+        uint32_t hash = hash64((uint32_t[]) { first, second }, 2 * sizeof(uint32_t));
+        map_set(&rasterizer->kerning, hash, (uint64_t) kerning);
       }
 
       // Go to the next line
@@ -256,7 +260,7 @@ float lovrRasterizerGetKerning(Rasterizer* rasterizer, uint32_t first, uint32_t 
     map_set(&rasterizer->kerning, hash, kerning);
   }
 
-  return kerning * rasterizer->scale;
+  return (int32_t) kerning * rasterizer->scale;
 }
 
 void lovrRasterizerGetBoundingBox(Rasterizer* rasterizer, float box[4]) {

--- a/src/modules/data/rasterizer.h
+++ b/src/modules/data/rasterizer.h
@@ -34,3 +34,5 @@ void lovrRasterizerGetBoundingBox(Rasterizer* rasterizer, float box[4]);
 void lovrRasterizerGetGlyphBoundingBox(Rasterizer* rasterizer, uint32_t codepoint, float box[4]);
 bool lovrRasterizerGetCurves(Rasterizer* rasterizer, uint32_t codepoint, void (*fn)(void* context, uint32_t degree, float* points), void* context);
 bool lovrRasterizerGetPixels(Rasterizer* rasterizer, uint32_t codepoint, float* pixels, uint32_t width, uint32_t height, double spread);
+struct Image* lovrRasterizerGetAtlas(Rasterizer* rasterizer);
+uint32_t lovrRasterizerGetAtlasGlyph(Rasterizer* rasterizer, uint32_t index, uint16_t* x, uint16_t* y);

--- a/src/modules/data/rasterizer.h
+++ b/src/modules/data/rasterizer.h
@@ -7,8 +7,10 @@
 struct Blob;
 struct Image;
 
+typedef void* RasterizerIO(const char* filename, size_t* bytesRead);
+
 typedef struct Rasterizer Rasterizer;
-Rasterizer* lovrRasterizerCreate(struct Blob* blob, float size);
+Rasterizer* lovrRasterizerCreate(struct Blob* blob, float size, RasterizerIO* io);
 void lovrRasterizerDestroy(void* ref);
 float lovrRasterizerGetFontSize(Rasterizer* rasterizer);
 uint32_t lovrRasterizerGetGlyphCount(Rasterizer* rasterizer);

--- a/src/modules/data/rasterizer.h
+++ b/src/modules/data/rasterizer.h
@@ -8,9 +8,9 @@ struct Blob;
 struct Image;
 
 typedef enum {
-  FONT_TTF,
-  FONT_BMF
-} FontType;
+  RASTERIZER_TTF,
+  RASTERIZER_BMF
+} RasterizerType;
 
 typedef void* RasterizerIO(const char* filename, size_t* bytesRead);
 
@@ -18,7 +18,7 @@ typedef struct Rasterizer Rasterizer;
 
 Rasterizer* lovrRasterizerCreate(struct Blob* blob, float size, RasterizerIO* io);
 void lovrRasterizerDestroy(void* ref);
-FontType lovrRasterizerGetType(Rasterizer* rasterizer);
+RasterizerType lovrRasterizerGetType(Rasterizer* rasterizer);
 float lovrRasterizerGetFontSize(Rasterizer* rasterizer);
 uint32_t lovrRasterizerGetGlyphCount(Rasterizer* rasterizer);
 bool lovrRasterizerHasGlyph(Rasterizer* rasterizer, uint32_t codepoint);

--- a/src/modules/data/rasterizer.h
+++ b/src/modules/data/rasterizer.h
@@ -7,11 +7,18 @@
 struct Blob;
 struct Image;
 
+typedef enum {
+  FONT_TTF,
+  FONT_BMF
+} FontType;
+
 typedef void* RasterizerIO(const char* filename, size_t* bytesRead);
 
 typedef struct Rasterizer Rasterizer;
+
 Rasterizer* lovrRasterizerCreate(struct Blob* blob, float size, RasterizerIO* io);
 void lovrRasterizerDestroy(void* ref);
+FontType lovrRasterizerGetType(Rasterizer* rasterizer);
 float lovrRasterizerGetFontSize(Rasterizer* rasterizer);
 uint32_t lovrRasterizerGetGlyphCount(Rasterizer* rasterizer);
 bool lovrRasterizerHasGlyph(Rasterizer* rasterizer, uint32_t codepoint);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -3523,7 +3523,7 @@ Font* lovrFontCreate(const FontInfo* info) {
 
   font->pixelDensity = lovrRasterizerGetLeading(info->rasterizer);
   font->lineSpacing = 1.f;
-  font->padding = (uint32_t) ceil(info->spread / 2.);
+  font->padding = lovrRasterizerGetType(info->rasterizer) == RASTERIZER_TTF ? (uint32_t) ceil(info->spread / 2.) : 0;
 
   // Initial atlas size must be big enough to hold any of the glyphs
   float box[4];
@@ -3623,9 +3623,9 @@ static Glyph* lovrFontGetGlyph(Font* font, uint32_t codepoint, bool* resized) {
   glyph->x = font->atlasX + font->padding;
   glyph->y = font->atlasY + font->padding;
   glyph->uv[0] = (uint16_t) ((float) glyph->x / font->atlasWidth * 65535.f + .5f);
-  glyph->uv[1] = (uint16_t) ((float) (glyph->y + height) / font->atlasHeight * 65535.f + .5f);
+  glyph->uv[1] = (uint16_t) ((float) glyph->y / font->atlasHeight * 65535.f + .5f);
   glyph->uv[2] = (uint16_t) ((float) (glyph->x + width) / font->atlasWidth * 65535.f + .5f);
-  glyph->uv[3] = (uint16_t) ((float) glyph->y / font->atlasHeight * 65535.f + .5f);
+  glyph->uv[3] = (uint16_t) ((float) (glyph->y + height) / font->atlasHeight * 65535.f + .5f);
 
   font->atlasX += pixelWidth;
   font->rowHeight = MAX(font->rowHeight, pixelHeight);
@@ -3684,9 +3684,9 @@ static Glyph* lovrFontGetGlyph(Font* font, uint32_t codepoint, bool* resized) {
       Glyph* g = &font->glyphs.data[i];
       if (g->box[2] - g->box[0] > 0.f) {
         g->uv[0] = (uint16_t) ((float) g->x / font->atlasWidth * 65535.f + .5f);
-        g->uv[1] = (uint16_t) ((float) (g->y + g->box[3] - g->box[1]) / font->atlasHeight * 65535.f + .5f);
+        g->uv[1] = (uint16_t) ((float) g->y / font->atlasHeight * 65535.f + .5f);
         g->uv[2] = (uint16_t) ((float) (g->x + g->box[2] - g->box[0]) / font->atlasWidth * 65535.f + .5f);
-        g->uv[3] = (uint16_t) ((float) g->y / font->atlasHeight * 65535.f + .5f);
+        g->uv[3] = (uint16_t) ((float) (g->y + g->box[3] - g->box[1]) / font->atlasHeight * 65535.f + .5f);
       }
     }
 
@@ -6980,7 +6980,7 @@ void lovrPassText(Pass* pass, ColoredString* strings, uint32_t count, float* tra
   uint16_t* indices;
   lovrPassDraw(pass, &(DrawInfo) {
     .mode = DRAW_TRIANGLES,
-    .shader = SHADER_FONT,
+    .shader = lovrRasterizerGetType(font->info.rasterizer) == RASTERIZER_TTF ? SHADER_FONT : SHADER_UNLIT,
     .material = font->material,
     .transform = transform,
     .vertex.format = VERTEX_GLYPH,

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -3503,7 +3503,7 @@ const MaterialInfo* lovrMaterialGetInfo(Material* material) {
 
 Font* lovrGraphicsGetDefaultFont(void) {
   if (!state.defaultFont) {
-    Rasterizer* rasterizer = lovrRasterizerCreate(NULL, 32);
+    Rasterizer* rasterizer = lovrRasterizerCreate(NULL, 32, NULL);
     state.defaultFont = lovrFontCreate(&(FontInfo) {
       .rasterizer = rasterizer,
       .spread = 4.

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -160,7 +160,6 @@ struct Material {
 };
 
 typedef struct {
-  uint32_t codepoint;
   float advance;
   uint16_t x, y;
   uint16_t uv[4];
@@ -3583,7 +3582,6 @@ static Glyph* lovrFontGetGlyph(Font* font, uint32_t codepoint, bool* resized) {
   map_set(&font->glyphLookup, hash, font->glyphs.length);
   Glyph* glyph = &font->glyphs.data[font->glyphs.length++];
 
-  glyph->codepoint = codepoint;
   glyph->advance = lovrRasterizerGetAdvance(font->info.rasterizer, codepoint);
 
   if (lovrRasterizerIsGlyphEmpty(font->info.rasterizer, codepoint)) {
@@ -3695,7 +3693,7 @@ static Glyph* lovrFontGetGlyph(Font* font, uint32_t codepoint, bool* resized) {
 
   size_t stack = tempPush(&state.allocator);
   float* pixels = tempAlloc(&state.allocator, pixelWidth * pixelHeight * 4 * sizeof(float));
-  lovrRasterizerGetPixels(font->info.rasterizer, glyph->codepoint, pixels, pixelWidth, pixelHeight, font->info.spread);
+  lovrRasterizerGetPixels(font->info.rasterizer, codepoint, pixels, pixelWidth, pixelHeight, font->info.spread);
   BufferView view = getBuffer(GPU_BUFFER_UPLOAD, pixelWidth * pixelHeight * 4 * sizeof(uint8_t), 64);
   float* src = pixels;
   uint8_t* dst = view.pointer;


### PR DESCRIPTION
Adds support for BMFont fonts.  They are useful for rendering fonts in 2D contexts (potentially with the new `Layer` object) or for stylized image fonts or icons/emoji.  Both text and binary BMFont files are supported.  Non-unicode charsets are not supported.

The usage is similar to TTF:

```lua
function lovr.load()
  font = lovr.graphics.newFont('font.fnt')
end

function lovr.draw(pass)
  pass:setFont(font)
  pass:text('hi!', x, y, z)
end
```