### PR TITLE
Shape queries

### DIFF
--- a/src/api/l_physics_shapes.c
+++ b/src/api/l_physics_shapes.c
@@ -338,6 +338,34 @@ static int l_lovrShapeGetAABB(lua_State* L) {
   return 6;
 }
 
+static int l_lovrShapeContainsPoint(lua_State* L) {
+  Shape* shape = luax_checkshape(L, 1);
+  float point[3];
+  luax_readvec3(L, 2, point, NULL);
+  bool hit = lovrShapeContainsPoint(shape, point);
+  lua_pushboolean(L, hit);
+  return 1;
+}
+
+static int l_lovrShapeRaycast(lua_State* L) {
+  Shape* shape = luax_checkshape(L, 1);
+  int index = 2;
+  float start[3], end[3];
+  index = luax_readvec3(L, index, start, NULL);
+  index = luax_readvec3(L, index, end, NULL);
+  CastResult hit;
+  if (lovrShapeRaycast(shape, start, end, &hit)) {
+    lua_pushnumber(L, hit.position[0]);
+    lua_pushnumber(L, hit.position[1]);
+    lua_pushnumber(L, hit.position[2]);
+    lua_pushnumber(L, hit.normal[0]);
+    lua_pushnumber(L, hit.normal[1]);
+    lua_pushnumber(L, hit.normal[2]);
+    return 6;
+  }
+  return 0;
+}
+
 #define lovrShape \
   { "destroy", l_lovrShapeDestroy }, \
   { "isDestroyed", l_lovrShapeIsDestroyed }, \
