### PR TITLE
Fix OBJ texture Y direction inversion (#841)

### DIFF
--- a/src/modules/data/modelData_obj.c
+++ b/src/modules/data/modelData_obj.c
@@ -54,7 +54,7 @@ static bool parseMtl(char* path, char* base, ModelDataIO* io, arr_image_t* image
         .color = { 1.f, 1.f, 1.f, 1.f },
         .glow = { 0.f, 0.f, 0.f, 1.f },
         .uvShift = { 0.f, 1.f },
-        .uvScale = { 1.f, -1.f },
+        .uvScale = { 1.f, 1.f },
         .metalness = 1.f,
         .roughness = 1.f,
         .clearcoat = 0.f,
@@ -207,7 +207,7 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
       float vt[2];
       char* s = line + 3;
       vt[0] = strtof(s, &s);
-      vt[1] = strtof(s, &s);
+      vt[1] = 1.0f - strtof(s, &s);
       arr_append(&uvs, vt, 2);
     } else if (line[0] == 'f' && line[1] == ' ') {
       char* s = line + 2;


### PR DESCRIPTION
## **Fix OBJ Texture Y Direction Inversion**  

- Fixes the Y texture coordinate inversion for OBJ models.  
- Closes #841.  

## **Reproducing the Issue**  
The issue was reproduced by importing an OBJ model **without materials** using `{ materials = false }`. This caused the texture to appear **inverted in the Y direction**:  

### Importing without mat
![Importing without mat](https://github.com/user-attachments/assets/fa8134d8-92bf-4d4f-93b5-e6ddcb651547)

### Fix Implementation
The fix was applied directly in the `lovrModelDataInitObj(...)` function, ensuring the Y coordinate inversion is handled at the vertex level, rather than relying on material properties.

#### After changes imported without materials again
![Screenshot from 2025-03-08 21-37-33](https://github.com/user-attachments/assets/c10440d5-b57c-4c1d-9c4a-70bbebceae38)

#### After changes imported with materials
![Screenshot from 2025-03-08 21-38-36](https://github.com/user-attachments/assets/9faab48e-3eec-4279-8985-38a4e119f478)
