### PR TITLE
HDR

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -27,6 +27,7 @@ local conf = {
     vsync = true,
     stencil = false,
     antialias = true,
+    hdr = false,
     shadercache = true
   },
   headset = {

--- a/etc/shaders/lovr.glsl
+++ b/etc/shaders/lovr.glsl
@@ -448,6 +448,58 @@ vec3 linearToGamma(vec3 color) {
   return mix(1.055 * pow(color, vec3(1. / 2.4)) - .055, color * 12.92, lessThanEqual(color, vec3(.0031308)));
 }
 
+vec3 pqToLinear(vec3 color) {
+  float c1 = .835975;
+  float c2 = 18.8515625;
+  float c3 = 18.6875;
+  float m1 = .1593017578125;
+  float m2 = 78.84375;
+  vec3 em2 = pow(color, vec3(1. / m2));
+  return pow(max(em2 - c1, 0.) / (c2 - c3 * em2), vec3(1. / m1));
+}
+
+vec3 linearToPQ(vec3 color) {
+  float c1 = .835975;
+  float c2 = 18.8515625;
+  float c3 = 18.6875;
+  float m1 = .1593017578125;
+  float m2 = 78.84375;
+  vec3 ym1 = pow(color, vec3(m1));
+  return pow((c1 + c2 * ym1) / (1. + c3 * ym1), vec3(m2));
+}
+
+vec3 sRGBToRec2020(vec3 color) {
+  mat3 xyz_from_srgb = transpose(mat3(
+    vec3(0.4123908, 0.3575843, 0.1804808),
+    vec3(0.2126390, 0.7151687, 0.0721923),
+    vec3(0.0193308, 0.1191948, 0.9505322)
+  ));
+
+  mat3 rec2020_from_xyz = transpose(mat3(
+    vec3( 1.7166512, -0.3556708, -0.2533663),
+    vec3(-0.6666844,  1.6164812,  0.0157685),
+    vec3( 0.0176399, -0.0427706,  0.9421031)
+  ));
+
+  return rec2020_from_xyz * xyz_from_srgb * color;
+}
+
+vec3 rec2020ToSRGB(vec3 color) {
+  mat3 xyz_from_rec2020 = transpose(mat3(
+    vec3(0.6369580, 0.1446169, 0.1688810),
+    vec3(0.2627002, 0.6779981, 0.0593017),
+    vec3(0.0000000, 0.0280727, 1.0609851)
+  ));
+
+  mat3 srgb_from_xyz = transpose(mat3(
+    vec3( 3.2409699, -1.5373832, -0.4986108),
+    vec3(-0.9692436,  1.8759675,  0.0415551),
+    vec3( 0.0556301, -0.2039770,  1.0569715)
+  ));
+
+  return srgb_from_xyz * xyz_from_rec2020 * color;
+}
+
 uint packSnorm10x3(vec4 v) {
   return
     ((int(v.x * 511.) & 0x3ff) <<  0) |

--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -325,7 +325,8 @@ static int l_lovrGraphicsInitialize(lua_State* L) {
     .debug = false,
     .vsync = false,
     .stencil = false,
-    .antialias = true
+    .antialias = true,
+    .hdr = false
   };
 
   bool shaderCache = true;
@@ -347,6 +348,10 @@ static int l_lovrGraphicsInitialize(lua_State* L) {
 
     lua_getfield(L, -1, "antialias");
     config.antialias = lua_toboolean(L, -1);
+    lua_pop(L, 1);
+
+    lua_getfield(L, -1, "hdr");
+    config.hdr = lua_toboolean(L, -1);
     lua_pop(L, 1);
 
     lua_getfield(L, -1, "shadercache");
@@ -529,6 +534,12 @@ static int l_lovrGraphicsIsFormatSupported(lua_State* L) {
   lua_pushboolean(L, support & (1 << 0)); // linear
   lua_pushboolean(L, support & (1 << 1)); // srgb
   return 2;
+}
+
+static int l_lovrGraphicsIsHDR(lua_State* L) {
+  bool hdr = lovrGraphicsIsHDR();
+  lua_pushboolean(L, hdr);
+  return 1;
 }
 
 static int l_lovrGraphicsGetBackgroundColor(lua_State* L) {
@@ -1541,6 +1552,7 @@ static const luaL_Reg lovrGraphics[] = {
   { "getFeatures", l_lovrGraphicsGetFeatures },
   { "getLimits", l_lovrGraphicsGetLimits },
   { "isFormatSupported", l_lovrGraphicsIsFormatSupported },
+  { "isHDR", l_lovrGraphicsIsHDR },
   { "getBackgroundColor", l_lovrGraphicsGetBackgroundColor },
   { "setBackgroundColor", l_lovrGraphicsSetBackgroundColor },
   { "getWindowPass", l_lovrGraphicsGetWindowPass },

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -163,6 +163,7 @@ typedef struct {
   uint32_t width;
   uint32_t height;
   bool vsync;
+  bool hdr;
   union {
     struct {
       uintptr_t window;
@@ -180,6 +181,7 @@ typedef struct {
 
 bool gpu_surface_init(gpu_surface_info* info);
 gpu_texture_format gpu_surface_get_format(void);
+bool gpu_surface_is_hdr(void);
 bool gpu_surface_resize(uint32_t width, uint32_t height);
 bool gpu_surface_acquire(gpu_texture** texture);
 bool gpu_surface_present(void);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -1024,6 +1024,11 @@ void lovrGraphicsGetShaderCache(void* data, size_t* size) {
   gpu_pipeline_get_cache(data, size);
 }
 
+bool lovrGraphicsIsHDR(void) {
+  Texture* texture = NULL;
+  return lovrGraphicsGetWindowTexture(&texture) && gpu_surface_is_hdr();
+}
+
 void lovrGraphicsGetBackgroundColor(float background[4]) {
   background[0] = lovrMathLinearToGamma(state.background[0]);
   background[1] = lovrMathLinearToGamma(state.background[1]);
@@ -2262,6 +2267,7 @@ bool lovrGraphicsGetWindowTexture(Texture** texture) {
       .width = width,
       .height = height,
       .vsync = vsync,
+      .hdr = state.config.hdr,
 #if defined(_WIN32)
       .win32.window = os_get_win32_window(),
       .win32.instance = os_get_win32_instance()

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -25,6 +25,7 @@ typedef struct {
   bool vsync;
   bool stencil;
   bool antialias;
+  bool hdr;
   void* cacheData;
   size_t cacheSize;
 } GraphicsConfig;
@@ -100,6 +101,8 @@ void lovrGraphicsGetFeatures(GraphicsFeatures* features);
 void lovrGraphicsGetLimits(GraphicsLimits* limits);
 uint32_t lovrGraphicsGetFormatSupport(uint32_t format, uint32_t features);
 void lovrGraphicsGetShaderCache(void* data, size_t* size);
+
+bool lovrGraphicsIsHDR(void);
 
 void lovrGraphicsGetBackgroundColor(float background[4]);
 void lovrGraphicsSetBackgroundColor(float background[4]);


### PR DESCRIPTION
Adds extremely experimental support for HDR window output.

- Add `t.graphics.hdr` to request an HDR window (`rgb10a2`, rec2020/pq colorspace).
- Use `lovr.graphics.isHDR` to figure out if HDR is active (supported and enabled).
- For now, it's up to you to output reasonable colors to the window, but there are `sRGBToRec2020` and `linearToPQ` shader helpers to make it a bit easier.

Please try it and leave feedback.  I've been messing with the PBR example and I can get something vaguely HDR-looking but it still looks pretty awful (lack of HDR tonemapping?  lack of HDR metadata? lack of decent monitor?).