### PR TITLE
Raycast returns triangle index; Mesh/Convex shape scale;

### DIFF
--- a/src/api/l_physics_shapes.c
+++ b/src/api/l_physics_shapes.c
@@ -583,6 +583,7 @@ static int l_lovrMeshShapeGetScale(lua_State* L) {
 
 const luaL_Reg lovrMeshShape[] = {
   lovrShape,
+  { "getScale", l_lovrMeshShapeGetScale },
   { NULL, NULL }
 };
 

--- a/src/api/l_physics_world.c
+++ b/src/api/l_physics_world.c
@@ -21,8 +21,13 @@ static int luax_pushcastresult(lua_State* L, CastResult* hit) {
   lua_pushnumber(L, hit->normal[0]);
   lua_pushnumber(L, hit->normal[1]);
   lua_pushnumber(L, hit->normal[2]);
+  if (hit->triangle == ~0u) {
+    lua_pushnil(L);
+  } else {
+    lua_pushinteger(L, hit->triangle + 1);
+  }
   lua_pushnumber(L, hit->fraction);
-  return 9;
+  return 10;
 }
 
 static int luax_pushoverlapresult(lua_State* L, OverlapResult* hit) {

--- a/src/modules/physics/physics.h
+++ b/src/modules/physics/physics.h
@@ -57,6 +57,7 @@ typedef struct {
 typedef struct {
   Collider* collider;
   Shape* shape;
+  uint32_t triangle;
   float position[3];
   float normal[3];
   float fraction;
@@ -253,15 +254,17 @@ bool lovrCylinderShapeSetRadius(CylinderShape* shape, float radius);
 float lovrCylinderShapeGetLength(CylinderShape* shape);
 bool lovrCylinderShapeSetLength(CylinderShape* shape, float length);
 
-ConvexShape* lovrConvexShapeCreate(float points[], uint32_t count);
-ConvexShape* lovrConvexShapeClone(ConvexShape* parent);
+ConvexShape* lovrConvexShapeCreate(float points[], uint32_t count, float scale);
+ConvexShape* lovrConvexShapeClone(ConvexShape* parent, float scale);
 uint32_t lovrConvexShapeGetPointCount(ConvexShape* shape);
 bool lovrConvexShapeGetPoint(ConvexShape* shape, uint32_t index, float point[3]);
 uint32_t lovrConvexShapeGetFaceCount(ConvexShape* shape);
 uint32_t lovrConvexShapeGetFace(ConvexShape* shape, uint32_t index, uint32_t* pointIndices, uint32_t capacity);
+float lovrConvexShapeGetScale(ConvexShape* shape);
 
-MeshShape* lovrMeshShapeCreate(uint32_t vertexCount, float vertices[], uint32_t indexCount, uint32_t indices[]);
-MeshShape* lovrMeshShapeClone(MeshShape* parent);
+MeshShape* lovrMeshShapeCreate(uint32_t vertexCount, float vertices[], uint32_t indexCount, uint32_t indices[], float scale);
+MeshShape* lovrMeshShapeClone(MeshShape* parent, float scale);
+float lovrMeshShapeGetScale(MeshShape* shape);
 
 TerrainShape* lovrTerrainShapeCreate(float* vertices, uint32_t n, float scaleXZ, float scaleY);
 


### PR DESCRIPTION
- Fix bug where raycasting against a clone of a mesh/convex shape would return the parent shape (only when the collider had multiple shapes).
- MeshShape and ConvexShape constructors take an optional scale to apply to the mesh. Clones can have their own scale.  `ConvexShape:getPoint` does not currently apply the scale.
  - Add `MeshShape:getScale` and `ConvexShape:getScale`.
- `World:raycast` and `World:shapecast` return the index of the triangle that was hit (after the normal vector), or nil for non-mesh shapes.

Just waiting on a joltc change.