### PR TITLE
Controller Hand Tracking Customization

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -36,7 +36,8 @@ local conf = {
     stencil = false,
     antialias = true,
     submitdepth = true,
-    overlay = false
+    overlay = false,
+    controllerSkeleton = 'controller'
   },
   math = {
     globals = true

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -37,7 +37,7 @@ local conf = {
     antialias = true,
     submitdepth = true,
     overlay = false,
-    controllerSkeleton = 'controller'
+    controllerskeleton = 'controller'
   },
   math = {
     globals = true

--- a/etc/webxr.js
+++ b/etc/webxr.js
@@ -374,7 +374,7 @@ var webxr = {
   },
 
   webxr_getSkeleton__deps: ['$writePose'],
-  webxr_getSkeleton: function(device, poses, controller) {
+  webxr_getSkeleton: function(device, poses, source) {
     var inputSource = state.hands[device];
 
     if (!inputSource || !inputSource.hand) {

--- a/etc/webxr.js
+++ b/etc/webxr.js
@@ -374,7 +374,7 @@ var webxr = {
   },
 
   webxr_getSkeleton__deps: ['$writePose'],
-  webxr_getSkeleton: function(device, poses) {
+  webxr_getSkeleton: function(device, poses, controller) {
     var inputSource = state.hands[device];
 
     if (!inputSource || !inputSource.hand) {

--- a/src/api/l_headset.c
+++ b/src/api/l_headset.c
@@ -505,8 +505,8 @@ static int l_lovrHeadsetGetAxis(lua_State* L) {
 static int l_lovrHeadsetGetSkeleton(lua_State* L) {
   Device device = luax_optdevice(L, 1);
   float poses[HAND_JOINT_COUNT * 8];
-  bool controller = false;
-  if (lovrHeadsetInterface->getSkeleton(device, poses, &controller)) {
+  SkeletonSource source = SOURCE_UNKNOWN;
+  if (lovrHeadsetInterface->getSkeleton(device, poses, &source)) {
     if (!lua_istable(L, 2)) {
       lua_createtable(L, HAND_JOINT_COUNT, 0);
     } else {
@@ -542,8 +542,10 @@ static int l_lovrHeadsetGetSkeleton(lua_State* L) {
       lua_rawseti(L, -2, i + 1);
     }
 
-    lua_pushboolean(L, controller);
-    lua_setfield(L, -2, "controller");
+    if (source != SOURCE_UNKNOWN) {
+      lua_pushboolean(L, source == SOURCE_CONTROLLER);
+      lua_setfield(L, -2, "controller");
+    }
 
     return 1;
   }

--- a/src/modules/headset/headset.h
+++ b/src/modules/headset/headset.h
@@ -131,6 +131,12 @@ typedef enum {
 } HandJoint;
 
 typedef enum {
+  SOURCE_UNKNOWN,
+  SOURCE_CONTROLLER,
+  SOURCE_HAND
+} SkeletonSource;
+
+typedef enum {
   EYE_BOTH,
   EYE_LEFT,
   EYE_RIGHT
@@ -184,7 +190,7 @@ typedef struct HeadsetInterface {
   bool (*isDown)(Device device, DeviceButton button, bool* down, bool* changed);
   bool (*isTouched)(Device device, DeviceButton button, bool* touched);
   bool (*getAxis)(Device device, DeviceAxis axis, float* value);
-  bool (*getSkeleton)(Device device, float* poses, bool* controller);
+  bool (*getSkeleton)(Device device, float* poses, SkeletonSource* source);
   bool (*vibrate)(Device device, float strength, float duration, float frequency);
   void (*stopVibration)(Device device);
   struct ModelData* (*newModelData)(Device device, bool animated);

--- a/src/modules/headset/headset.h
+++ b/src/modules/headset/headset.h
@@ -20,6 +20,12 @@ typedef enum {
   DRIVER_WEBXR
 } HeadsetDriver;
 
+typedef enum {
+  SKELETON_NONE,
+  SKELETON_CONTROLLER,
+  SKELETON_NATURAL
+} ControllerSkeletonMode;
+
 typedef struct {
   HeadsetDriver* drivers;
   size_t driverCount;
@@ -30,6 +36,7 @@ typedef struct {
   bool submitDepth;
   bool overlay;
   uint32_t overlayOrder;
+  ControllerSkeletonMode controllerSkeleton;
 } HeadsetConfig;
 
 typedef enum {
@@ -177,7 +184,7 @@ typedef struct HeadsetInterface {
   bool (*isDown)(Device device, DeviceButton button, bool* down, bool* changed);
   bool (*isTouched)(Device device, DeviceButton button, bool* touched);
   bool (*getAxis)(Device device, DeviceAxis axis, float* value);
-  bool (*getSkeleton)(Device device, float* poses);
+  bool (*getSkeleton)(Device device, float* poses, bool* controller);
   bool (*vibrate)(Device device, float strength, float duration, float frequency);
   void (*stopVibration)(Device device);
   struct ModelData* (*newModelData)(Device device, bool animated);

--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -398,13 +398,14 @@ static XrHandTrackerEXT getHandTracker(Device device) {
 
     XrHandTrackingDataSourceInfoEXT sourceInfo = {
       .type = XR_TYPE_HAND_TRACKING_DATA_SOURCE_INFO_EXT,
-      .requestedDataSourceCount = 1,
-      .requestedDataSources = (XrHandTrackingDataSourceEXT[1]) {
-        XR_HAND_TRACKING_DATA_SOURCE_UNOBSTRUCTED_EXT
+      .requestedDataSourceCount = state.config.controllerSkeleton == SKELETON_NONE ? 1 : 2,
+      .requestedDataSources = (XrHandTrackingDataSourceEXT[2]) {
+        XR_HAND_TRACKING_DATA_SOURCE_UNOBSTRUCTED_EXT,
+        XR_HAND_TRACKING_DATA_SOURCE_CONTROLLER_EXT
       }
     };
 
-    if (state.features.handTrackingDataSource && state.config.controllerSkeleton == SKELETON_NONE) {
+    if (state.features.handTrackingDataSource) {
       sourceInfo.next = info.next;
       info.next = &sourceInfo;
     }

--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -2084,7 +2084,7 @@ static bool openxr_getAxis(Device device, DeviceAxis axis, float* value) {
   }
 }
 
-static bool openxr_getSkeleton(Device device, float* poses, bool* controller) {
+static bool openxr_getSkeleton(Device device, float* poses, SkeletonSource* source) {
   XrHandTrackerEXT tracker = getHandTracker(device);
 
   if (!tracker || state.frameState.predictedDisplayTime <= 0) {
@@ -2116,13 +2116,13 @@ static bool openxr_getSkeleton(Device device, float* poses, bool* controller) {
     .jointLocations = joints
   };
 
-  XrHandTrackingDataSourceStateEXT source = {
+  XrHandTrackingDataSourceStateEXT sourceState = {
     .type = XR_TYPE_HAND_TRACKING_DATA_SOURCE_STATE_EXT
   };
 
   if (state.features.handTrackingDataSource) {
-    source.next = hand.next;
-    hand.next = &source;
+    sourceState.next = hand.next;
+    hand.next = &sourceState;
   }
 
   if (XR_FAILED(xrLocateHandJointsEXT(tracker, &info, &hand)) || !hand.isActive) {
@@ -2138,9 +2138,9 @@ static bool openxr_getSkeleton(Device device, float* poses, bool* controller) {
   }
 
   if (state.features.handTrackingDataSource) {
-    *controller = source.dataSource == XR_HAND_TRACKING_DATA_SOURCE_CONTROLLER_EXT;
+    *source = sourceState.dataSource == XR_HAND_TRACKING_DATA_SOURCE_CONTROLLER_EXT ? SOURCE_CONTROLLER : SOURCE_HAND;
   } else {
-    *controller = false;
+    *source = SOURCE_UNKNOWN;
   }
 
   return true;

--- a/src/modules/headset/headset_simulator.c
+++ b/src/modules/headset/headset_simulator.c
@@ -255,7 +255,7 @@ static bool simulator_getAxis(Device device, DeviceAxis axis, vec3 value) {
   return false;
 }
 
-static bool simulator_getSkeleton(Device device, float* poses, bool* controller) {
+static bool simulator_getSkeleton(Device device, float* poses, SkeletonSource* source) {
   return false;
 }
 

--- a/src/modules/headset/headset_simulator.c
+++ b/src/modules/headset/headset_simulator.c
@@ -255,7 +255,7 @@ static bool simulator_getAxis(Device device, DeviceAxis axis, vec3 value) {
   return false;
 }
 
-static bool simulator_getSkeleton(Device device, float* poses) {
+static bool simulator_getSkeleton(Device device, float* poses, bool* controller) {
   return false;
 }
 

--- a/src/modules/headset/headset_webxr.c
+++ b/src/modules/headset/headset_webxr.c
@@ -28,7 +28,7 @@ extern bool webxr_getVelocity(Device device, float* velocity, float* angularVelo
 extern bool webxr_isDown(Device device, DeviceButton button, bool* down, bool* changed);
 extern bool webxr_isTouched(Device device, DeviceButton button, bool* touched);
 extern bool webxr_getAxis(Device device, DeviceAxis axis, float* value);
-extern bool webxr_getSkeleton(Device device, float* poses, bool* controller);
+extern bool webxr_getSkeleton(Device device, float* poses, SkeletonSource* source);
 extern bool webxr_vibrate(Device device, float strength, float duration, float frequency);
 extern void webxr_stopVibration(Device device);
 extern struct ModelData* webxr_newModelData(Device device, bool animated);

--- a/src/modules/headset/headset_webxr.c
+++ b/src/modules/headset/headset_webxr.c
@@ -28,7 +28,7 @@ extern bool webxr_getVelocity(Device device, float* velocity, float* angularVelo
 extern bool webxr_isDown(Device device, DeviceButton button, bool* down, bool* changed);
 extern bool webxr_isTouched(Device device, DeviceButton button, bool* touched);
 extern bool webxr_getAxis(Device device, DeviceAxis axis, float* value);
-extern bool webxr_getSkeleton(Device device, float* poses);
+extern bool webxr_getSkeleton(Device device, float* poses, bool* controller);
 extern bool webxr_vibrate(Device device, float strength, float duration, float frequency);
 extern void webxr_stopVibration(Device device);
 extern struct ModelData* webxr_newModelData(Device device, bool animated);


### PR DESCRIPTION
Currently, on some headsets, `lovr.headset.getSkeleton` will return a hand tracking skeleton when you're holding a controller, with joint poses emulated from the capsense buttons on the controller.  This PR adds some more customization around that behavior.  There is a new conf.lua flag, `t.headset.controllerskeleton`, that can be one of the following:

- `none` -- disables emulated hand poses.  `lovr.headset.getSkeleton` returns nil when the user is holding a controller.
- `controller` -- returns emulated hand poses that conform to the shape of the controller (default value, matches current behavior).  nice when also rendering a controller model.
- `natural` -- returns emulated hand poses that do not take the shape of the controller but instead represent natural "hand gestures" based on the buttons that are being pressed.  The behavior varies on different runtimes but generally the hand will make a fist when trigger/grip are pressed, point when releasing trigger, etc.

Additionally, the table returned by `lovr.headset.getSkeleton` includes a `controller` key that indicates if the data is coming from a controller or a hand (or nil when unknown).