### PR TITLE
Fix infinite loop during model animation caused by integer overflow.

### DIFF
--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -5129,8 +5129,10 @@ static void lovrModelAnimateVertices(Model* model) {
       // - Blended vertices should animate the post-blended vertices in-place
       for (uint32_t j = 0; j < 2; j++) {
         uint32_t subgroupSize = state.device.subgroupSize;
-        uint32_t maxVerticesPerDispatch = state.limits.workgroupCount[0] * subgroupSize;
+        uint32_t maxVerticesPerDispatch = MAX(state.limits.workgroupCount[0] * subgroupSize, 4294967295);
         uint32_t verticesRemaining = j == 0 ? skin->blendedVertexCount : (skin->vertexCount - skin->blendedVertexCount);
+
+        lovrAssert(maxVerticesPerDispatch > 0, "maxVerticesPerDispatch count must be greater than zero.");
 
         while (verticesRemaining > 0) {
           uint32_t vertexCount = MIN(verticesRemaining, maxVerticesPerDispatch);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -5128,10 +5128,9 @@ static void lovrModelAnimateVertices(Model* model) {
       // - Unblended vertices should animate the original vertices from rawVertexBuffer
       // - Blended vertices should animate the post-blended vertices in-place
       for (uint32_t j = 0; j < 2; j++) {
-        uint32_t subgroupSize = state.device.subgroupSize;
-        uint32_t maxVerticesPerDispatch = MAX(state.limits.workgroupCount[0] * subgroupSize, 4294967295);
+        uint32_t subgroupSize = state.device.subgroupSize; 
         uint32_t verticesRemaining = j == 0 ? skin->blendedVertexCount : (skin->vertexCount - skin->blendedVertexCount);
-
+        uint32_t maxVerticesPerDispatch = (uint32_t) MIN((uint64_t) state.limits.workgroupCount[0] * subgroupSize, (uint64_t) verticesRemaining);
         lovrAssert(maxVerticesPerDispatch > 0, "maxVerticesPerDispatch count must be greater than zero.");
 
         while (verticesRemaining > 0) {

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -5131,7 +5131,6 @@ static void lovrModelAnimateVertices(Model* model) {
         uint32_t subgroupSize = state.device.subgroupSize; 
         uint32_t verticesRemaining = j == 0 ? skin->blendedVertexCount : (skin->vertexCount - skin->blendedVertexCount);
         uint32_t maxVerticesPerDispatch = (uint32_t) MIN((uint64_t) state.limits.workgroupCount[0] * subgroupSize, (uint64_t) verticesRemaining);
-        lovrAssert(maxVerticesPerDispatch > 0, "maxVerticesPerDispatch count must be greater than zero.");
 
         while (verticesRemaining > 0) {
           uint32_t vertexCount = MIN(verticesRemaining, maxVerticesPerDispatch);


### PR DESCRIPTION
Update calculations to avoid overflow per discussion in the discord with Bjorn.