### PR TITLE
Window Focus/Visible Events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ dev
 - Add `t.headset.debug` to enable additional messages from the VR runtime.
 - Add `lovr.headset.getFeatures`.
 - Add `Model:resetBlendShapes`.
+- Add `lovr.system.isWindowVisible` and `lovr.system.isWindowFocused`.
 - Add `lovr.system.wasMousePressed` and `lovr.system.wasMouseReleased`.
 - Add `lovr.system.get/setClipboardText`.
 - Add `KeyCode`s for numpad keys.
@@ -120,6 +121,8 @@ dev
 - Change `Image:get/set/mapPixel` to support `r16f`, `rg16f`, and `rgba16f`.
 - Change `Image:getPixel` to return 1 for alpha when the format doesn't have an alpha component.
 - Change stack size of `state` stack (used with `Pass:push/pop`) from 4 to 8.
+- Change `lovr.focus` and `lovr.visible` to also get called for window events.
+- Change `lovr.focus` and `lovr.visible` to have an extra parameter for the display type.
 
 ### Fix
 

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -34,6 +34,7 @@ extern StringEntry lovrDefaultShader[];
 extern StringEntry lovrDevice[];
 extern StringEntry lovrDeviceAxis[];
 extern StringEntry lovrDeviceButton[];
+extern StringEntry lovrDisplayType[];
 extern StringEntry lovrDrawMode[];
 extern StringEntry lovrDrawStyle[];
 extern StringEntry lovrEffect[];

