### PR TITLE
Add support for terrain holes

### DIFF
--- a/src/api/l_physics_shapes.c
+++ b/src/api/l_physics_shapes.c
@@ -150,8 +150,14 @@ Shape* luax_newterrainshape(lua_State* L, int index) {
       lua_pushnumber(L, x);
       lua_pushnumber(L, z);
       lua_call(L, 2, 1);
-      luax_check(L, lua_type(L, -1) == LUA_TNUMBER, "Expected TerrainShape callback to return a number");
-      vertices[i] = luax_tofloat(L, -1);
+      int height_type = lua_type(L, -1);
+      if (height_type == LUA_TNUMBER) {
+        vertices[i] = luax_tofloat(L, -1);
+      } else if (height_type == LUA_TNIL) {
+        vertices[i] = FLT_MAX;
+      } else {
+        luax_check(L, 0, "Expected TerrainShape callback to return a number or nil");
+      }
       lua_pop(L, 1);
     }
     TerrainShape* shape = lovrTerrainShapeCreate(vertices, n, scaleXZ, 1.f);


### PR DESCRIPTION
Jolt's heightmap shape supports a special height value FLT_MAX, which signifies the cNoCollisionValue gets handled as a hole in the terrain.

The FLT_MAX is not readily available in Lua. Instead, the heightfield callback can return a `nil` value for x,z coordinates to specify that the heightmap area should be ignored for collisions.

The downside: previously if you unintentionally leave the callback fn empty you'd get a helpful error message. Now it will create a void terrain, which to me makes sense.