### PR TITLE
MX Ink Input

### DIFF
--- a/src/api/l_headset.c
+++ b/src/api/l_headset.c
@@ -53,6 +53,7 @@ StringEntry lovrDevice[] = {
   [DEVICE_FOOT_RIGHT] = ENTRY("foot/right"),
   [DEVICE_CAMERA] = ENTRY("camera"),
   [DEVICE_KEYBOARD] = ENTRY("keyboard"),
+  [DEVICE_STYLUS] = ENTRY("stylus"),
   [DEVICE_EYE_LEFT] = ENTRY("eye/left"),
   [DEVICE_EYE_RIGHT] = ENTRY("eye/right"),
   [DEVICE_EYE_GAZE] = ENTRY("eye/gaze"),
@@ -70,7 +71,7 @@ StringEntry lovrDeviceButton[] = {
   [BUTTON_B] = ENTRY("b"),
   [BUTTON_X] = ENTRY("x"),
   [BUTTON_Y] = ENTRY("y"),
-  [BUTTON_PROXIMITY] = ENTRY("proximity"),
+  [BUTTON_NIB] = ENTRY("nib"),
   { 0 }
 };
 
@@ -79,6 +80,7 @@ StringEntry lovrDeviceAxis[] = {
   [AXIS_THUMBSTICK] = ENTRY("thumbstick"),
   [AXIS_TOUCHPAD] = ENTRY("touchpad"),
   [AXIS_GRIP] = ENTRY("grip"),
+  [AXIS_NIB] = ENTRY("nib"),
   { 0 }
 };
 
@@ -512,7 +514,8 @@ static const int axisCounts[MAX_AXES] = {
   [AXIS_TRIGGER] = 1,
   [AXIS_THUMBSTICK] = 2,
   [AXIS_TOUCHPAD] = 2,
-  [AXIS_GRIP] = 1
+  [AXIS_GRIP] = 1,
+  [AXIS_NIB] = 1
 };
 
 static int l_lovrHeadsetGetAxis(lua_State* L) {

--- a/src/modules/headset/headset.h
+++ b/src/modules/headset/headset.h
@@ -94,6 +94,7 @@ typedef enum {
   DEVICE_FOOT_RIGHT,
   DEVICE_CAMERA,
   DEVICE_KEYBOARD,
+  DEVICE_STYLUS,
   DEVICE_EYE_LEFT,
   DEVICE_EYE_RIGHT,
   DEVICE_EYE_GAZE,
@@ -111,7 +112,7 @@ typedef enum {
   BUTTON_B,
   BUTTON_X,
   BUTTON_Y,
-  BUTTON_PROXIMITY,
+  BUTTON_NIB,
   MAX_BUTTONS
 } DeviceButton;
 
@@ -120,6 +121,7 @@ typedef enum {
   AXIS_THUMBSTICK,
   AXIS_TOUCHPAD,
   AXIS_GRIP,
+  AXIS_NIB,
   MAX_AXES
 } DeviceAxis;
 


### PR DESCRIPTION
This adds support for MX Ink, a tracked stylus that works with Quest.

- New Device: `stylus`
- New DeviceButton: `nib`
- New DeviceAxis: `nib`

MX Ink input mapping:

- `lovr.headset.getPose('stylus')` returns the pose of the tip
- `lovr.headset.isDown('stylus', 'nib')`: whether nib is pressed
- `lovr.headset.getAxis('stylus', 'nib')`: nib pressure
- `lovr.headset.isDown('stylus', 'grip')`: middle button
- `lovr.headset.getAxis('stylus', 'grip')`: middle button pressure
- `lovr.headset.isDown('stylus', 'a')`: front button
- `lovr.headset.isDown('stylus', 'b')`: back button
- `lovr.headset.vibrate('stylus', ...params)`: haptics

Issues:

- While the stylus is being used, the hand it's assigned to (hand/left or hand/right) will continue to report pose data as an emulated controller.  This may be undesirable.  Lua code doesn't know if a hand pose is being driven by a stylus.
- MX Ink behaves like a touch controller for apps that don't natively support it.  But because LÖVR supports MX Ink now, we lose out on that controller emulation (seems we still get poses, but no buttons).  It might be nice if LÖVR apps could still work with MX Ink even if they didn't explicitly add support for it.  So maybe this should be opt-in with a `t.headset.stylus` flag or something.

There was some OpenXR action cleanup as part of this work.  Now buttons/axes can be on any device instead of just hands.  Any device can have a haptic action now.  The trackpad/thumbstick axis actions were converted to vec2 actions instead of 2 float actions.  And the unused `proximity` button was removed.

Also naming is TBD.  `stylus` could be `pen`, `nib` could be `tip`.

Closes #815.