### PR TITLE
Remove Pico OpenXR Loader

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "deps/vulkan-headers"]
 	path = deps/vulkan-headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers
-[submodule "deps/pico-openxr"]
-	path = deps/pico-openxr
-	url = https://github.com/lovr-org/pico_openxr_sdk
 [submodule "plugins/lua-enet"]
 	path = plugins/lua-enet
 	url = https://github.com/bjornbytes/lua-enet

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -818,13 +818,8 @@ elseif(ANDROID)
       add_custom_command(TARGET move_files POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
         $<TARGET_SONAME_FILE:${LOVR_OPENXR}>
-        raw/lib/${ANDROID_ABI}/libopenxr_loader_generic.so
+        raw/lib/${ANDROID_ABI}/libopenxr_loader.so
       )
-
-      set(PICO_LOADER "${CMAKE_CURRENT_SOURCE_DIR}/deps/pico-openxr/libs/android.${ANDROID_ABI}/libopenxr_loader.so")
-      if(EXISTS ${PICO_LOADER})
-        configure_file(${PICO_LOADER} "raw/lib/${ANDROID_ABI}/libopenxr_loader_pico.so" COPYONLY)
-      endif()
 
       configure_file("${ANDROID_NDK}/toolchains/llvm/prebuilt/${ANDROID_HOST_TAG}/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" "raw/lib/${ANDROID_ABI}/libc++_shared.so" COPYONLY)
     endif()

--- a/etc/Activity.java
+++ b/etc/Activity.java
@@ -3,18 +3,11 @@ package @ANDROID_PACKAGE@;
 import android.Manifest;
 import android.app.NativeActivity;
 import android.content.pm.PackageManager;
-import android.util.Log;
 import android.os.Build;
 
 public class Activity extends NativeActivity {
   static {
-    if (Build.MANUFACTURER.contains("Pico")) {
-      Log.d("LOVR", "Using Pico OpenXR Loader");
-      System.loadLibrary("openxr_loader_pico");
-    } else {
-      Log.d("LOVR", "Using Generic OpenXR Loader");
-      System.loadLibrary("openxr_loader_generic");
-    }
+    System.loadLibrary("openxr_loader");
     System.loadLibrary("lovr");
   }
 


### PR DESCRIPTION
According to [Pico docs](https://developer.picoxr.com/document/native/), Pico now supports the official OpenXR loader, so LÖVR doesn't need to include a special loader for Pico anymore.