### PR TITLE
More general vulkan loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,6 @@ target_include_directories(lovr PRIVATE
 )
 
 target_link_directories(lovr PRIVATE
-  ${LOVR_LUA_LIBDIR}
   ${LOVR_VULKAN_LIBDIR}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,8 +210,8 @@ if(LOVR_USE_VULKAN)
 
   if(LOVR_LINK_VULKAN)
     pkg_search_module(VULKAN REQUIRED vulkan)
-    target_link_directories(lovr ${VULKAN_LIBRARY_DIRS})
-    target_link_libraries(lovr ${VULKAN_LIBRARIES})
+    set(LOVR_VULKAN_LIBDIR ${VULKAN_LIBRARY_DIRS})
+    set(LOVR_VULKAN ${VULKAN_LIBRARIES})
   endif()
 endif()
 
@@ -346,6 +346,11 @@ target_include_directories(lovr PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/etc
 )
 
+target_link_directories(lovr PRIVATE
+  ${LOVR_LUA_LIBDIR}
+  ${LOVR_VULKAN_LIBDIR}
+)
+
 target_link_libraries(lovr
   ${LOVR_GLFW}
   ${LOVR_LUA}
@@ -355,6 +360,7 @@ target_link_libraries(lovr
   ${LOVR_OPENXR}
   ${LOVR_OCULUS_AUDIO}
   ${LOVR_PTHREADS}
+  ${LOVR_VULKAN}
   ${EMSCRIPTEN_LINKER_FLAGS}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,10 +344,6 @@ target_include_directories(lovr PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/etc
 )
 
-target_link_directories(lovr PRIVATE
-  ${LOVR_VULKAN_LIBDIR}
-)
-
 target_link_libraries(lovr
   ${LOVR_GLFW}
   ${LOVR_LUA}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ option(LOVR_BUILD_SHARED "Build a shared library (takes precedence over LOVR_BUI
 option(LOVR_BUILD_BUNDLE "On macOS, build a .app bundle instead of a raw program" OFF)
 option(LOVR_BUILD_WITH_SYMBOLS "Build with C function symbols exposed" OFF)
 
+option(LOVR_LINK_VULKAN "Links vulkan with lovr bypassing the libvulkan search" OFF)
+
 # Setup
 if(EMSCRIPTEN)
   string(CONCAT EMSCRIPTEN_LINKER_FLAGS
@@ -205,6 +207,12 @@ endif()
 # Vulkan
 if(LOVR_USE_VULKAN)
   list(APPEND LOVR_INCLUDES deps/vulkan-headers/include)
+
+  if(LOVR_LINK_VULKAN)
+    pkg_search_module(VULKAN REQUIRED vulkan)
+    target_link_directories(lovr ${VULKAN_LIBRARY_DIRS})
+    target_link_libraries(lovr ${VULKAN_LIBRARIES})
+  endif()
 endif()
 
 # OpenXR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,9 +209,7 @@ if(LOVR_USE_VULKAN)
   list(APPEND LOVR_INCLUDES deps/vulkan-headers/include)
 
   if(LOVR_LINK_VULKAN)
-    pkg_search_module(VULKAN REQUIRED vulkan)
-    set(LOVR_VULKAN_LIBDIR ${VULKAN_LIBRARY_DIRS})
-    set(LOVR_VULKAN ${VULKAN_LIBRARIES})
+    find_package(Vulkan REQUIRED)
   endif()
 endif()
 
@@ -359,9 +357,12 @@ target_link_libraries(lovr
   ${LOVR_OPENXR}
   ${LOVR_OCULUS_AUDIO}
   ${LOVR_PTHREADS}
-  ${LOVR_VULKAN}
   ${EMSCRIPTEN_LINKER_FLAGS}
 )
+
+if(LOVR_USE_VULKAN AND LOVR_LINK_VULKAN)
+  target_link_libraries(lovr PRIVATE Vulkan::Vulkan)
+endif()
 
 if(LOVR_SANITIZE)
   set(LOVR_SANITIZE_FLAGS "-fsanitize=address,undefined" "-O1" "-fno-omit-frame-pointer")

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -2525,7 +2525,7 @@ bool gpu_init(gpu_config* config) {
   ASSERT(state.library, "Failed to load vulkan library") goto fail;
   vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr) GetProcAddress(state.library, "vkGetInstanceProcAddr");
 #else
-  // Checking if vulkan was linked in (`-DLOVR_LINK_VULKAN`)
+  // Checking if vulkan was linked in (`-DLOVR_LINK_VULKAN` or `LD_PRELOAD`)
   state.library = NULL;
   void *selflib = dlopen(NULL, RTLD_NOW);
   if (selflib) {

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -1,6 +1,7 @@
 #include "gpu.h"
 #include <string.h>
 #include <threads.h>
+#include <stdlib.h>
 #include <stdatomic.h>
 
 #ifdef _WIN32
@@ -2528,15 +2529,13 @@ bool gpu_init(gpu_config* config) {
   // Checking if vulkan was linked in (`-DLOVR_LINK_VULKAN` or `LD_PRELOAD`)
   state.library = NULL;
   void *selflib = dlopen(NULL, RTLD_NOW);
-  if (selflib) {
-    if (dlsym(selflib, "vkGetInstanceProcAddr"))
-      state.library = selflib;
-    else
-      dlclose(selflib);
-  }
+  if (dlsym(selflib, "vkGetInstanceProcAddr"))
+    state.library = selflib;
+  else
+    dlclose(selflib);
 
 #ifdef __APPLE__
-  state.library = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
+  if (!state.library) state.library = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
   if (!state.library) state.library = dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
   if (!state.library) state.library = dlopen("libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
   if (!state.library) state.library = dlopen("vulkan.framework/vulkan", RTLD_NOW | RTLD_LOCAL);
@@ -2546,7 +2545,7 @@ bool gpu_init(gpu_config* config) {
   ASSERT(state.library, "Failed to load vulkan library") goto fail;
   vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr) dlsym(state.library, "vkGetInstanceProcAddr");
 #else
-  state.library = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
+  if (!state.library) state.library = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
   if (!state.library) state.library = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
   ASSERT(state.library, "Failed to load vulkan library") goto fail;
   vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr) dlsym(state.library, "vkGetInstanceProcAddr");

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -2524,9 +2524,25 @@ bool gpu_init(gpu_config* config) {
   state.library = LoadLibraryA("vulkan-1.dll");
   ASSERT(state.library, "Failed to load vulkan library") goto fail;
   vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr) GetProcAddress(state.library, "vkGetInstanceProcAddr");
-#elif __APPLE__
-  state.library = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
+#else
+  // Checking if vulkan was linked in (`-DLOVR_LINK_VULKAN`)
+  state.library = NULL;
+  void *selflib = dlopen(NULL, RTLD_NOW);
+  if (selflib) {
+    if (dlsym(selflib, "vkGetInstanceProcAddr"))
+      state.library = selflib;
+    else
+      dlclose(selflib);
+  }
+
+#ifdef __APPLE__
+  state.library = dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
+  if (!state.library) state.library = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
   if (!state.library) state.library = dlopen("libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
+  if (!state.library) state.library = dlopen("vulkan.framework/vulkan", RTLD_NOW | RTLD_LOCAL);
+  if (!state.library) state.library = dlopen("MoltenVK.framework/MoltenVK", RTLD_NOW | RTLD_LOCAL);
+  if (!state.library && getenv("DYLD_FALLBACK_LIBRARY_PATH") == NULL)
+    state.library = dlopen("/usr/local/lib/libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
   ASSERT(state.library, "Failed to load vulkan library") goto fail;
   vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr) dlsym(state.library, "vkGetInstanceProcAddr");
 #else
@@ -2534,6 +2550,7 @@ bool gpu_init(gpu_config* config) {
   if (!state.library) state.library = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
   ASSERT(state.library, "Failed to load vulkan library") goto fail;
   vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr) dlsym(state.library, "vkGetInstanceProcAddr");
+#endif
 #endif
   GPU_FOREACH_ANONYMOUS(GPU_LOAD_ANONYMOUS);
 

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -2536,8 +2536,8 @@ bool gpu_init(gpu_config* config) {
   }
 
 #ifdef __APPLE__
-  state.library = dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
-  if (!state.library) state.library = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
+  state.library = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
+  if (!state.library) state.library = dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
   if (!state.library) state.library = dlopen("libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
   if (!state.library) state.library = dlopen("vulkan.framework/vulkan", RTLD_NOW | RTLD_LOCAL);
   if (!state.library) state.library = dlopen("MoltenVK.framework/MoltenVK", RTLD_NOW | RTLD_LOCAL);


### PR DESCRIPTION
The order of loading (for Linux/MacOS) is now:
- check the executable itself
- if MacOS:
  - libvulkan.1.dylib
  - libvulkan.dylib
  - libMoltenVK.dylib
  - vulkan.framework/vulkan
  - MoltenVK.framework/MoltenVK
- elseif linux:
  - libvulkan.1.so
  - libvulkan.so