### PR TITLE
Frame Pacing Improvements

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -183,9 +183,11 @@ function lovr.run()
       if headset and lovr.draw and lovr.draw(headset) then headset = nil end
       if window and lovr.mirror and lovr.mirror(window) then window = nil end
       if headset or window then lovr.graphics.submit(headset, window) end
+      if lovr.headset then lovr.headset.submit() end
       lovr.graphics.present()
+    elseif lovr.headset then
+      lovr.headset.submit()
     end
-    if lovr.headset then lovr.headset.submit() end
     if lovr.math then lovr.math.drain() end
   end
 end

--- a/src/api/l_graphics_readback.c
+++ b/src/api/l_graphics_readback.c
@@ -13,10 +13,8 @@ static int l_lovrReadbackIsComplete(lua_State* L) {
 
 static int l_lovrReadbackWait(lua_State* L) {
   Readback* readback = luax_checktype(L, 1, Readback);
-  bool waited;
-  luax_assert(L, lovrReadbackWait(readback, &waited));
-  lua_pushboolean(L, waited);
-  return 1;
+  luax_assert(L, lovrReadbackWait(readback));
+  return 0;
 }
 
 static int l_lovrReadbackGetData(lua_State* L) {

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -748,9 +748,8 @@ typedef struct {
 
 bool gpu_init(gpu_config* config);
 void gpu_destroy(void);
-const char* gpu_get_error(void);
-bool gpu_begin(uint32_t* tick);
-bool gpu_submit(gpu_stream** streams, uint32_t count);
+char* gpu_get_error(void);
+bool gpu_submit(gpu_stream** streams, uint32_t count, uint32_t tick);
 bool gpu_is_complete(uint32_t tick);
-bool gpu_wait_tick(uint32_t tick, bool* waited);
+bool gpu_wait_tick(uint32_t tick);
 bool gpu_wait_idle(void);

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -96,7 +96,7 @@ size_t gpu_sizeof_tally(void) { return sizeof(gpu_tally); }
 
 // Internals
 
-#define TICK_DEPTH 2
+#define FRAME_DEPTH 2
 
 struct gpu_memory {
   VkDeviceMemory handle;
@@ -156,12 +156,6 @@ typedef struct {
   bool valid;
 } gpu_surface;
 
-typedef struct {
-  VkSemaphore acquireSemaphore;
-  VkSemaphore presentSemaphore;
-  VkFence fence;
-} gpu_tick;
-
 typedef struct gpu_stream_pool {
   struct gpu_stream_pool* next;
   VkCommandPool handle;
@@ -184,6 +178,7 @@ typedef struct {
   bool renderPass2;
   bool synchronization2;
   bool dynamicRendering;
+  bool timelineSemaphore;
   bool scalarBlockLayout;
   bool foveation;
   bool pipelineCacheControl;
@@ -192,10 +187,15 @@ typedef struct {
 
 // State
 
-static THREAD_LOCAL struct {
-  gpu_stream_pool streamPools[TICK_DEPTH];
-  char error[256];
-} thread;
+typedef struct gpu_thread_state {
+  struct gpu_thread_state* next;
+  gpu_stream_pool* streamPools;
+  gpu_stream_pool* activeStreamPool;
+  char error[255];
+  bool initialized;
+} gpu_thread_state;
+
+static THREAD_LOCAL gpu_thread_state thread;
 
 static struct {
   void* library;
@@ -207,15 +207,17 @@ static struct {
   VkDevice device;
   VkQueue queue;
   uint32_t queueFamilyIndex;
+  uint32_t tick;
+  uint32_t frame;
+  VkSemaphore semaphore;
+  VkSemaphore acquireSemaphore[FRAME_DEPTH];
+  VkSemaphore presentSemaphore[FRAME_DEPTH];
   VkPipelineCache pipelineCache;
   VkDebugUtilsMessengerEXT messenger;
   gpu_allocator allocators[GPU_MEMORY_COUNT];
   uint8_t allocatorLookup[GPU_MEMORY_COUNT];
   gpu_memory memory[1024];
-  uint32_t tick;
-  uint32_t lastTickFinished;
-  gpu_tick ticks[TICK_DEPTH];
-  gpu_stream_pool* streamPools;
+  gpu_thread_state* threads;
   gpu_morgue morgue;
 } state;
 
@@ -231,13 +233,14 @@ enum { LINEAR, SRGB };
 #define LOG(s) if (state.config.fnLog) state.config.fnLog(state.config.userdata, s)
 #define VK(f, s) if (!vkcheck(f, s))
 #define ASSERT(c, s) if (!(c) && (error(s), true))
-#define TICK_MASK (TICK_DEPTH - 1)
+#define FRAME_MASK (FRAME_DEPTH - 1)
 #define MORGUE_MASK (COUNTOF(state.morgue.data) - 1)
 
 static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkDeviceSize* offset);
 static void release(gpu_memory* memory);
 static void condemn(void* handle, VkObjectType type);
-static void expunge(void);
+static void expunge(uint64_t tick);
+static uint64_t getFinishedTick(void);
 static bool hasLayer(VkLayerProperties* layers, uint32_t count, const char* layer);
 static bool hasExtension(VkExtensionProperties* extensions, uint32_t count, const char* extension);
 static VkBufferUsageFlags getBufferUsage(gpu_buffer_type type);
@@ -304,6 +307,8 @@ static void error(const char* message);
   X(vkWaitForFences)\
   X(vkCreateSemaphore)\
   X(vkDestroySemaphore)\
+  X(vkWaitSemaphoresKHR)\
+  X(vkGetSemaphoreCounterValueKHR)\
   X(vkCmdPipelineBarrier2KHR)\
   X(vkCreateQueryPool)\
   X(vkDestroyQueryPool)\
@@ -968,7 +973,7 @@ bool gpu_surface_acquire(gpu_texture** texture) {
   }
 
   gpu_surface* surface = &state.surface;
-  VkSemaphore semaphore = state.ticks[state.tick & TICK_MASK].acquireSemaphore;
+  VkSemaphore semaphore = state.acquireSemaphore[state.frame & FRAME_MASK];
   VkResult result = vkAcquireNextImageKHR(state.device, surface->swapchain, UINT64_MAX, semaphore, VK_NULL_HANDLE, &surface->imageIndex);
 
   if (result == VK_ERROR_OUT_OF_DATE_KHR) {
@@ -987,7 +992,7 @@ bool gpu_surface_acquire(gpu_texture** texture) {
 }
 
 bool gpu_surface_present(void) {
-  VkSemaphore semaphore = state.ticks[state.tick & TICK_MASK].presentSemaphore;
+  VkSemaphore semaphore = state.presentSemaphore[state.frame & FRAME_MASK];
 
   VkSubmitInfo submit = {
     .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
@@ -1839,31 +1844,52 @@ void gpu_tally_destroy(gpu_tally* tally) {
 // Stream
 
 gpu_stream* gpu_stream_begin(const char* label) {
-  gpu_stream_pool* pool = &thread.streamPools[state.tick & TICK_MASK];
-
-  if (!pool->handle) {
-    VkCommandPoolCreateInfo poolInfo = {
-      .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
-      .flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
-      .queueFamilyIndex = state.queueFamilyIndex
-    };
-
-    VK(vkCreateCommandPool(state.device, &poolInfo, NULL, &pool->handle), "vkCreateCommandPool") return NULL;
-
-    pool->next = state.streamPools;
-    while (!atomic_compare_exchange_strong(&state.streamPools, &pool->next, pool)) {
+  if (!thread.initialized) {
+    thread.initialized = true;
+    thread.next = state.threads;
+    while (!atomic_compare_exchange_strong(&state.threads, &thread.next, &thread)) {
       continue;
     }
-
-    pool->head = NULL;
-    pool->tail = NULL;
-    pool->tick = state.tick;
   }
 
-  if (pool->tick != state.tick) {
-    VK(vkResetCommandPool(state.device, pool->handle, 0), "vkResetCommandPool") return NULL;
-    pool->tick = state.tick;
-    pool->tail = NULL;
+  gpu_stream_pool* pool = thread.activeStreamPool;
+
+  if (!pool) {
+    // Find an existing pool to reuse
+    for (gpu_stream_pool* p = thread.streamPools; p; p = p->next) {
+      if (gpu_is_complete(p->tick)) {
+        pool = p;
+        VK(vkResetCommandPool(state.device, pool->handle, 0), "vkResetCommandPool") return NULL;
+        pool->tail = NULL;
+        break;
+      }
+    }
+
+    // No pool available?  Make a new one
+    if (!pool) {
+      pool = state.config.fnAlloc(sizeof(gpu_stream_pool));
+      ASSERT(pool, "Out of memory") return NULL;
+
+      VkCommandPoolCreateInfo poolInfo = {
+        .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+        .flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
+        .queueFamilyIndex = state.queueFamilyIndex
+      };
+
+      VK(vkCreateCommandPool(state.device, &poolInfo, NULL, &pool->handle), "vkCreateCommandPool") {
+        state.config.fnFree(pool);
+        return NULL;
+      }
+
+      pool->next = thread.streamPools;
+      thread.streamPools = pool;
+
+      pool->head = NULL;
+      pool->tail = NULL;
+      pool->tick = 0;
+    }
+
+    thread.activeStreamPool = pool;
   }
 
   gpu_stream* stream = pool->tail ? pool->tail->next : pool->head;
@@ -2685,6 +2711,7 @@ bool gpu_init(gpu_config* config) {
       { "VK_KHR_image_format_list", true, &state.extensions.formatList },
       { "VK_KHR_synchronization2", true, &state.extensions.synchronization2 },
       { "VK_KHR_dynamic_rendering", true, &state.extensions.dynamicRendering },
+      { "VK_KHR_timeline_semaphore", true, &state.extensions.timelineSemaphore },
       { "VK_EXT_scalar_block_layout", true, &state.extensions.scalarBlockLayout },
       { "VK_EXT_fragment_density_map", true, &state.extensions.foveation },
       { "VK_EXT_pipeline_creation_cache_control", true, &state.extensions.pipelineCacheControl },
@@ -2708,6 +2735,7 @@ bool gpu_init(gpu_config* config) {
 
     ASSERT(state.extensions.renderPass2, "GPU driver is missing required Vulkan extension VK_KHR_render_pass2") goto fail;
     ASSERT(state.extensions.synchronization2, "GPU driver is missing required Vulkan extension VK_KHR_synchronization2") goto fail;
+    ASSERT(state.extensions.timelineSemaphore, "GPU driver is missing required Vulkan extension VK_KHR_timeline_semaphore") goto fail;
 
     config->fnFree(extensionInfo);
 
@@ -2781,6 +2809,7 @@ bool gpu_init(gpu_config* config) {
     VkPhysicalDeviceScalarBlockLayoutFeaturesEXT scalarBlockLayoutFeatures = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT };
     VkPhysicalDeviceFragmentDensityMapFeaturesEXT fragmentDensityMapFeatures = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT };
     VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT pipelineCreationCacheControlFeatures = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT };
+    VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timelineSemaphoreFeatures = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR };
 
     vkGetPhysicalDeviceFeatures2(state.adapter, &supported);
 
@@ -2813,6 +2842,9 @@ bool gpu_init(gpu_config* config) {
 
     synchronization2Features.synchronization2 = true;
     CHAIN(synchronization2Features);
+
+    timelineSemaphoreFeatures.timelineSemaphore = true;
+    CHAIN(timelineSemaphoreFeatures);
 
     if (state.extensions.dynamicRendering) {
       dynamicRenderingFeatures.dynamicRendering = true;
@@ -2946,9 +2978,7 @@ bool gpu_init(gpu_config* config) {
     // - STATIC: Regular device-local memory.  Not necessarily mappable, fast to read on GPU.
     // - STREAM: Used to "stream" data to the GPU, to be read by shaders.  This tries to use the
     //   special 256MB memory type present on discrete GPUs because it's both device local and host-
-    //   visible and that supposedly makes it fast.  A single buffer is allocated with a "zone" for
-    //   each tick.  If one of the zones fills up, a new bigger buffer is allocated.  It's important
-    //   to have one buffer and keep it alive since streaming is expected to happen very frequently.
+    //   visible and that supposedly makes it fast.
     // - UPLOAD: Used to stage data to upload to buffers/textures.  Can only be used for transfers.
     //   Uses uncached host-visible memory to not pollute the CPU cache or waste the STREAM memory.
     // - DOWNLOAD: Used for readbacks.  Uses cached memory when available since reading from
@@ -3073,21 +3103,23 @@ bool gpu_init(gpu_config* config) {
     }
   }
 
-  // Per-tick resources
-  for (uint32_t i = 0; i < TICK_DEPTH; i++) {
-    gpu_tick* tick = &state.ticks[i];
+  // Semaphores
 
+  for (uint32_t i = 0; i < FRAME_DEPTH; i++) {
     VkSemaphoreCreateInfo semaphoreInfo = { .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
-    VK(vkCreateSemaphore(state.device, &semaphoreInfo, NULL, &tick->acquireSemaphore), "vkCreateSemaphore") goto fail;
-    VK(vkCreateSemaphore(state.device, &semaphoreInfo, NULL, &tick->presentSemaphore), "vkCreateSemaphore") goto fail;
-
-    VkFenceCreateInfo fenceInfo = {
-      .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
-      .flags = VK_FENCE_CREATE_SIGNALED_BIT
-    };
-
-    VK(vkCreateFence(state.device, &fenceInfo, NULL, &tick->fence), "vkCreateFence") goto fail;
+    VK(vkCreateSemaphore(state.device, &semaphoreInfo, NULL, &state.acquireSemaphore[i]), "vkCreateSemaphore") goto fail;
+    VK(vkCreateSemaphore(state.device, &semaphoreInfo, NULL, &state.presentSemaphore[i]), "vkCreateSemaphore") goto fail;
   }
+
+  VkSemaphoreCreateInfo timelineSemaphoreInfo = {
+    .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+    .pNext = &(VkSemaphoreTypeCreateInfo) {
+      .sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO,
+      .semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE
+    }
+  };
+
+  VK(vkCreateSemaphore(state.device, &timelineSemaphoreInfo, NULL, &state.semaphore), "vkCreateSemaphore") goto fail;
 
   // Pipeline cache
 
@@ -3108,9 +3140,7 @@ bool gpu_init(gpu_config* config) {
 
   VK(vkCreatePipelineCache(state.device, &cacheInfo, NULL, &state.pipelineCache), "vkCreatePipelineCache") goto fail;
 
-  state.tick = TICK_DEPTH - 1;
   return true;
-
 fail:
   gpu_destroy();
   return false;
@@ -3118,26 +3148,25 @@ fail:
 
 void gpu_destroy(void) {
   if (state.device) vkDeviceWaitIdle(state.device);
-  state.lastTickFinished = state.tick;
-  expunge();
-  for (gpu_stream_pool* pool = state.streamPools; pool; pool = pool->next) {
-    vkDestroyCommandPool(state.device, pool->handle, NULL);
-    for (gpu_stream* stream = pool->head, *next; stream; stream = next) {
-      next = stream->next;
-      state.config.fnFree(stream);
+  expunge(UINT64_MAX);
+  for (gpu_thread_state* t = state.threads; t; t = t->next) {
+    for (gpu_stream_pool* pool = t->streamPools, *next; pool; pool = next) {
+      vkDestroyCommandPool(state.device, pool->handle, NULL);
+      for (gpu_stream* stream = pool->head, *next; stream; stream = next) {
+        next = stream->next;
+        state.config.fnFree(stream);
+      }
+      next = pool->next;
+      state.config.fnFree(pool);
     }
-    pool->handle = VK_NULL_HANDLE;
-    pool->head = NULL;
-    pool->tail = NULL;
-    pool->tick = 0;
+    t->initialized = false;
   }
   if (state.pipelineCache) vkDestroyPipelineCache(state.device, state.pipelineCache, NULL);
-  for (uint32_t i = 0; i < TICK_DEPTH; i++) {
-    gpu_tick* tick = &state.ticks[i];
-    if (tick->acquireSemaphore) vkDestroySemaphore(state.device, tick->acquireSemaphore, NULL);
-    if (tick->presentSemaphore) vkDestroySemaphore(state.device, tick->presentSemaphore, NULL);
-    if (tick->fence) vkDestroyFence(state.device, tick->fence, NULL);
+  for (uint32_t i = 0; i < FRAME_DEPTH; i++) {
+    if (state.acquireSemaphore[i]) vkDestroySemaphore(state.device, state.acquireSemaphore[i], NULL);
+    if (state.presentSemaphore[i]) vkDestroySemaphore(state.device, state.presentSemaphore[i], NULL);
   }
+  if (state.semaphore) vkDestroySemaphore(state.device, state.semaphore, NULL);
   for (uint32_t i = 0; i < COUNTOF(state.memory); i++) {
     if (state.memory[i].handle) vkFreeMemory(state.device, state.memory[i].handle, NULL);
   }
@@ -3157,33 +3186,11 @@ void gpu_destroy(void) {
   memset(&state, 0, sizeof(state));
 }
 
-const char* gpu_get_error(void) {
+char* gpu_get_error(void) {
   return thread.error;
 }
 
-bool gpu_begin(uint32_t* tick) {
-  uint32_t nextTick = state.tick + 1;
-  uint32_t pendingTick = nextTick - TICK_DEPTH;
-  VkFence fence = state.ticks[pendingTick & TICK_MASK].fence;
-
-  // Wait for the fence if needed
-  if (state.lastTickFinished < pendingTick) {
-    VK(vkWaitForFences(state.device, 1, &fence, VK_FALSE, ~0ull), "vkWaitForFences") return false;
-    state.lastTickFinished = pendingTick;
-  }
-
-  // Reset the fence
-  VK(vkResetFences(state.device, 1, &fence), "vkResetFences") return false;
-
-  // Free any destroyed resources that are no longer in use
-  expunge();
-
-  if (tick) *tick = nextTick;
-  state.tick = nextTick;
-  return true;
-}
-
-bool gpu_submit(gpu_stream** streams, uint32_t count) {
+bool gpu_submit(gpu_stream** streams, uint32_t count, uint32_t tick) {
   VkCommandBuffer stack[64];
   VkCommandBuffer* commandBuffers = stack;
 
@@ -3196,47 +3203,62 @@ bool gpu_submit(gpu_stream** streams, uint32_t count) {
     commandBuffers[i] = streams[i]->commands;
   }
 
+  for (gpu_thread_state* t = state.threads; t; t = t->next) {
+    if (t->activeStreamPool) {
+      t->activeStreamPool->tick = tick;
+      t->activeStreamPool = NULL;
+    }
+  }
+
   VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR;
 
   VkSubmitInfo submit = {
     .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+    .pNext = &(VkTimelineSemaphoreSubmitInfo) {
+      .sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO,
+      .signalSemaphoreValueCount = 1,
+      .pSignalSemaphoreValues = (uint64_t[1]) { tick }
+    },
     .waitSemaphoreCount = !!state.surface.semaphore,
     .pWaitSemaphores = &state.surface.semaphore,
     .pWaitDstStageMask = &waitStage,
+    .signalSemaphoreCount = 1,
+    .pSignalSemaphores = &state.semaphore,
     .commandBufferCount = count,
     .pCommandBuffers = commandBuffers
   };
 
-  VkFence fence = state.ticks[state.tick & TICK_MASK].fence;
-  VK(vkQueueSubmit(state.queue, 1, &submit, fence), "vkQueueSubmit") {
+  VK(vkQueueSubmit(state.queue, 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
     if (commandBuffers != stack) state.config.fnFree(commandBuffers);
     return false;
   }
 
+  expunge(getFinishedTick());
+
+  if (commandBuffers != stack) state.config.fnFree(commandBuffers);
   state.surface.semaphore = VK_NULL_HANDLE;
+  state.tick = tick;
   return true;
 }
 
 bool gpu_is_complete(uint32_t tick) {
-  return state.lastTickFinished >= tick;
+  return getFinishedTick() >= (uint64_t) tick;
 }
 
-bool gpu_wait_tick(uint32_t tick, bool* waited) {
-  if (state.lastTickFinished < tick && tick < state.tick) {
-    VkFence fence = state.ticks[tick & TICK_MASK].fence;
-    VK(vkWaitForFences(state.device, 1, &fence, VK_FALSE, ~0ull), "vkWaitForFences") return false;
-    state.lastTickFinished = tick;
-    if (waited) *waited = true;
-    return true;
-  } else {
-    if (waited) *waited = false;
-    return true;
-  }
+bool gpu_wait_tick(uint32_t tick) {
+  VkSemaphoreWaitInfo info = {
+    .sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO,
+    .semaphoreCount = 1,
+    .pSemaphores = &state.semaphore,
+    .pValues = (uint64_t[1]) { tick }
+  };
+
+  VK(vkWaitSemaphoresKHR(state.device, &info, UINT64_MAX), "vkWaitSemaphores") return false;
+  return true;
 }
 
 bool gpu_wait_idle(void) {
   VK(vkDeviceWaitIdle(state.device), "vkDeviceWaitIdle") return false;
-  state.lastTickFinished = state.tick;
   return true;
 }
 
@@ -3348,24 +3370,25 @@ static void condemn(void* handle, VkObjectType type) {
 
   // If the morgue is full, try expunging to reclaim some space
   if (morgue->head - morgue->tail >= COUNTOF(morgue->data)) {
-    expunge();
+    expunge(getFinishedTick());
 
     // If that didn't work, wait for the GPU to be done with the oldest victim and retry
     if (morgue->head - morgue->tail >= COUNTOF(morgue->data)) {
-      gpu_wait_tick(morgue->data[morgue->tail & MORGUE_MASK].tick, NULL);
-      expunge();
+      uint32_t tick = morgue->data[morgue->tail & MORGUE_MASK].tick;
+      gpu_wait_tick(tick);
+      expunge(tick);
     }
 
     // The following should be unreachable
     ASSERT(morgue->head - morgue->tail < COUNTOF(morgue->data), "Morgue overflow!") return;
   }
 
-  morgue->data[morgue->head++ & MORGUE_MASK] = (gpu_victim) { handle, type, state.tick };
+  morgue->data[morgue->head++ & MORGUE_MASK] = (gpu_victim) { handle, type, state.tick + 1 };
 }
 
-static void expunge(void) {
+static void expunge(uint64_t tick) {
   gpu_morgue* morgue = &state.morgue;
-  while (morgue->tail != morgue->head && state.lastTickFinished >= morgue->data[morgue->tail & MORGUE_MASK].tick) {
+  while (morgue->tail != morgue->head && tick >= morgue->data[morgue->tail & MORGUE_MASK].tick) {
     gpu_victim* victim = &morgue->data[morgue->tail++ & MORGUE_MASK];
     switch (victim->type) {
       case VK_OBJECT_TYPE_BUFFER: vkDestroyBuffer(state.device, victim->handle, NULL); break;
@@ -3383,6 +3406,12 @@ static void expunge(void) {
       default: LOG("Trying to destroy invalid Vulkan object type!"); break;
     }
   }
+}
+
+static uint64_t getFinishedTick(void) {
+  uint64_t value;
+  VK(vkGetSemaphoreCounterValueKHR(state.device, state.semaphore, &value), "vkGetSemaphoreCounterValue") return false;
+  return value;
 }
 
 static bool hasLayer(VkLayerProperties* layers, uint32_t count, const char* layer) {

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -582,6 +582,7 @@ static struct {
   gpu_tally* timestamps;
   uint32_t timestampCount;
   uint32_t tick;
+  uint32_t waitTick;
   float background[4];
   TextureFormat depthFormat;
   Texture* window;
@@ -1988,6 +1989,10 @@ bool lovrGraphicsPresent(void) {
     lovrAssert(gpu_surface_present(), "Failed to present: %s", gpu_get_error());
     lovrGraphicsGetWindowTexture(NULL);
   }
+
+  // Avoid CPU getting too far ahead of GPU
+  gpu_wait_tick(state.waitTick);
+  state.waitTick = state.tick - 1;
 
   lovrProfileMarkFrame();
   processReadbacks();

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -569,7 +569,6 @@ static thread_local struct {
 static struct {
   uint32_t ref;
   bool glslang;
-  bool active;
   bool resized;
   bool shouldPresent;
   bool timingEnabled;
@@ -620,8 +619,6 @@ static BufferView getBuffer(gpu_buffer_type type, uint32_t size, size_t align);
 static void recycleBlocks(BufferAllocator* allocator, BufferBlock* blocks);
 static void destroyBuffers(BufferAllocator* allocator);
 static int u64cmp(const void* a, const void* b);
-static bool beginFrame(void);
-static void flushTransfers(void);
 static void processReadbacks(void);
 static Layout* getLayout(gpu_slot* slots, uint32_t count);
 static gpu_bundle* getBundle(Layout* layout, gpu_binding* bindings, uint32_t count);
@@ -721,12 +718,15 @@ bool lovrGraphicsInit(GraphicsConfig* config) {
   state.uniformLayout = getLayout(uniformSlots, COUNTOF(uniformSlots));
   lovrAssertGoto(fail, state.builtinLayout && state.materialLayout && state.uniformLayout, "Failed to create GPU layouts: %s", gpu_get_error());
 
+  state.stream = gpu_stream_begin("Internal");
+  lovrAssertGoto(fail, state.stream, "Failed to begin command buffer: %s", gpu_get_error());
+  state.tick = 1;
+
   // Default Buffer
 
   float defaultBufferData[] = { 0.f, 0.f, 0.f, 0.f, 1.f, 1.f, 1.f, 1.f };
   state.defaultBuffer = lovrBufferCreate(&(BufferInfo) { .size = sizeof(defaultBufferData), }, NULL);
   if (!state.defaultBuffer) goto fail;
-  if (!beginFrame()) goto fail;
 
   BufferView view = getBuffer(GPU_BUFFER_UPLOAD, sizeof(defaultBufferData), 4);
   if (!view.buffer) goto fail;
@@ -1715,10 +1715,6 @@ static void syncAttachment(Texture* texture, bool depth, bool resolve, bool load
 }
 
 bool lovrGraphicsSubmit(Pass** passes, uint32_t count) {
-  if (!beginFrame()) {
-    return false;
-  }
-
   size_t stack = stackPush(&thread.stack);
 
   bool xrCanvas = false;
@@ -1953,6 +1949,9 @@ bool lovrGraphicsSubmit(Pass** passes, uint32_t count) {
 
   lovrAssertGoto(fail, gpu_submit(streams, streamCount, state.tick), "Failed to submit GPU command buffers: %s", gpu_get_error());
 
+  state.stream = gpu_stream_begin("Internal");
+  lovrAssertGoto(fail, state.stream, "Failed to begin new command buffer: %s", gpu_get_error());
+
   // All of the buffers after the front of the 'current' list are the buffers that filled up while
   // this frame was being recorded.  Set their tick to the current tick and chain them onto the end
   // of the freelist.
@@ -1969,9 +1968,11 @@ bool lovrGraphicsSubmit(Pass** passes, uint32_t count) {
     }
   }
 
+  memset(&state.barrier, 0, sizeof(gpu_barrier));
+  memset(&state.transferBarrier, 0, sizeof(gpu_barrier));
+  state.tick++;
+
   stackPop(&thread.stack, stack);
-  state.active = false;
-  state.stream = NULL;
   return true;
 fail:
   stackPop(&thread.stack, stack);
@@ -1988,14 +1989,13 @@ bool lovrGraphicsPresent(void) {
   }
 
   lovrProfileMarkFrame();
+  processReadbacks();
   return true;
 }
 
 bool lovrGraphicsWait(void) {
-  if (state.active) {
-    if (!lovrGraphicsSubmit(NULL, 0)) {
-      return false;
-    }
+  if (!lovrGraphicsSubmit(NULL, 0)) {
+    return false;
   }
 
   lovrAssert(gpu_wait_idle(), "Failed to wait: %s", gpu_get_error());
@@ -2166,11 +2166,6 @@ Buffer* lovrBufferCreate(const BufferInfo* info, void** data) {
     }
   }
 
-  if (!beginFrame()) {
-    lovrFree(buffer);
-    return NULL;
-  }
-
   gpu_buffer_info bufferInfo = {
     .type = GPU_BUFFER_STATIC,
     .size = size,
@@ -2200,6 +2195,7 @@ Buffer* lovrBufferCreate(const BufferInfo* info, void** data) {
 
 void lovrBufferDestroy(void* ref) {
   Buffer* buffer = ref;
+  lovrGraphicsSubmit(NULL, 0);
   gpu_buffer_destroy(buffer->gpu);
   lovrFree(buffer->sync);
   lovrFree(buffer);
@@ -2210,8 +2206,6 @@ const BufferInfo* lovrBufferGetInfo(Buffer* buffer) {
 }
 
 void* lovrBufferGetData(Buffer* buffer, uint32_t offset, uint32_t extent) {
-  if (!beginFrame()) return NULL;
-
   if (extent == ~0u) extent = buffer->info.size - offset;
   lovrCheck(offset + extent <= buffer->info.size, "Buffer read range goes past the end of the Buffer");
 
@@ -2231,8 +2225,6 @@ void* lovrBufferGetData(Buffer* buffer, uint32_t offset, uint32_t extent) {
 }
 
 void* lovrBufferSetData(Buffer* buffer, uint32_t offset, uint32_t extent) {
-  if (!beginFrame()) return NULL;
-
   if (extent == ~0u) extent = buffer->info.size - offset;
   lovrCheck(offset + extent <= buffer->info.size, "Attempt to write past the end of the Buffer");
 
@@ -2247,8 +2239,6 @@ void* lovrBufferSetData(Buffer* buffer, uint32_t offset, uint32_t extent) {
 }
 
 bool lovrBufferCopy(Buffer* src, Buffer* dst, uint32_t srcOffset, uint32_t dstOffset, uint32_t extent) {
-  if (!beginFrame()) return false;
-
   lovrCheck(srcOffset + extent <= src->info.size, "Buffer copy range goes past the end of the source Buffer");
   lovrCheck(dstOffset + extent <= dst->info.size, "Buffer copy range goes past the end of the destination Buffer");
   lovrCheck(src != dst || (srcOffset >= dstOffset + extent || dstOffset >= srcOffset + extent), "Copying part of a Buffer to itself requires non-overlapping copy regions");
@@ -2268,8 +2258,6 @@ bool lovrBufferClear(Buffer* buffer, uint32_t offset, uint32_t extent, uint32_t 
   lovrCheck(offset % 4 == 0, "Buffer clear offset must be a multiple of 4");
   lovrCheck(extent % 4 == 0, "Buffer clear extent must be a multiple of 4");
   lovrCheck(offset + extent <= buffer->info.size, "Buffer clear range goes past the end of the Buffer");
-
-  if (!beginFrame()) return false;
 
   gpu_barrier barrier = syncTransfer(buffer->sync, GPU_PHASE_CLEAR, GPU_CACHE_TRANSFER_WRITE);
   gpu_sync(state.stream, &barrier, 1);
@@ -2345,10 +2333,6 @@ bool lovrGraphicsGetWindowTexture(Texture** texture) {
   }
 
   if (state.window && !state.window->gpu) {
-    if (!beginFrame()) {
-      return false;
-    }
-
     if (state.resized) {
       lovrAssert(gpu_surface_resize(state.window->info.width, state.window->info.height), "Failed to resize window: %s", gpu_get_error());
       state.resized = false;
@@ -2425,11 +2409,6 @@ Texture* lovrTextureCreate(const TextureInfo* info) {
   uint32_t levelOffsets[16];
   uint32_t levelSizes[16];
   BufferView view = { 0 };
-
-  if (!beginFrame()) {
-    lovrTextureDestroy(texture);
-    return NULL;
-  }
 
   if (info->imageCount > 0) {
     levelCount = lovrImageGetLevelCount(info->images[0]);
@@ -2716,7 +2695,7 @@ void lovrTextureDestroy(void* ref) {
     if (texture->root == texture || texture->info.label != texture->root->info.label) {
       lovrFree((char*) texture->info.label);
     }
-    flushTransfers();
+    lovrGraphicsSubmit(NULL, 0);
     lovrRelease(texture->sampler, lovrSamplerDestroy);
     lovrRelease(texture->material, lovrMaterialDestroy);
     if (texture->root != texture) lovrRelease(texture->root, lovrTextureDestroy);
@@ -2734,8 +2713,6 @@ const TextureInfo* lovrTextureGetInfo(Texture* texture) {
 }
 
 Image* lovrTextureGetPixels(Texture* texture, uint32_t offset[4], uint32_t extent[3]) {
-  if (!beginFrame()) return NULL;
-
   if (extent[0] == ~0u) extent[0] = texture->info.width - offset[0];
   if (extent[1] == ~0u) extent[1] = texture->info.height - offset[1];
   lovrCheck(extent[2] == 1, "Currently only a single layer can be read from a Texture");
@@ -2768,8 +2745,6 @@ Image* lovrTextureGetPixels(Texture* texture, uint32_t offset[4], uint32_t exten
 }
 
 bool lovrTextureSetPixels(Texture* texture, Image* image, uint32_t dstOffset[4], uint32_t srcOffset[4], uint32_t extent[3]) {
-  if (!beginFrame()) return false;
-
   TextureFormat format = texture->info.format;
   if (extent[0] == ~0u) extent[0] = MIN(texture->info.width - dstOffset[0], lovrImageGetWidth(image, srcOffset[3]) - srcOffset[0]);
   if (extent[1] == ~0u) extent[1] = MIN(texture->info.height - dstOffset[1], lovrImageGetHeight(image, srcOffset[3]) - srcOffset[1]);
@@ -2810,8 +2785,6 @@ bool lovrTextureSetPixels(Texture* texture, Image* image, uint32_t dstOffset[4],
 }
 
 bool lovrTextureCopy(Texture* src, Texture* dst, uint32_t srcOffset[4], uint32_t dstOffset[4], uint32_t extent[3]) {
-  if (!beginFrame()) return false;
-
   if (src->info.format != dst->info.format) return lovrTextureBlit(src, dst, srcOffset, dstOffset, extent, extent, FILTER_NEAREST);
 
   if (extent[0] == ~0u) extent[0] = MIN(src->info.width - srcOffset[0], dst->info.width - dstOffset[0]);
@@ -2835,8 +2808,6 @@ bool lovrTextureCopy(Texture* src, Texture* dst, uint32_t srcOffset[4], uint32_t
 }
 
 bool lovrTextureBlit(Texture* src, Texture* dst, uint32_t srcOffset[4], uint32_t dstOffset[4], uint32_t srcExtent[3], uint32_t dstExtent[3], FilterMode filter) {
-  if (!beginFrame()) return false;
-
   bool depth = isDepthFormat(src->info.format) || isDepthFormat(dst->info.format);
 
   if (depth) filter = FILTER_NEAREST;
@@ -2871,8 +2842,6 @@ bool lovrTextureBlit(Texture* src, Texture* dst, uint32_t srcOffset[4], uint32_t
 }
 
 bool lovrTextureClear(Texture* texture, float value[4], uint32_t layer, uint32_t layerCount, uint32_t level, uint32_t levelCount) {
-  if (!beginFrame()) return false;
-
   if (layerCount == ~0u) layerCount = texture->info.layers - layer;
   if (levelCount == ~0u) levelCount = texture->info.mipmaps - level;
   lovrCheck(texture->info.usage & TEXTURE_TRANSFER, "Texture must be created with 'transfer' usage to clear it");
@@ -2887,8 +2856,6 @@ bool lovrTextureClear(Texture* texture, float value[4], uint32_t layer, uint32_t
 }
 
 bool lovrTextureGenerateMipmaps(Texture* texture, uint32_t base, uint32_t count) {
-  if (!beginFrame()) return false;
-
   if (count == ~0u) count = texture->info.mipmaps - (base + 1);
   uint32_t supports = state.features.formats[texture->info.format][texture->info.srgb];
   lovrCheck(texture->info.usage & TEXTURE_TRANSFER, "Texture must be created with the 'transfer' usage to mipmap it");
@@ -3949,10 +3916,6 @@ Material* lovrMaterialCreate(const MaterialInfo* info) {
   if (block->pointer) {
     data = (MaterialData*) ((char*) block->pointer + material->index * stride);
   } else {
-    if (!beginFrame()) {
-      return NULL;
-    }
-
     BufferView staging = getBuffer(GPU_BUFFER_UPLOAD, sizeof(MaterialData), 4);
     if (!staging.buffer) return NULL;
 
@@ -4170,10 +4133,6 @@ static Glyph* lovrFontGetGlyph(Font* font, uint32_t codepoint, bool* resized) {
   float height = glyph->box[3] - glyph->box[1];
   uint32_t pixelWidth = 2 * font->padding + (uint32_t) ceilf(width);
   uint32_t pixelHeight = 2 * font->padding + (uint32_t) ceilf(height);
-
-  if (!beginFrame()) {
-    return NULL;
-  }
 
   BufferView bufferView = getBuffer(GPU_BUFFER_UPLOAD, pixelWidth * pixelHeight * 4 * sizeof(uint8_t), 64);
 
@@ -5027,8 +4986,6 @@ Model* lovrModelCreate(const ModelInfo* info) {
     model->rawVertexBuffer = lovrBufferCreate(&vertexBufferInfo, NULL);
     lovrAssertGoto(fail, model->rawVertexBuffer, "Failed to create model raw vertex buffer: %s", lovrGetError());
 
-    if (!beginFrame()) goto fail;
-
     // The vertex buffer may already have a pending copy if its memory was not host-visible, need to
     // wait for that to complete before copying to the raw vertex buffer
     gpu_barrier barrier = syncTransfer(model->vertexBuffer->sync, GPU_PHASE_COPY, GPU_CACHE_TRANSFER_READ);
@@ -5231,7 +5188,7 @@ Model* lovrModelClone(Model* parent) {
   if (parent->vertexBuffer) {
     model->vertexBuffer = lovrBufferCreate(&parent->vertexBuffer->info, NULL);
 
-    if (!model->vertexBuffer || !beginFrame()) {
+    if (!model->vertexBuffer) {
       lovrModelDestroy(model);
       return NULL;
     }
@@ -5544,8 +5501,6 @@ static bool lovrModelAnimateVertices(Model* model) {
   bool blend = model->blendGroupCount > 0;
   bool skin = data->skinCount > 0;
 
-  if (!beginFrame()) return false;
-
   if ((!blend && !skin) || (!model->transformsDirty && !model->blendShapesDirty) || model->lastVertexAnimation == state.tick || !model->vertexBuffer) {
     return true;
   }
@@ -5699,7 +5654,6 @@ static Readback* lovrReadbackCreate(ReadbackType type) {
 }
 
 Readback* lovrReadbackCreateBuffer(Buffer* buffer, uint32_t offset, uint32_t extent) {
-  if (!beginFrame()) return NULL;
   if (extent == ~0u) extent = buffer->info.size - offset;
   lovrCheck(offset + extent <= buffer->info.size, "Tried to read past the end of the Buffer");
   lovrCheck(!buffer->info.format || offset % buffer->info.format->stride == 0, "Readback offset must be a multiple of Buffer's stride");
@@ -5719,7 +5673,6 @@ Readback* lovrReadbackCreateBuffer(Buffer* buffer, uint32_t offset, uint32_t ext
 }
 
 Readback* lovrReadbackCreateTexture(Texture* texture, uint32_t offset[4], uint32_t extent[3]) {
-  if (!beginFrame()) return NULL;
   if (extent[0] == ~0u) extent[0] = texture->info.width - offset[0];
   if (extent[1] == ~0u) extent[1] = texture->info.height - offset[1];
   lovrCheck(extent[2] == 1, "Currently, only one layer can be read from a Texture");
@@ -5781,14 +5734,10 @@ bool lovrReadbackWait(Readback* readback) {
     return true;
   }
 
-  if (readback->tick == state.tick && state.active) {
+  if (readback->tick == state.tick) {
     if (!lovrGraphicsSubmit(NULL, 0)) {
       return false;
     }
-  }
-
-  if (!beginFrame()) {
-    return false;
   }
 
   if (!gpu_wait_tick(readback->tick)) {
@@ -6124,10 +6073,6 @@ bool lovrPassSetCanvas(Pass* pass, Canvas* canvas) {
   }
 
   // Create temporary textures, trying to reuse existing ones when possible
-
-  if (!beginFrame()) {
-    return false;
-  }
 
   gpu_texture* tempColorTextures[4] = { 0 };
   gpu_texture* tempDepthTexture = NULL;
@@ -8013,10 +7958,6 @@ bool lovrPassText(Pass* pass, ColoredString* strings, uint32_t count, float* tra
     totalLength += strings[i].length;
   }
 
-  if (!beginFrame()) {
-    return false;
-  }
-
   size_t stack = stackPush(&thread.stack);
   GlyphVertex* vertices = allocate(&thread.stack, totalLength * 4 * sizeof(GlyphVertex));
   uint32_t glyphCount;
@@ -8529,34 +8470,6 @@ static void destroyBuffers(BufferAllocator* allocator) {
 static int u64cmp(const void* a, const void* b) {
   uint64_t x = *(uint64_t*) a, y = *(uint64_t*) b;
   return (x > y) - (x < y);
-}
-
-static bool beginFrame(void) {
-  if (!state.active) {
-    state.tick++;
-    state.active = true;
-    memset(&state.barrier, 0, sizeof(gpu_barrier));
-    memset(&state.transferBarrier, 0, sizeof(gpu_barrier));
-    processReadbacks();
-  }
-
-  if (!state.stream && (state.stream = gpu_stream_begin("Internal")) == NULL) {
-    return lovrSetError("Failed to begin command buffer: %s", gpu_get_error());
-  }
-
-  return true;
-}
-
-// When a Texture is garbage collected, if it has any transfer operations recorded to state.stream,
-// those transfers need to be submitted before it gets destroyed.  The allocator offset is saved and
-// restored, which is pretty gross, but we don't want to invalidate temp memory (currently this is
-// only a problem for Font: when the font's atlas gets destroyed, it could invalidate the temp
-// memory used by Font:getLines and Pass:text).
-static void flushTransfers(void) {
-  if (state.active) {
-    lovrGraphicsSubmit(NULL, 0);
-    beginFrame();
-  }
 }
 
 static void processReadbacks(void) {

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -1951,7 +1951,7 @@ bool lovrGraphicsSubmit(Pass** passes, uint32_t count) {
     atomic_store(&state.newPipelines, NULL);
   }
 
-  lovrAssertGoto(fail, gpu_submit(streams, streamCount), "Failed to submit GPU command buffers: %s", gpu_get_error());
+  lovrAssertGoto(fail, gpu_submit(streams, streamCount, state.tick), "Failed to submit GPU command buffers: %s", gpu_get_error());
 
   // All of the buffers after the front of the 'current' list are the buffers that filled up while
   // this frame was being recorded.  Set their tick to the current tick and chain them onto the end
@@ -5776,9 +5776,8 @@ bool lovrReadbackIsComplete(Readback* readback) {
   return gpu_is_complete(readback->tick);
 }
 
-bool lovrReadbackWait(Readback* readback, bool* waited) {
+bool lovrReadbackWait(Readback* readback) {
   if (lovrReadbackIsComplete(readback)) {
-    *waited = false;
     return true;
   }
 
@@ -5792,14 +5791,11 @@ bool lovrReadbackWait(Readback* readback, bool* waited) {
     return false;
   }
 
-  if (!gpu_wait_tick(readback->tick, waited)) {
+  if (!gpu_wait_tick(readback->tick)) {
     return lovrSetError("Failed to wait for readback: %s", gpu_get_error());
   }
 
-  if (*waited) {
-    processReadbacks();
-  }
-
+  processReadbacks();
   return true;
 }
 
@@ -8537,10 +8533,7 @@ static int u64cmp(const void* a, const void* b) {
 
 static bool beginFrame(void) {
   if (!state.active) {
-    if (!gpu_begin(&state.tick)) {
-      return lovrSetError("Failed to begin GPU frame: %s", gpu_get_error());
-    }
-
+    state.tick++;
     state.active = true;
     memset(&state.barrier, 0, sizeof(gpu_barrier));
     memset(&state.transferBarrier, 0, sizeof(gpu_barrier));

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -1986,6 +1986,7 @@ bool lovrGraphicsPresent(void) {
     state.window->renderView = NULL;
     state.shouldPresent = false;
     lovrAssert(gpu_surface_present(), "Failed to present: %s", gpu_get_error());
+    lovrGraphicsGetWindowTexture(NULL);
   }
 
   lovrProfileMarkFrame();
@@ -2343,12 +2344,12 @@ bool lovrGraphicsGetWindowTexture(Texture** texture) {
 
     // Window texture may be unavailable during a resize
     if (!state.window->gpu) {
-      *texture = NULL;
+      if (texture) *texture = NULL;
       return true;
     }
   }
 
-  *texture = state.window;
+  if (texture) *texture = state.window;
   return true;
 }
 

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -504,7 +504,7 @@ Readback* lovrReadbackCreateBuffer(Buffer* buffer, uint32_t offset, uint32_t ext
 Readback* lovrReadbackCreateTexture(Texture* texture, uint32_t offset[4], uint32_t extent[3]);
 void lovrReadbackDestroy(void* ref);
 bool lovrReadbackIsComplete(Readback* readback);
-bool lovrReadbackWait(Readback* readback, bool* waited);
+bool lovrReadbackWait(Readback* readback);
 void* lovrReadbackGetData(Readback* readback, DataField** format, uint32_t* count);
 struct Blob* lovrReadbackGetBlob(Readback* readback);
 struct Image* lovrReadbackGetImage(Readback* readback);


### PR DESCRIPTION
Some improvements to frame pacing:

- You can do `lovr.graphics.submit` any number of times per frame, without incurring stalls.
- vsync waits happen reliably in `lovr.graphics.present`, instead of the first time graphics work happens during the frame.  This reduces desktop input latency, because `lovr.system.pollEvents` is called later in the frame.  It may reduce throughput in some situations though (you could have been doing some CPU work during the vsync wait, but now this isn't an option).
- `lovr.graphics.present` is the main synchronization point for graphics work now.  It presents the window swapchain, acquires a new image, waits for old frames to complete, and processes readbacks.
  - The `lovr.headset.submit` (`xrEndFrame`) call was moved before `lovr.graphics.present` so it doesn't happen after a huge wait.
- On the Vulkan side of things:
  - Switch from fences to timeline semaphores (Qualcomm drivers support it now).
  - Simplify core/gpu interface -- `gpu_begin` was removed, you can just submit streams whenever you want.  You can provide an ID that is used to poll/wait for completion.