### PR TITLE
Fix simulator reload while mouse button is down

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -210,6 +210,7 @@ function lovr.simulate(dt)
 
   if not pitch or not yaw then
     pitch, yaw = quat(lovr.headset.getOrientation()):getEuler()
+    mouseX, mouseY = lovr.system.getMousePosition()
   end
 
   local movespeed = 3


### PR DESCRIPTION
If the left mouse button is held while lovr `--watch` is reloading it results in an error:

```
Error:

boot.lua:229: attempt to perform arithmetic on local 'lastX' (a nil value)
```

The fix makes sure to init all the `nil` variables.

Tested with:
```bash
# Changes main.lua to have different number of spaces in the last line every second
#!/bin/bash

FILE="main.lua"

while true; do
    SPACES=$(sed -n '$s/ *$//; s/.*//p' "$FILE" | wc -c)
    NEW_SPACES=$(( (SPACES + 1) % 10 ))
    sed -i -E "s/^(.*[^ ])[ ]*$/\1 $(printf '%*s' "$NEW_SPACES")/" "$FILE"
    sleep 1
done
```