### PR TITLE
Better Plugin Errors

### DIFF
--- a/src/api/l_filesystem.c
+++ b/src/api/l_filesystem.c
@@ -507,6 +507,7 @@ static int libLoaderCommon(lua_State* L, bool allInOneFlag) {
   memcpy(p, subpath, subpathLength);
   length += subpathLength;
   p += subpathLength;
+  char* leaf = p;
 #else
   size_t length = lovrFilesystemGetExecutablePath(path, sizeof(path));
   if (length == 0) {


### PR DESCRIPTION
Not sure if this is a good idea, but currently when you try to require plugins and they aren't packaged right, they are pretty much silently skipped, and you'll just get a regular "module not found" error without any extra info.

Specifically, `package.loadlib` returns nil plus an error message and we don't do anything with that error message.  We could return that error message from the lovr.filesystem searcher, which would look like this on Android:

```
main.lua:1: module 'mylib' not found:
	no field package.preload['mylib']
	failed to load plugin: dlopen failed: cannot locate symbol "lua_pushinteger" referenced by "/data/app/~~bFAnAwWdtkqkrPaReQBFsg==/org.lovr.app-luJnKjeMqIXUMbxDRw8vPw==/base.apk!/lib/arm64-v8a/mylib.so"...
	failed to load all-in-one plugin: dlopen failed: cannot locate symbol "lua_pushinteger" referenced by "/data/app/~~bFAnAwWdtkqkrPaReQBFsg==/org.lovr.app-luJnKjeMqIXUMbxDRw8vPw==/base.apk!/lib/arm64-v8a/mylib.so"...
	no file './mylib.lua'
	no file '/usr/local/share/luajit-2.1.0-beta3/mylib.lua'
	no file '/usr/local/share/lua/5.1/mylib.lua'
	no file '/usr/local/share/lua/5.1/mylib/init.lua'
	no file './mylib.so'
	no file '/usr/local/lib/lua/5.1/mylib.so'
	no file '/usr/local/lib/lua/5.1/loadall.so'
```

Here we can see that the plugin failed to load because `lua_pushinteger` is missing, maybe the plugin failed to link against the Lua library when it was compiled.

It basically takes the `dlerror` error message returned by `package.loadlib` and includes it like all of the other failure messages.  They are kind of noisy though, maybe it should just say "failed to load plugin from luaopen_mylib in mylib.so" and log the full error instead?

> Note: There are already some ways to get extended library errors today.  On Linux you can use LD_DEBUG and on Android you can do `db shell setprop debug.ld.all dlerror,dlopen`.  It's easy to forget that these options exist though, and they require hunting through logs.