### PR TITLE
Fixed Foveated Rendering

### DIFF
--- a/etc/webxr.js
+++ b/etc/webxr.js
@@ -213,6 +213,15 @@ var webxr = {
     return 0; /* NULL */ // TODO
   },
 
+  webxr_getFoveation: function(level, dynamic) {
+    HEAPU32[level >> 0] = 0; /* FOVEATION_NONE */
+    HEAPU32[dynamic >> 0] = false;
+  },
+
+  webxr_setFoveation: function(level, dynamic) {
+    return level == 0; /* FOVEATION_NONE */
+  },
+
   webxr_getPassthrough: function() {
     return 0; /* PASSTHROUGH_OPAQUE */
   },

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -40,6 +40,7 @@ extern StringEntry lovrEffect[];
 extern StringEntry lovrEventType[];
 extern StringEntry lovrFileAction[];
 extern StringEntry lovrFilterMode[];
+extern StringEntry lovrFoveationLevel[];
 extern StringEntry lovrHeadsetDriver[];
 extern StringEntry lovrHorizontalAlign[];
 extern StringEntry lovrJointType[];

--- a/src/api/l_graphics_pass.c
+++ b/src/api/l_graphics_pass.c
@@ -40,8 +40,9 @@ static int l_lovrPassGetCanvas(lua_State* L) {
   CanvasTexture color[4];
   CanvasTexture depth;
   uint32_t depthFormat;
+  Texture* foveation;
   uint32_t samples;
-  lovrPassGetCanvas(pass, color, &depth, &depthFormat, &samples);
+  lovrPassGetCanvas(pass, color, &depth, &depthFormat, &foveation, &samples);
 
   if (!color[0].texture && !depth.texture) {
     lua_pushnil(L);
@@ -141,7 +142,7 @@ int l_lovrPassSetCanvas(lua_State* L) {
   } else if (!lua_isnoneornil(L, 2)) {
     luaL_error(L, "Expected Texture, table, or nil for canvas");
   }
-  luax_assert(L, lovrPassSetCanvas(pass, color, &depth, depthFormat, samples));
+  luax_assert(L, lovrPassSetCanvas(pass, color, &depth, depthFormat, NULL, samples));
   return 0;
 }
 

--- a/src/api/l_headset.c
+++ b/src/api/l_headset.c
@@ -21,6 +21,14 @@ StringEntry lovrControllerSkeletonMode[] = {
   { 0 }
 };
 
+StringEntry lovrFoveationLevel[] = {
+  [FOVEATION_NONE] = ENTRY("none"),
+  [FOVEATION_LOW] = ENTRY("low"),
+  [FOVEATION_MEDIUM] = ENTRY("medium"),
+  [FOVEATION_HIGH] = ENTRY("high"),
+  { 0 }
+};
+
 StringEntry lovrPassthroughMode[] = {
   [PASSTHROUGH_OPAQUE] = ENTRY("opaque"),
   [PASSTHROUGH_BLEND] = ENTRY("blend"),
@@ -216,6 +224,29 @@ static int l_lovrHeadsetGetRefreshRates(lua_State* L) {
   }
 
   return 1;
+}
+
+static int l_lovrHeadsetGetFoveation(lua_State* L) {
+  FoveationLevel level;
+  bool dynamic;
+  lovrHeadsetInterface->getFoveation(&level, &dynamic);
+  luax_pushenum(L, FoveationLevel, level);
+  lua_pushboolean(L, dynamic);
+  return 2;
+}
+
+static int l_lovrHeadsetSetFoveation(lua_State* L) {
+  if (lua_isnoneornil(L, 1)) {
+    bool success = lovrHeadsetInterface->setFoveation(FOVEATION_NONE, false);
+    lua_pushboolean(L, success);
+    return 1;
+  } else {
+    FoveationLevel level = luax_checkenum(L, 1, FoveationLevel, NULL);
+    bool dynamic = lua_isnoneornil(L, -1) ? true : lua_toboolean(L, 2);
+    bool success = lovrHeadsetInterface->setFoveation(level, dynamic);
+    lua_pushboolean(L, success);
+    return 1;
+  }
 }
 
 static int l_lovrHeadsetGetPassthrough(lua_State* L) {
@@ -895,6 +926,8 @@ static const luaL_Reg lovrHeadset[] = {
   { "getRefreshRate", l_lovrHeadsetGetRefreshRate },
   { "setRefreshRate", l_lovrHeadsetSetRefreshRate },
   { "getRefreshRates", l_lovrHeadsetGetRefreshRates },
+  { "getFoveation", l_lovrHeadsetGetFoveation },
+  { "setFoveation", l_lovrHeadsetSetFoveation },
   { "getPassthrough", l_lovrHeadsetGetPassthrough },
   { "setPassthrough", l_lovrHeadsetSetPassthrough },
   { "getPassthroughModes", l_lovrHeadsetGetPassthroughModes },

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -54,7 +54,8 @@ enum {
   GPU_TEXTURE_RENDER    = (1 << 1),
   GPU_TEXTURE_STORAGE   = (1 << 2),
   GPU_TEXTURE_COPY_SRC  = (1 << 3),
-  GPU_TEXTURE_COPY_DST  = (1 << 4)
+  GPU_TEXTURE_COPY_DST  = (1 << 4),
+  GPU_TEXTURE_FOVEATION = (1 << 5)
 };
 
 typedef enum {
@@ -348,6 +349,7 @@ typedef struct {
   uint32_t colorCount;
   uint32_t samples;
   uint32_t views;
+  bool foveated;
   bool surface;
 } gpu_pass_info;
 
@@ -579,6 +581,7 @@ typedef struct {
 typedef struct {
   gpu_color_attachment color[4];
   gpu_depth_attachment depth;
+  gpu_texture* foveation;
   gpu_pass* pass;
   uint32_t width;
   uint32_t height;
@@ -690,6 +693,7 @@ typedef struct {
   bool wireframe;
   bool depthClamp;
   bool depthResolve;
+  bool foveation;
   bool indirectDrawFirstInstance;
   bool packedBuffers;
   bool shaderDebug;

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -177,6 +177,7 @@ typedef struct {
   bool renderPass2;
   bool synchronization2;
   bool scalarBlockLayout;
+  bool foveation;
 } gpu_extensions;
 
 // State
@@ -486,6 +487,7 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
       ((info->usage & GPU_TEXTURE_STORAGE) ? VK_IMAGE_USAGE_STORAGE_BIT : 0) |
       ((info->usage & GPU_TEXTURE_COPY_SRC) ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : 0) |
       ((info->usage & GPU_TEXTURE_COPY_DST) ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0) |
+      ((info->usage & GPU_TEXTURE_FOVEATION) ? VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT : 0) |
       ((info->usage == GPU_TEXTURE_RENDER) ? VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT : 0) |
       (info->upload.levelCount > 0 ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0) |
       (info->upload.generateMipmaps ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : 0)
@@ -697,7 +699,8 @@ bool gpu_texture_init_view(gpu_texture* texture, gpu_texture_view_info* info) {
       ((info->usage & GPU_TEXTURE_SAMPLE) ? VK_IMAGE_USAGE_SAMPLED_BIT : 0) |
       (((info->usage & GPU_TEXTURE_RENDER) && texture->aspect == VK_IMAGE_ASPECT_COLOR_BIT) ? VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT : 0) |
       (((info->usage & GPU_TEXTURE_RENDER) && texture->aspect != VK_IMAGE_ASPECT_COLOR_BIT) ? VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT : 0) |
-      ((info->usage & GPU_TEXTURE_STORAGE) && !texture->srgb ? VK_IMAGE_USAGE_STORAGE_BIT : 0)
+      ((info->usage & GPU_TEXTURE_STORAGE) && !texture->srgb ? VK_IMAGE_USAGE_STORAGE_BIT : 0) |
+      ((info->usage & GPU_TEXTURE_FOVEATION) ? VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT : 0)
   };
 
   if (viewUsage.usage == 0) {
@@ -1413,6 +1416,18 @@ bool gpu_pass_init(gpu_pass* pass, gpu_pass_info* info) {
     }
   }
 
+  if (info->foveated) {
+    attachments[attachmentCount++] = (VkAttachmentDescription2) {
+      .sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2,
+      .format = VK_FORMAT_R8G8_UNORM,
+      .samples = VK_SAMPLE_COUNT_1_BIT,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
+      .storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+      .initialLayout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT,
+      .finalLayout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT
+    };
+  }
+
   uint32_t referenceCount = (info->colorCount << hasColorResolve) + (depth << info->depth.resolve);
 
   VkSubpassDescription2 subpass = {
@@ -1432,6 +1447,13 @@ bool gpu_pass_init(gpu_pass* pass, gpu_pass_info* info) {
 
   VkRenderPassCreateInfo2 createInfo = {
     .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2,
+    .pNext = info->foveated ? &(VkRenderPassFragmentDensityMapCreateInfoEXT) {
+      .sType = VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT,
+      .fragmentDensityMapAttachment = {
+        .attachment = attachmentCount - 1,
+        .layout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT
+      }
+    } : NULL,
     .attachmentCount = attachmentCount,
     .pAttachments = attachments,
     .subpassCount = 1,
@@ -1860,8 +1882,8 @@ void gpu_render_begin(gpu_stream* stream, gpu_canvas* canvas) {
 
   // Framebuffer
 
-  VkImageView images[10];
-  VkClearValue clears[10];
+  VkImageView images[11];
+  VkClearValue clears[11];
   uint32_t attachmentCount = 0;
 
   for (uint32_t i = 0; i < pass->colorCount; i++) {
@@ -1883,6 +1905,11 @@ void gpu_render_begin(gpu_stream* stream, gpu_canvas* canvas) {
     if (canvas->depth.resolve) {
       images[attachmentCount++] = canvas->depth.resolve->view;
     }
+  }
+
+  if (canvas->foveation) {
+    uint32_t index = attachmentCount++;
+    images[index] = canvas->foveation->view;
   }
 
   VkFramebufferCreateInfo info = {
@@ -2386,7 +2413,8 @@ bool gpu_init(gpu_config* config) {
       { "VK_KHR_shader_non_semantic_info", config->debug, &state.extensions.shaderDebug },
       { "VK_KHR_image_format_list", true, &state.extensions.formatList },
       { "VK_KHR_synchronization2", true, &state.extensions.synchronization2 },
-      { "VK_EXT_scalar_block_layout", true, &state.extensions.scalarBlockLayout }
+      { "VK_EXT_scalar_block_layout", true, &state.extensions.scalarBlockLayout },
+      { "VK_EXT_fragment_density_map", true, &state.extensions.foveation }
     };
 
     uint32_t extensionCount = 0;
@@ -2471,6 +2499,10 @@ bool gpu_init(gpu_config* config) {
 
     // Features
 
+    VkPhysicalDeviceFragmentDensityMapFeaturesEXT fragmentDensityMapFeatures = {
+      .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT
+    };
+
     VkPhysicalDeviceScalarBlockLayoutFeaturesEXT scalarBlockLayoutFeatures = {
       .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT
     };
@@ -2498,6 +2530,12 @@ bool gpu_init(gpu_config* config) {
       VkPhysicalDeviceFeatures2 features2 = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
       VkPhysicalDeviceFeatures* enable = &enabledFeatures.features;
       VkPhysicalDeviceFeatures* supports = &features2.features;
+
+      if (state.extensions.foveation) {
+        fragmentDensityMapFeatures.pNext = features2.pNext;
+        features2.pNext = &fragmentDensityMapFeatures;
+      }
+
       vkGetPhysicalDeviceFeatures2(state.adapter, &features2);
 
       // Required features
@@ -2535,6 +2573,14 @@ bool gpu_init(gpu_config* config) {
         scalarBlockLayoutFeatures.scalarBlockLayout = true;
         scalarBlockLayoutFeatures.pNext = enabledFeatures.pNext;
         enabledFeatures.pNext = &scalarBlockLayoutFeatures;
+      }
+
+      if (state.extensions.foveation && fragmentDensityMapFeatures.fragmentDensityMap) {
+        fragmentDensityMapFeatures.fragmentDensityMapDynamic = false;
+        fragmentDensityMapFeatures.fragmentDensityMapNonSubsampledImages = true;
+        fragmentDensityMapFeatures.pNext = enabledFeatures.pNext;
+        enabledFeatures.pNext = &fragmentDensityMapFeatures;
+        config->features->foveation = true;
       }
 
       // Formats

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -195,10 +195,11 @@ typedef enum {
 } TextureType;
 
 enum {
-  TEXTURE_SAMPLE   = (1 << 0),
-  TEXTURE_RENDER   = (1 << 1),
-  TEXTURE_STORAGE  = (1 << 2),
-  TEXTURE_TRANSFER = (1 << 3)
+  TEXTURE_SAMPLE    = (1 << 0),
+  TEXTURE_RENDER    = (1 << 1),
+  TEXTURE_STORAGE   = (1 << 2),
+  TEXTURE_TRANSFER  = (1 << 3),
+  TEXTURE_FOVEATION = (1 << 4)
 };
 
 typedef struct {
@@ -580,8 +581,8 @@ void lovrPassReset(Pass* pass);
 const PassStats* lovrPassGetStats(Pass* pass);
 const char* lovrPassGetLabel(Pass* pass);
 
-void lovrPassGetCanvas(Pass* pass, CanvasTexture color[4], CanvasTexture* depth, uint32_t* depthFormat, uint32_t* samples);
-bool lovrPassSetCanvas(Pass* pass, CanvasTexture color[4], CanvasTexture* depth, uint32_t depthFormat, uint32_t samples);
+void lovrPassGetCanvas(Pass* pass, CanvasTexture color[4], CanvasTexture* depth, uint32_t* depthFormat, Texture** foveation, uint32_t* samples);
+bool lovrPassSetCanvas(Pass* pass, CanvasTexture color[4], CanvasTexture* depth, uint32_t depthFormat, Texture* foveation, uint32_t samples);
 void lovrPassGetClear(Pass* pass, LoadAction loads[4], float clears[4][4], LoadAction* depthLoad, float* depthClear);
 bool lovrPassSetClear(Pass* pass, LoadAction loads[4], float clears[4][4], LoadAction depthLoad, float depthClear);
 uint32_t lovrPassGetAttachmentCount(Pass* pass, bool* depth);

--- a/src/modules/headset/headset.h
+++ b/src/modules/headset/headset.h
@@ -63,6 +63,13 @@ typedef struct {
 } HeadsetFeatures;
 
 typedef enum {
+  FOVEATION_NONE,
+  FOVEATION_LOW,
+  FOVEATION_MEDIUM,
+  FOVEATION_HIGH
+} FoveationLevel;
+
+typedef enum {
   PASSTHROUGH_OPAQUE,
   PASSTHROUGH_BLEND,
   PASSTHROUGH_ADD,
@@ -205,6 +212,8 @@ typedef struct HeadsetInterface {
   float (*getRefreshRate)(void);
   bool (*setRefreshRate)(float refreshRate);
   const float* (*getRefreshRates)(uint32_t* count);
+  void (*getFoveation)(FoveationLevel* level, bool* dynamic);
+  bool (*setFoveation)(FoveationLevel level, bool dynamic);
   PassthroughMode (*getPassthrough)(void);
   bool (*setPassthrough)(PassthroughMode mode);
   bool (*isPassthroughSupported)(PassthroughMode mode);

--- a/src/modules/headset/headset_simulator.c
+++ b/src/modules/headset/headset_simulator.c
@@ -191,6 +191,15 @@ static const float* simulator_getRefreshRates(uint32_t* count) {
   return *count = 0, NULL;
 }
 
+static void simulator_getFoveation(FoveationLevel* level, bool* dynamic) {
+  *level = FOVEATION_NONE;
+  *dynamic = false;
+}
+
+static bool simulator_setFoveation(FoveationLevel level, bool dynamic) {
+  return level == FOVEATION_NONE;
+}
+
 static PassthroughMode simulator_getPassthrough(void) {
   return PASSTHROUGH_OPAQUE;
 }
@@ -451,7 +460,7 @@ static bool simulator_getPass(Pass** pass) {
     }
 
     CanvasTexture color[4] = { [0].texture = state.texture };
-    if (!lovrPassSetCanvas(state.pass, color, NULL, state.depthFormat, state.config.antialias ? 4 : 1)) {
+    if (!lovrPassSetCanvas(state.pass, color, NULL, state.depthFormat, NULL, state.config.antialias ? 4 : 1)) {
       return false;
     }
   }
@@ -606,6 +615,8 @@ HeadsetInterface lovrHeadsetSimulatorDriver = {
   .getRefreshRate = simulator_getRefreshRate,
   .setRefreshRate = simulator_setRefreshRate,
   .getRefreshRates = simulator_getRefreshRates,
+  .getFoveation = simulator_getFoveation,
+  .setFoveation = simulator_setFoveation,
   .getPassthrough = simulator_getPassthrough,
   .setPassthrough = simulator_setPassthrough,
   .isPassthroughSupported = simulator_isPassthroughSupported,

--- a/src/modules/headset/headset_webxr.c
+++ b/src/modules/headset/headset_webxr.c
@@ -12,6 +12,8 @@ extern void webxr_getDisplayDimensions(uint32_t* width, uint32_t* height);
 extern float webxr_getRefreshRate(void);
 extern bool webxr_setRefreshRate(float refreshRate);
 extern const float* webxr_getRefreshRates(uint32_t* count);
+extern void webxr_getFoveation(FoveationLevel* level, bool* dynamic);
+extern bool webxr_setFoveation(FoveationLevel level, bool dynamic);
 PassthroughMode webxr_getPassthrough(void);
 extern bool webxr_setPassthrough(PassthroughMode mode);
 extern bool webxr_isPassthroughSupported(PassthroughMode mode);


### PR DESCRIPTION
This adds support for fixed foveated rendering!  It runs pixel shaders at a lower rate around the edges of the canvas to make things run faster.  It does make the edges a little blocky/blurry, but it often isn't very noticeable due to lens distortion and eyes.  So far this is only supported on Quest/Pico.

The API is one function:

```lua
lovr.headset.setFoveation(level, dynamic)
```

- `level` is the foveation level you want: `low`, `medium`, or `high`.  Use `nil` to disable foveation.
- `dynamic` is a boolean indicating whether the system is allowed to adjust the foveation level based on GPU load, and defaults to true.  This treats the `level` as a maximum allowed foveation level.

This was just a quick experiment, I'm not totally happy with the code yet.  But it works!