@@ -356,7 +384,9 @@ static int l_lovrShapeGetAABB(lua_State* L) {
   { "getPosition", l_lovrShapeGetPosition }, \
   { "getOrientation", l_lovrShapeGetOrientation }, \
   { "getPose", l_lovrShapeGetPose }, \
-  { "getAABB", l_lovrShapeGetAABB }
+  { "getAABB", l_lovrShapeGetAABB }, \
+  { "containsPoint", l_lovrShapeContainsPoint }, \
+  { "raycast", l_lovrShapeRaycast }
 
 static int l_lovrBoxShapeGetDimensions(lua_State* L) {
   BoxShape* box = luax_checktype(L, 1, BoxShape);

--- a/src/modules/physics/physics.c
+++ b/src/modules/physics/physics.c
@@ -282,7 +282,7 @@ static void onContactRemoved(void* userdata, const JPH_SubShapeIDPair* pair) {
 
 bool lovrPhysicsInit(void (*freeUserData)(void* object, uintptr_t userdata)) {
   if (state.initialized) return true;
-  JPH_Init(32 * 1024 * 1024);
+  JPH_Init();
   state.sphere = lovrSphereShapeCreate(.001f);
   state.freeUserData = freeUserData;
   return state.initialized = true;

--- a/src/modules/physics/physics.c
+++ b/src/modules/physics/physics.c
@@ -2054,10 +2054,9 @@ bool lovrShapeRaycast(Shape* shape, float start[3], float end[3], CastResult* hi
   vec3_init(direction, end);
   vec3_sub(direction, start);
 
-  float inverseRotation[4];
+  float position[3], orientation[4], inverseRotation[4];
 
   if (shape->collider) {
-    float position[3], orientation[4];
     lovrColliderGetPose(shape->collider, position, orientation);
     inverseTransformRay(start, direction, position, orientation);
   }
@@ -2074,12 +2073,22 @@ bool lovrShapeRaycast(Shape* shape, float start[3], float end[3], CastResult* hi
     vec3_init(hit->position, direction);
     vec3_scale(hit->position, result.fraction);
     vec3_add(hit->position, start);
+
     JPH_Vec3 normal;
     JPH_Shape_GetSurfaceNormal(shape->handle, result.subShapeID2, vec3_toJolt(hit->position), &normal);
-    quat_rotate(shape->rotation, vec3_fromJolt(hit->normal, &normal));
+    vec3_fromJolt(hit->normal, &normal);
+
+    quat_rotate(shape->rotation, hit->normal);
     quat_rotate(shape->rotation, hit->position);
     vec3_add(hit->position, shape->translation);
     vec3_add(hit->position, center);
+
+    if (shape->collider) {
+      quat_rotate(orientation, hit->position);
+      quat_rotate(orientation, hit->normal);
+      vec3_add(hit->position, position);
+    }
+
     return true;
   }
 

--- a/src/modules/physics/physics.c
+++ b/src/modules/physics/physics.c
@@ -2054,6 +2054,7 @@ bool lovrShapeRaycast(Shape* shape, float start[3], float end[3], CastResult* hi
     quat_rotate(shape->rotation, vec3_fromJolt(hit->normal, &normal));
     quat_rotate(shape->rotation, hit->position);
     vec3_add(hit->position, shape->translation);
+    vec3_add(hit->position, center);
     return true;
   }
 

--- a/src/modules/physics/physics.h
+++ b/src/modules/physics/physics.h
@@ -232,6 +232,8 @@ void lovrShapeGetOffset(Shape* shape, float position[3], float orientation[4]);
 bool lovrShapeSetOffset(Shape* shape, float position[3], float orientation[4]);
 void lovrShapeGetPose(Shape* shape, float position[3], float orientation[4]);
 void lovrShapeGetAABB(Shape* shape, float aabb[6]);
+bool lovrShapeContainsPoint(Shape* shape, float point[3]);
+bool lovrShapeRaycast(Shape* shape, float start[3], float end[3], CastResult* hit);
 
 BoxShape* lovrBoxShapeCreate(float dimensions[3]);
 void lovrBoxShapeGetDimensions(BoxShape* shape, float dimensions[3]);

--- a/test/lovr/physics.lua
+++ b/test/lovr/physics.lua
@@ -66,17 +66,34 @@ group('physics', function()
     end)
   end)
 
-  group('MeshShape', function()
-    if lovr.graphics then
-      test('from Mesh', function()
-        mesh = lovr.graphics.newMesh({
-          {   0,  .4, 0 },
-          { -.5, -.4, 0 },
-          {  .5, -.4, 0 }
-        })
+  group('Shape', function()
+    test(':raycast', function()
+      shape = lovr.physics.newBoxShape(2, 10, 2)
+      expect(shape:raycast(-10, 10, 0,  10, 10, 0)).to_not.be.truthy()
+      expect({ shape:raycast(-10, 0, 0,  10, 0, 0) }).to.equal({ -1, 0, 0, -1, 0, 0 }, 1e-6)
+      expect({ shape:raycast(-10, 4, 0,  10, 4, 0) }).to.equal({ -1, 4, 0, -1, 0, 0 }, 1e-6)
+      shape:setOffset(0, 0, 0, math.pi / 2, 0, 0, 1)
+      expect({ shape:raycast(-10, 0, 0,  10, 0, 0) }).to.equal({ -5, 0, 0, -1, 0, 0 }, 1e-6)
+      expect(shape:raycast(-10, 4, 0,  10, 4, 0)).to.equal(nil)
 
-        shape = lovr.physics.newMeshShape(mesh)
-      end)
-    end
+      collider = world:newCollider(100, 100, 100)
+      collider:addShape(shape)
+      expect(shape:raycast(-10, 0, 0, 10, 0, 0)).to.equal(nil)
+      expect({ shape:raycast(-500, 100, 100, 500, 100, 100) }).to.equal({ 95, 100, 100, -1, 0, 0 }, 1e-6)
+    end)
+
+    group('MeshShape', function()
+      if lovr.graphics then
+        test('from Mesh', function()
+          mesh = lovr.graphics.newMesh({
+            {   0,  .4, 0 },
+            { -.5, -.4, 0 },
+            {  .5, -.4, 0 }
+          })
+
+          shape = lovr.physics.newMeshShape(mesh)
+        end)
+      end
+    end)
   end)
 end)

--- a/test/lust.lua
+++ b/test/lust.lua
@@ -102,14 +102,15 @@ local function has(t, x)
   return false
 end
 
-local function strict_eq(t1, t2)
+local function eq(t1, t2, eps)
   if type(t1) ~= type(t2) then return false end
+  if type(t1) == 'number' then return math.abs(t1 - t2) <= (eps or 0) end
   if type(t1) ~= 'table' then return t1 == t2 end
   for k, _ in pairs(t1) do
-    if not strict_eq(t1[k], t2[k]) then return false end
+    if not eq(t1[k], t2[k], eps) then return false end
   end
   for k, _ in pairs(t2) do
-    if not strict_eq(t2[k], t1[k]) then return false end
+    if not eq(t2[k], t1[k], eps) then return false end
   end
   return true
 end
@@ -123,8 +124,8 @@ local paths = {
   be = { 'a', 'an', 'truthy',
     test = function(v, x)
       return v == x,
-        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to be equal',
-        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to not be equal'
+        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to be the same',
+        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to not be the same'
     end
   },
   exist = {
@@ -142,10 +143,10 @@ local paths = {
     end
   },
   equal = {
-    test = function(v, x)
-      return strict_eq(v, x),
-        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to be exactly equal',
-        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to not be exactly equal'
+    test = function(v, x, eps)
+      return eq(v, x, eps),
+        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to be equal',
+        'expected ' .. tostring(v) .. ' and ' .. tostring(x) .. ' to not be equal'
     end
   },
   have = {


### PR DESCRIPTION
Adds `Shape:containsPoint` and `Shape:raycast`

- `Shape:containsPoint(x, y, z)`
- `x, y, z, nx, ny, nz = Shape:raycast(x1, y1, z1, x2, y2, z2)`

All units are in world space.  The queries take into account the shape's offset and collider pose (if any).

The math is kinda gross because Jolt's shape queries are in the shape's local space, relative to its center of mass.  So we have to do lots of conversions between world space and center-of-mass space.