--- a/src/api/l_event.c
+++ b/src/api/l_event.c
@@ -6,6 +6,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+StringEntry lovrDisplayType[] = {
+  [DISPLAY_HEADSET] = ENTRY("headset"),
+  [DISPLAY_WINDOW] = ENTRY("window"),
+  { 0 }
+};
+
 StringEntry lovrEventType[] = {
   [EVENT_QUIT] = ENTRY("quit"),
   [EVENT_RESTART] = ENTRY("restart"),
@@ -198,15 +204,17 @@ static int nextEvent(lua_State* L) {
       return 2;
 
     case EVENT_VISIBLE:
-      lua_pushboolean(L, event.data.boolean.value);
-      return 2;
+      lua_pushboolean(L, event.data.visible.visible);
+      luax_pushenum(L, DisplayType, event.data.visible.display);
+      return 3;
 
     case EVENT_FOCUS:
-      lua_pushboolean(L, event.data.boolean.value);
-      return 2;
+      lua_pushboolean(L, event.data.focus.focused);
+      luax_pushenum(L, DisplayType, event.data.focus.display);
+      return 3;
 
     case EVENT_MOUNT:
-      lua_pushboolean(L, event.data.boolean.value);
+      lua_pushboolean(L, event.data.mount.mounted);
       return 2;
 
     case EVENT_RECENTER:

--- a/src/api/l_system.c
+++ b/src/api/l_system.c
@@ -185,6 +185,18 @@ static int l_lovrSystemIsWindowOpen(lua_State* L) {
   return 1;
 }
 
+static int l_lovrSystemIsWindowVisible(lua_State* L) {
+  bool visible = lovrSystemIsWindowVisible();
+  lua_pushboolean(L, visible);
+  return 1;
+}
+
+static int l_lovrSystemIsWindowFocused(lua_State* L) {
+  bool focused = lovrSystemIsWindowFocused();
+  lua_pushboolean(L, focused);
+  return 1;
+}
+
 static int l_lovrSystemGetWindowWidth(lua_State* L) {
   uint32_t width, height;
   lovrSystemGetWindowSize(&width, &height);
@@ -329,6 +341,8 @@ static const luaL_Reg lovrSystem[] = {
   { "requestPermission", l_lovrSystemRequestPermission },
   { "openWindow", l_lovrSystemOpenWindow },
   { "isWindowOpen", l_lovrSystemIsWindowOpen },
+  { "isWindowVisible", l_lovrSystemIsWindowVisible },
+  { "isWindowFocused", l_lovrSystemIsWindowFocused },
   { "getWindowWidth", l_lovrSystemGetWindowWidth },
   { "getWindowHeight", l_lovrSystemGetWindowHeight },
   { "getWindowDimensions", l_lovrSystemGetWindowDimensions },

--- a/src/core/os.h
+++ b/src/core/os.h
@@ -143,6 +143,7 @@ typedef enum {
 } os_permission;
 
 typedef void fn_quit(void);
+typedef void fn_visible(bool visible);
 typedef void fn_focus(bool focused);
 typedef void fn_resize(uint32_t width, uint32_t height);
 typedef void fn_key(os_button_action action, os_key key, uint32_t scancode, bool repeat);
@@ -173,6 +174,7 @@ void os_thread_detach(void);
 
 void os_poll_events(void);
 void os_on_quit(fn_quit* callback);
+void os_on_visible(fn_visible* callback);
 void os_on_focus(fn_focus* callback);
 void os_on_resize(fn_resize* callback);
 void os_on_key(fn_key* callback);
@@ -184,6 +186,8 @@ void os_on_permission(fn_permission* callback);
 
 bool os_window_open(const os_window_config* config);
 bool os_window_is_open(void);
+bool os_window_is_visible(void);
+bool os_window_is_focused(void);
 void os_window_get_size(uint32_t* width, uint32_t* height);
 float os_window_get_pixel_density(void);
 void os_window_message_box(const char* message);

--- a/src/core/os_android.c
+++ b/src/core/os_android.c
@@ -318,6 +318,10 @@ void os_on_quit(fn_quit* callback) {
   state.onQuit = callback;
 }
 
+void os_on_visible(fn_visible* callback) {
+  //
+}
+
 void os_on_focus(fn_focus* callback) {
   //
 }

--- a/src/core/os_android.c
+++ b/src/core/os_android.c
@@ -358,6 +358,14 @@ bool os_window_is_open(void) {
   return false;
 }
 
+bool os_window_is_visible(void) {
+  return false;
+}
+
+bool os_window_is_focused(void) {
+  return false;
+}
+
 void os_window_get_size(uint32_t* width, uint32_t* height) {
   *width = *height = 0;
 }

--- a/src/core/os_glfw.h
+++ b/src/core/os_glfw.h
@@ -131,7 +131,7 @@ uintptr_t os_get_xcb_window(void) {
 static struct {
   GLFWwindow* window;
   fn_quit* onQuitRequest;
-  fn_focus* onWindowVisible;
+  fn_visible* onWindowVisible;
   fn_focus* onWindowFocus;
   fn_resize* onWindowResize;
   fn_key* onKeyboardEvent;

--- a/src/core/os_glfw.h
+++ b/src/core/os_glfw.h
@@ -20,6 +20,14 @@ bool os_window_is_open(void) {
   return false;
 }
 
+bool os_window_is_visible(void) {
+  return false;
+}
+
+bool os_window_is_focused(void) {
+  return false;
+}
+
 void os_window_get_size(uint32_t* width, uint32_t* height) {
   *width = *height = 0;
 }
@@ -123,6 +131,7 @@ uintptr_t os_get_xcb_window(void) {
 static struct {
   GLFWwindow* window;
   fn_quit* onQuitRequest;
+  fn_focus* onWindowVisible;
   fn_focus* onWindowFocus;
   fn_resize* onWindowResize;
   fn_key* onKeyboardEvent;
@@ -141,6 +150,12 @@ static void onError(int code, const char* description) {
 static void onWindowClose(GLFWwindow* window) {
   if (glfwState.onQuitRequest) {
     glfwState.onQuitRequest();
+  }
+}
+
+static void onWindowVisible(GLFWwindow* window, int minimized) {
+  if (glfwState.onWindowVisible) {
+    glfwState.onWindowVisible(!minimized);
   }
 }
 
@@ -390,6 +405,7 @@ bool os_window_open(const os_window_config* config) {
   }
 
   glfwSetWindowCloseCallback(glfwState.window, onWindowClose);
+  glfwSetWindowIconifyCallback(glfwState.window, onWindowVisible);
   glfwSetWindowFocusCallback(glfwState.window, onWindowFocus);
   glfwSetWindowSizeCallback(glfwState.window, onWindowResize);
   glfwSetKeyCallback(glfwState.window, onKeyboardEvent);
@@ -404,6 +420,14 @@ bool os_window_open(const os_window_config* config) {
 
 bool os_window_is_open(void) {
   return glfwState.window;
+}
+
+bool os_window_is_visible(void) {
+  return !glfwGetWindowAttrib(glfwState.window, GLFW_ICONIFIED);
+}
+
+bool os_window_is_focused(void) {
+  return glfwGetWindowAttrib(glfwState.window, GLFW_FOCUSED);
 }
 
 void os_window_get_size(uint32_t* width, uint32_t* height) {
@@ -424,6 +448,10 @@ float os_window_get_pixel_density(void) {
 
 void os_on_quit(fn_quit* callback) {
   glfwState.onQuitRequest = callback;
+}
+
+void os_on_visible(fn_focus* callback) {
+  glfwState.onWindowVisible = callback;
 }
 
 void os_on_focus(fn_focus* callback) {

--- a/src/modules/event/event.h
+++ b/src/modules/event/event.h
@@ -10,6 +10,11 @@ struct Thread;
 struct Variant;
 
 typedef enum {
+  DISPLAY_HEADSET,
+  DISPLAY_WINDOW
+} DisplayType;
+
+typedef enum {
   EVENT_QUIT,
   EVENT_RESTART,
   EVENT_VISIBLE,
@@ -86,8 +91,18 @@ typedef struct {
 } QuitEvent;
 
 typedef struct {
-  bool value;
-} BoolEvent;
+  bool visible;
+  DisplayType display;
+} VisibleEvent;
+
+typedef struct {
+  bool focused;
+  DisplayType display;
+} FocusEvent;
+
+typedef struct {
+  bool mounted;
+} MountEvent;
 
 typedef struct {
   uint32_t width;
@@ -142,7 +157,9 @@ typedef struct {
 
 typedef union {
   QuitEvent quit;
-  BoolEvent boolean;
+  VisibleEvent visible;
+  FocusEvent focus;
+  MountEvent mount;
   ResizeEvent resize;
   KeyEvent key;
   TextEvent text;

--- a/src/modules/headset/headset_openxr.c
+++ b/src/modules/headset/headset_openxr.c
@@ -3752,13 +3752,17 @@ static bool openxr_update(double* dt) {
         bool wasVisible = state.sessionState >= XR_SESSION_STATE_VISIBLE;
         bool isVisible = event->state >= XR_SESSION_STATE_VISIBLE;
         if (wasVisible != isVisible) {
-          lovrEventPush((Event) { .type = EVENT_VISIBLE, .data.boolean.value = isVisible });
+          lovrEventPush((Event) { .type = EVENT_VISIBLE, .data.visible.visible = isVisible });
         }
 
         bool wasFocused = state.sessionState == XR_SESSION_STATE_FOCUSED;
         bool isFocused = event->state == XR_SESSION_STATE_FOCUSED;
         if (wasFocused != isFocused) {
-          lovrEventPush((Event) { .type = EVENT_FOCUS, .data.boolean.value = isFocused });
+          lovrEventPush((Event) {
+            .type = EVENT_FOCUS,
+            .data.focus.focused = isFocused,
+            .data.focus.display = DISPLAY_HEADSET
+          });
         }
 
         state.sessionState = event->state;
@@ -3780,7 +3784,7 @@ static bool openxr_update(double* dt) {
       case XR_TYPE_EVENT_DATA_USER_PRESENCE_CHANGED_EXT: {
         XrEventDataUserPresenceChangedEXT* event = (XrEventDataUserPresenceChangedEXT*) &e;
         state.mounted = event->isUserPresent;
-        lovrEventPush((Event) { .type = EVENT_MOUNT, .data.boolean.value = state.mounted });
+        lovrEventPush((Event) { .type = EVENT_MOUNT, .data.mount.mounted = state.mounted });
         break;
       }
       default: break;

--- a/src/modules/headset/headset_simulator.c
+++ b/src/modules/headset/headset_simulator.c
@@ -65,11 +65,6 @@ static struct {
   float clipFar;
 } state;
 
-static void onFocus(bool focused) {
-  state.focused = focused;
-  lovrEventPush((Event) { .type = EVENT_FOCUS, .data.boolean = { focused } });
-}
-
 static bool simulator_init(HeadsetConfig* config) {
   state.config = *config;
   state.clipNear = .01f;
@@ -84,8 +79,7 @@ static bool simulator_init(HeadsetConfig* config) {
     state.initialized = true;
   }
 
-  state.focused = true;
-  os_on_focus(onFocus);
+  state.focused = os_window_is_focused();
 
   return true;
 }
@@ -500,7 +494,7 @@ static bool simulator_isVisible(void) {
 }
 
 static bool simulator_isFocused(void) {
-  return state.focused;
+  return os_window_is_focused();
 }
 
 static bool simulator_isMounted(void) {
@@ -511,6 +505,15 @@ static bool simulator_update(double* dt) {
   if (!state.active) {
     *dt = 0.;
     return true;
+  }
+
+  if (os_window_is_focused() != state.focused) {
+    state.focused = !state.focused;
+    lovrEventPush((Event) {
+      .type = EVENT_FOCUS,
+      .data.focus.focused = state.focused,
+      .data.focus.display = DISPLAY_HEADSET
+    });
   }
 
   double t = os_get_time() - state.epoch;

--- a/src/modules/system/system.c
+++ b/src/modules/system/system.c
@@ -84,6 +84,22 @@ static void onQuit(void) {
   });
 }
 
+static void onVisible(bool visible) {
+  lovrEventPush((Event) {
+    .type = EVENT_VISIBLE,
+    .data.visible.visible = visible,
+    .data.visible.display = DISPLAY_WINDOW
+  });
+}
+
+static void onFocus(bool focused) {
+  lovrEventPush((Event) {
+    .type = EVENT_FOCUS,
+    .data.focus.focused = focused,
+    .data.focus.display = DISPLAY_WINDOW
+  });
+}
+
 bool lovrSystemInit(void) {
   if (atomic_fetch_add(&state.ref, 1)) return false;
   os_on_key(onKey);
@@ -123,11 +139,21 @@ void lovrSystemRequestPermission(Permission permission) {
 bool lovrSystemOpenWindow(os_window_config* window) {
   lovrAssert(os_window_open(window), "Could not open window");
   os_on_quit(onQuit);
+  os_on_visible(onVisible);
+  os_on_focus(onFocus);
   return true;
 }
 
 bool lovrSystemIsWindowOpen(void) {
   return os_window_is_open();
+}
+
+bool lovrSystemIsWindowVisible(void) {
+  return os_window_is_visible();
+}
+
+bool lovrSystemIsWindowFocused(void) {
+  return os_window_is_focused();
 }
 
 void lovrSystemGetWindowSize(uint32_t* width, uint32_t* height) {

--- a/src/modules/system/system.h
+++ b/src/modules/system/system.h
@@ -17,6 +17,8 @@ void lovrSystemOpenConsole(void);
 void lovrSystemRequestPermission(Permission permission);
 bool lovrSystemOpenWindow(struct os_window_config* config);
 bool lovrSystemIsWindowOpen(void);
+bool lovrSystemIsWindowVisible(void);
+bool lovrSystemIsWindowFocused(void);
 void lovrSystemGetWindowSize(uint32_t* width, uint32_t* height);
 float lovrSystemGetWindowDensity(void);
 void lovrSystemPollEvents(void);


### PR DESCRIPTION
- `lovr.focus` and `lovr.visible` are also called for the desktop window now.  They have a second parameter, `display`, indicating whether the event came from the `headset` or the `window`.
- Add `lovr.system.isWindowVisible` and `lovr.system.isWindowFocused`.

Minor TODO: simulator could emit visible and mounted events.