### PR TITLE
Model Rework

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,14 @@ dev
 - Add `Pass:getViewRay`.
 - Add `lovr.headset.connect` and `t.headset.connect`.
 - Add support for creating 3D texture views.
+- Add `Model:meshes` to iterate over model nodes with meshes.
+- Add `Pass:drawPart` to draw a single part or mesh of a `Model`.
+- Add `Model(Data):getNodeChild/getNodeSibling`.
+- Add `Model(Data):getNodeMesh` (replaces `:getNodeMeshes`).
+- Add `ModelData:getMeshBlendShapeCount/getMeshBlendShapeName/getBlendVertex`.
+- Add `ModelData:getMeshPartCount`.
+- Add `ModelData:getMeshDrawRange`.
+- Add `Mesh:get/setBaseVertex`.
 
 ### Change
 
@@ -29,6 +37,11 @@ dev
 - Change `lovr.headset.getPosition/Orientation/Direction/Pose` to also take a `Model`.
 - Change `TerrainShape` to support `nil` heights (treated as holes).
 - Change `Curve:render` to no longer always return 2 points for curves with 2 control points.
+- Change `ModelData:getMeshVertex` to return data in a consistent vertex format.
+- Change `ModelData:getMeshDrawMode/getMeshMaterial` to take an optional part index.
+- Change `ModelData:getWidth/Height/Depth/Dimensions/BoundingBox` to take an optional mesh/part index.
+- Change model loading to use multiple threads to load images.
+- Change `lovr.graphics.newModel` to no longer retain its `ModelData`, allowing its memory to be freed.
 
 ### Fix
 
@@ -52,10 +65,23 @@ dev
 ### Deprecate
 
 - Deprecate variant of `lovr.headset.newModel` that takes a `Device`.
+- Deprecate `Model(Data):getNodeChildren` (use `:getNodeChild` and `:getNodeSibling`).
+- Deprecate base vertex argument in `Mesh:get/setDrawRange` (use `Mesh:get/setBaseVertex`).
+- Deprecate `Model:getVertexBuffer/getIndexBuffer/getMesh` (create your own from `ModelData`).
 
 ### Remove
 
 - Remove `animated` flag in `lovr.headset.newModel` (all models are animated now).
+- Remove support for creating `ConvexShape` and `MeshShape` from a `Model` (use `ModelData`).
+- Remove support for passing a `Model` to `lovr.audio.setGeometry` (use `ModelData`).
+- Remove `ModelData:getBlobCount` and `ModelData:getBlob`.
+- Remove `ModelData:getNodeMeshes` (use `ModelData:getNodeMesh`).
+- Remove `ModelData:getMeshVertexFormat/getMeshIndexFormat`.
+- Remove `ModelData:getTriangleCount` (use `ModelData:getMeshVertexCount/getMeshIndexCount`).
+- Remove `ModelData:getTriangles` (use `ModelData:getMeshVertex/getMeshIndex`).
+- Remove `Model(Data):getBoundingSphere`.
+- Remove `Model:getVertexCount` (use `ModelData:getMeshVertexCount`).
+- Remove `Model:getData` (create and keep a `ModelData` around as needed).
 
 v0.18.0 - 2025-02-14
 ---

--- a/etc/shaders/animator.comp
+++ b/etc/shaders/animator.comp
@@ -6,7 +6,8 @@
 layout(local_size_x = 32, local_size_x_id = 0) in;
 
 layout(push_constant) uniform PushConstants {
-  uint baseVertex;
+  uint baseVertexIn;
+  uint baseVertexOut;
   uint vertexCount;
   bool inplace;
 };
@@ -31,14 +32,14 @@ layout(set = 0, binding = 3) uniform JointTransforms { mat4 joints[256]; };
 
 void lovrmain() {
   if (GlobalThreadID.x >= vertexCount) return;
-  uint vertexIndex = baseVertex + GlobalThreadID.x;
+  uint id = GlobalThreadID.x;
 
-  uint indices = skin[vertexIndex].indices;
+  uint indices = skin[baseVertexIn + id].indices;
   uint i0 = (indices >> 0) & 0xff;
   uint i1 = (indices >> 8) & 0xff;
   uint i2 = (indices >> 16) & 0xff;
   uint i3 = (indices >> 24) & 0xff;
-  vec4 weights = unpackUnorm4x8(skin[vertexIndex].weights);
+  vec4 weights = unpackUnorm4x8(skin[baseVertexIn + id].weights);
 
   // Model loader does not currently renormalize weights post-quantization
   weights /= weights[0] + weights[1] + weights[2] + weights[3];
@@ -49,15 +50,15 @@ void lovrmain() {
   matrix += joints[i2] * weights[2];
   matrix += joints[i3] * weights[3];
 
-  ModelVertex vertex = inplace ? vertexOut[vertexIndex] : vertexIn[vertexIndex];
+  ModelVertex vertex = inplace ? vertexOut[baseVertexOut + id] : vertexIn[baseVertexIn + id];
   vec4 position = vec4(vertex.x, vertex.y, vertex.z, 1.);
   vec3 normal = normalize(unpackSnorm10x3(vertex.normal).xyz);
 
   vec3 skinnedPosition = (matrix * position).xyz;
   vec3 skinnedNormal = mat3(matrix) * normal;
 
-  vertexOut[vertexIndex].x = skinnedPosition.x;
-  vertexOut[vertexIndex].y = skinnedPosition.y;
-  vertexOut[vertexIndex].z = skinnedPosition.z;
-  vertexOut[vertexIndex].normal = packSnorm10x3(vec4(skinnedNormal, 0.));
+  vertexOut[baseVertexOut + id].x = skinnedPosition.x;
+  vertexOut[baseVertexOut + id].y = skinnedPosition.y;
+  vertexOut[baseVertexOut + id].z = skinnedPosition.z;
+  vertexOut[baseVertexOut + id].normal = packSnorm10x3(vec4(skinnedNormal, 0.));
 }

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -545,7 +545,7 @@ void luax_optcolor(lua_State* L, int index, float color[4]) {
   }
 }
 
-int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCount, uint32_t** indices, uint32_t* indexCount, bool* shouldFree) {
+int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCount, uint32_t** indices, uint32_t* indexCount) {
   if (lua_istable(L, index)) {
     lua_rawgeti(L, index, 1);
     bool nested = lua_type(L, -1) == LUA_TTABLE;
@@ -554,7 +554,6 @@ int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCou
     *vertexCount = luax_len(L, index) / (nested ? 1 : 3);
     luax_check(L, *vertexCount > 0, "Invalid mesh data: vertex count is zero");
     *vertices = lovrMalloc(sizeof(float) * *vertexCount * 3);
-    *shouldFree = true;
 
     if (nested) {
       for (uint32_t i = 0; i < *vertexCount; i++) {
@@ -598,7 +597,6 @@ int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCou
 
   if (modelData) {
     lovrModelDataGetTriangles(modelData, vertices, indices, vertexCount, indexCount);
-    *shouldFree = false;
     return index + 1;
   }
 
@@ -607,7 +605,6 @@ int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCou
 
   if (mesh) {
     luax_assert(L, lovrMeshGetTriangles(mesh, vertices, indices, vertexCount, indexCount));
-    *shouldFree = true;
     return index + 1;
   }
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -603,15 +603,6 @@ int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCou
   }
 
 #ifndef LOVR_DISABLE_GRAPHICS
-  Model* model = luax_totype(L, index, Model);
-
-  if (model) {
-    ModelData* modelData = lovrModelGetInfo(model)->data;
-    lovrModelDataGetTriangles(modelData, vertices, indices, vertexCount, indexCount);
-    *shouldFree = false;
-    return index + 1;
-  }
-
   Mesh* mesh = luax_totype(L, index, Mesh);
 
   if (mesh) {
@@ -620,7 +611,7 @@ int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCou
     return index + 1;
   }
 
-  luaL_argerror(L, index, "table, ModelData, Model, or Mesh expected");
+  luaL_argerror(L, index, "table, ModelData, or Mesh expected");
 #else
   luaL_argerror(L, index, "table or ModelData expected");
 #endif

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -146,13 +146,13 @@ int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCou
 #ifndef LOVR_DISABLE_DATA
 struct Blob;
 struct Image;
-struct ModelData;
+struct ModelMetadata;
 struct Blob* luax_readblob(lua_State* L, int index, const char* debug);
 struct Image* luax_checkimage(lua_State* L, int index);
 uint32_t luax_checkcodepoint(lua_State* L, int index);
-uint32_t luax_checkanimationindex(lua_State* L, int index, struct ModelData* model);
-uint32_t luax_checkmaterialindex(lua_State* L, int index, struct ModelData* model);
-uint32_t luax_checknodeindex(lua_State* L, int index, struct ModelData* model);
+uint32_t luax_checkanimationindex(lua_State* L, int index, struct ModelMetadata* model);
+uint32_t luax_checkmaterialindex(lua_State* L, int index, struct ModelMetadata* model);
+uint32_t luax_checknodeindex(lua_State* L, int index, struct ModelMetadata* model);
 #endif
 
 #ifndef LOVR_DISABLE_EVENT

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -139,7 +139,7 @@ uint32_t _luax_checku32(lua_State* L, int index);
 uint32_t _luax_optu32(lua_State* L, int index, uint32_t fallback);
 void luax_readcolor(lua_State* L, int index, float color[4]);
 void luax_optcolor(lua_State* L, int index, float color[4]);
-int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCount, uint32_t** indices, uint32_t* indexCount, bool* shouldFree);
+int luax_readmesh(lua_State* L, int index, float** vertices, uint32_t* vertexCount, uint32_t** indices, uint32_t* indexCount);
 
 // Module helpers
 

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -17,7 +17,6 @@ typedef struct {
 
 extern StringEntry lovrAnimationProperty[];
 extern StringEntry lovrArcMode[];
-extern StringEntry lovrAttributeType[];
 extern StringEntry lovrAudioMaterial[];
 extern StringEntry lovrAudioShareMode[];
 extern StringEntry lovrAudioType[];
@@ -31,7 +30,6 @@ extern StringEntry lovrChannelLayout[];
 extern StringEntry lovrCompareMode[];
 extern StringEntry lovrCullMode[];
 extern StringEntry lovrDataType[];
-extern StringEntry lovrDefaultAttribute[];
 extern StringEntry lovrDefaultShader[];
 extern StringEntry lovrDevice[];
 extern StringEntry lovrDeviceAxis[];

--- a/src/api/l_audio.c
+++ b/src/api/l_audio.c
@@ -193,14 +193,11 @@ static int l_lovrAudioSetGeometry(lua_State* L) {
   float* vertices;
   uint32_t* indices;
   uint32_t vertexCount, indexCount;
-  bool shouldFree;
-  int index = luax_readmesh(L, 1, &vertices, &vertexCount, &indices, &indexCount, &shouldFree);
+  int index = luax_readmesh(L, 1, &vertices, &vertexCount, &indices, &indexCount);
   AudioMaterial material = luax_checkenum(L, index, AudioMaterial, "generic");
   bool success = lovrAudioSetGeometry(vertices, indices, vertexCount, indexCount, material);
-  if (shouldFree) {
-    lovrFree(vertices);
-    lovrFree(indices);
-  }
+  lovrFree(vertices);
+  lovrFree(indices);
   lua_pushboolean(L, success);
   return 1;
 }

--- a/src/api/l_data.c
+++ b/src/api/l_data.c
@@ -16,28 +16,6 @@ StringEntry lovrAnimationProperty[] = {
   { 0 }
 };
 
-StringEntry lovrAttributeType[] = {
-  [I8] = ENTRY("i8"),
-  [U8] = ENTRY("u8"),
-  [I16] = ENTRY("i16"),
-  [U16] = ENTRY("u16"),
-  [I32] = ENTRY("i32"),
-  [U32] = ENTRY("u32"),
-  [F32] = ENTRY("f32"),
-  { 0 }
-};
-
-StringEntry lovrDefaultAttribute[] = {
-  [ATTR_POSITION] = ENTRY("position"),
-  [ATTR_NORMAL] = ENTRY("normal"),
-  [ATTR_UV] = ENTRY("uv"),
-  [ATTR_COLOR] = ENTRY("color"),
-  [ATTR_TANGENT] = ENTRY("tangent"),
-  [ATTR_JOINTS] = ENTRY("joints"),
-  [ATTR_WEIGHTS] = ENTRY("weights"),
-  { 0 }
-};
-
 StringEntry lovrModelDrawMode[] = {
   [DRAW_POINT_LIST] = ENTRY("points"),
   [DRAW_LINE_LIST] = ENTRY("lines"),

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -61,6 +61,19 @@ uint32_t luax_checknodeindex(lua_State* L, int index, ModelData* model) {
   }
 }
 
+uint32_t luax_checkmeshindex(lua_State* L, int index, ModelData* model) {
+  uint32_t mesh = luax_checku32(L, index) - 1;
+  luax_check(L, mesh < model->meshCount, "Invalid mesh index '%d'", mesh + 1);
+  return 1;
+}
+
+ModelPart* luax_checkmeshpart(lua_State* L, int index, ModelData* model) {
+  uint32_t mesh = luax_checkmeshindex(L, index, model);
+  uint32_t part = luax_optu32(L, index + 1, 1) - 1;
+  luax_check(L, part < model->meshes[mesh].partCount, "Invalid part index '%d'", part + 1);
+  return &model->meshes[mesh].parts[part];
+}
+
 static int l_lovrModelDataGetMetadata(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
 
@@ -281,9 +294,37 @@ static int l_lovrModelDataGetMeshCount(lua_State* L) {
 
 static int l_lovrModelDataGetMeshPartCount(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t mesh = luax_checku32(L, 2) - 1;
-  luax_check(L, mesh < model->meshCount, "Invalid mesh index '%d'", mesh + 1);
+  uint32_t mesh = luax_checkmeshindex(L, 2, model);
   lua_pushinteger(L, model->meshes[mesh].partCount);
+  return 1;
+}
+
+static int l_lovrModelDataGetMeshDrawMode(lua_State* L) {
+  ModelData* model = luax_checktype(L,  1, ModelData);
+  ModelPart* part = luax_checkmeshpart(L, 2, model);
+  luax_pushenum(L, ModelDrawMode, part->mode);
+  return 1;
+}
+
+static int l_lovrModelDataGetMeshDrawRange(lua_State* L) {
+  ModelData* model = luax_checktype(L,  1, ModelData);
+  ModelPart* part = luax_checkmeshpart(L, 2, model);
+  lua_pushinteger(L, part->start + 1);
+  lua_pushinteger(L, part->count);
+  return 2;
+}
+
+static int l_lovrModelDataGetMeshBaseVertex(lua_State* L) {
+  ModelData* model = luax_checktype(L,  1, ModelData);
+  ModelPart* part = luax_checkmeshpart(L, 2, model);
+  lua_pushinteger(L, part->baseVertex);
+  return 1;
+}
+
+static int l_lovrModelDataGetMeshMaterial(lua_State* L) {
+  ModelData* model = luax_checktype(L,  1, ModelData);
+  ModelPart* part = luax_checkmeshpart(L, 2, model);
+  lua_pushinteger(L, part->material + 1);
   return 1;
 }
 
@@ -673,6 +714,10 @@ const luaL_Reg lovrModelData[] = {
   { "getNodeSkin", l_lovrModelDataGetNodeSkin },
   { "getMeshCount", l_lovrModelDataGetMeshCount },
   { "getMeshPartCount", l_lovrModelDataGetMeshPartCount },
+  { "getMeshDrawMode", l_lovrModelDataGetMeshDrawMode },
+  { "getMeshDrawRange", l_lovrModelDataGetMeshDrawRange },
+  { "getMeshBaseVertex", l_lovrModelDataGetMeshBaseVertex },
+  { "getMeshMaterial", l_lovrModelDataGetMeshMaterial },
   { "getTriangles", l_lovrModelDataGetTriangles },
   { "getTriangleCount", l_lovrModelDataGetTriangleCount },
   { "getVertexCount", l_lovrModelDataGetVertexCount },

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -103,25 +103,6 @@ static ModelPart* luax_checkmeshpart(lua_State* L, int index, ModelMetadata* met
   return &meta->meshes[mesh].parts[part];
 }
 
-static int luax_pushmodelvertex(lua_State* L, ModelVertex* vertex) {
-  lua_pushnumber(L, vertex->position.x);
-  lua_pushnumber(L, vertex->position.y);
-  lua_pushnumber(L, vertex->position.z);
-  lua_pushnumber(L, (float) ((vertex->normal >>  0) & 0x3ff) / 511.f);
-  lua_pushnumber(L, (float) ((vertex->normal >> 10) & 0x3ff) / 511.f);
-  lua_pushnumber(L, (float) ((vertex->normal >> 20) & 0x3ff) / 511.f);
-  lua_pushnumber(L, vertex->uv.u);
-  lua_pushnumber(L, vertex->uv.v);
-  lua_pushinteger(L, vertex->color.r);
-  lua_pushinteger(L, vertex->color.g);
-  lua_pushinteger(L, vertex->color.b);
-  lua_pushinteger(L, vertex->color.a);
-  lua_pushnumber(L, (float) ((vertex->tangent >>  0) & 0x3ff) / 511.f);
-  lua_pushnumber(L, (float) ((vertex->tangent >> 10) & 0x3ff) / 511.f);
-  lua_pushnumber(L, (float) ((vertex->tangent >> 20) & 0x3ff) / 511.f);
-  return 15;
-}
-
 int l_lovrModelMetaGetMetadata(lua_State* L) {
   ModelMetadata* meta = luax_checkmodelmeta(L, 1);
 
@@ -340,6 +321,83 @@ int l_lovrModelMetaGetMeshCount(lua_State* L) {
   return 1;
 }
 
+int l_lovrModelMetaGetMeshVertexCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  if (lua_isnoneornil(L, 2)) {
+    lua_pushinteger(L, meta->vertexCount);
+  } else {
+    uint32_t mesh = luax_checkmeshindex(L, 2, meta);
+    lua_pushinteger(L, meta->meshes[mesh].vertexCount);
+  }
+  return 1;
+}
+
+int l_lovrModelMetaGetMeshIndexCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  if (lua_isnoneornil(L, 2)) {
+    lua_pushinteger(L, meta->indexCount);
+  } else {
+    uint32_t mesh = luax_checkmeshindex(L, 2, meta);
+    lua_pushinteger(L, meta->meshes[mesh].indexCount);
+  }
+  return 1;
+}
+
+static int l_lovrModelDataGetMeshVertex(lua_State* L) {
+  ModelData* model = luax_checktype(L, 1, ModelData);
+
+  uint32_t index;
+  if (lua_isnil(L, 2)) {
+    index = luax_checku32(L, 3) - 1;
+    luax_check(L, index < model->meta.vertexCount, "Vertex %d is out of range", index + 1);
+  } else {
+    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
+    uint32_t index = luax_checku32(L, 3) - 1;
+    luax_check(L, index < model->meta.meshes[mesh].vertexCount, "Vertex %d is out of range", index + 1);
+    index += model->meta.meshes[mesh].vertexOffset;
+  }
+
+  ModelVertex* vertex = &model->vertices[index];
+  lua_pushnumber(L, vertex->position.x);
+  lua_pushnumber(L, vertex->position.y);
+  lua_pushnumber(L, vertex->position.z);
+  lua_pushnumber(L, (float) ((vertex->normal >>  0) & 0x3ff) / 511.f);
+  lua_pushnumber(L, (float) ((vertex->normal >> 10) & 0x3ff) / 511.f);
+  lua_pushnumber(L, (float) ((vertex->normal >> 20) & 0x3ff) / 511.f);
+  lua_pushnumber(L, vertex->uv.u);
+  lua_pushnumber(L, vertex->uv.v);
+  lua_pushinteger(L, vertex->color.r);
+  lua_pushinteger(L, vertex->color.g);
+  lua_pushinteger(L, vertex->color.b);
+  lua_pushinteger(L, vertex->color.a);
+  lua_pushnumber(L, (float) ((vertex->tangent >>  0) & 0x3ff) / 511.f);
+  lua_pushnumber(L, (float) ((vertex->tangent >> 10) & 0x3ff) / 511.f);
+  lua_pushnumber(L, (float) ((vertex->tangent >> 20) & 0x3ff) / 511.f);
+  return 15;
+}
+
+static int l_lovrModelDataGetMeshIndex(lua_State* L) {
+  ModelData* model = luax_checktype(L, 1, ModelData);
+
+  uint32_t index;
+  if (lua_isnoneornil(L, 2)) {
+    index = luax_checku32(L, 3) - 1;
+    luax_check(L, index < model->meta.indexCount, "Index %d is out of range", index + 1);
+  } else {
+    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
+    index = luax_checku32(L, 3) - 1;
+    luax_check(L, index < model->meta.indexCount, "Index %d is out of range", index + 1);
+  }
+
+  if (model->meta.indexSize == 4) {
+    lua_pushinteger(L, ((uint32_t*) model->indices)[index]);
+  } else {
+    lua_pushinteger(L, ((uint16_t*) model->indices)[index]);
+  }
+
+  return 1;
+}
+
 int l_lovrModelMetaGetMeshPartCount(lua_State* L) {
   ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   uint32_t mesh = luax_checkmeshindex(L, 2, meta);
@@ -373,222 +431,6 @@ int l_lovrModelMetaGetMeshMaterial(lua_State* L) {
   ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   ModelPart* part = luax_checkmeshpart(L, 2, meta);
   lua_pushinteger(L, part->material + 1);
-  return 1;
-}
-
-int l_lovrModelMetaGetMeshVertexCount(lua_State* L) {
-  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
-  if (lua_isnoneornil(L, 2)) {
-    lua_pushinteger(L, meta->vertexCount);
-  } else {
-    uint32_t mesh = luax_checkmeshindex(L, 2, meta);
-    lua_pushinteger(L, meta->meshes[mesh].vertexCount);
-  }
-  return 1;
-}
-
-int l_lovrModelMetaGetMeshIndexCount(lua_State* L) {
-  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
-  if (lua_isnoneornil(L, 2)) {
-    lua_pushinteger(L, meta->indexCount);
-  } else {
-    uint32_t mesh = luax_checkmeshindex(L, 2, meta);
-    lua_pushinteger(L, meta->meshes[mesh].indexCount);
-  }
-  return 1;
-}
-
-static int l_lovrModelDataGetMeshVertices(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-
-  uint32_t start, count;
-  if (lua_isnoneornil(L, 2)) {
-    start = 0;
-    count = model->meta.vertexCount;
-  } else {
-    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
-    start = model->meta.meshes[mesh].vertexOffset;
-    count = model->meta.meshes[mesh].vertexCount;
-  }
-
-  lua_createtable(L, (int) count, 0);
-  for (uint32_t i = 0; i < count; i++) {
-    lua_createtable(L, 15, 0);
-    luax_pushmodelvertex(L, &model->vertices[start + i]);
-    for (int j = 15; j >= 1; j--) {
-      lua_rawseti(L, -j - 1, j);
-    }
-    lua_rawseti(L, -2, (int) i + 1);
-  }
-
-  return 1;
-}
-
-static int l_lovrModelDataGetMeshIndices(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-
-  uint32_t start, count;
-  if (lua_isnoneornil(L, 2)) {
-    start = 0;
-    count = model->meta.indexCount;
-  } else {
-    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
-    start = model->meta.meshes[mesh].indexOffset;
-    count = model->meta.meshes[mesh].indexCount;
-  }
-
-  lua_createtable(L, (int) count, 0);
-  if (model->meta.indexSize == 4) {
-    uint32_t* indices = (uint32_t*) model->indices + start;
-    for (uint32_t i = 0; i < count; i++) {
-      lua_pushinteger(L, indices[i]);
-      lua_rawseti(L, -2, i + 1);
-    }
-  } else {
-    uint16_t* indices = (uint16_t*) model->indices + start;
-    for (uint32_t i = 0; i < count; i++) {
-      lua_pushinteger(L, indices[i]);
-      lua_rawseti(L, -2, i + 1);
-    }
-  }
-
-  return 1;
-}
-
-static int l_lovrModelDataGetMeshVertex(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-
-  uint32_t index;
-  if (lua_isnil(L, 2)) {
-    index = luax_checku32(L, 3) - 1;
-    luax_check(L, index < model->meta.vertexCount, "Vertex %d is out of range", index + 1);
-  } else {
-    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
-    uint32_t index = luax_checku32(L, 3) - 1;
-    luax_check(L, index < model->meta.meshes[mesh].vertexCount, "Vertex %d is out of range", index + 1);
-    index += model->meta.meshes[mesh].vertexOffset;
-  }
-
-  return luax_pushmodelvertex(L, &model->vertices[index]);
-}
-
-static int l_lovrModelDataGetMeshIndex(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-
-  uint32_t index;
-  if (lua_isnoneornil(L, 2)) {
-    index = luax_checku32(L, 3) - 1;
-    luax_check(L, index < model->meta.indexCount, "Index %d is out of range", index + 1);
-  } else {
-    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
-    index = luax_checku32(L, 3) - 1;
-    luax_check(L, index < model->meta.indexCount, "Index %d is out of range", index + 1);
-  }
-
-  if (model->meta.indexSize == 4) {
-    lua_pushinteger(L, ((uint32_t*) model->indices)[index]);
-  } else {
-    lua_pushinteger(L, ((uint16_t*) model->indices)[index]);
-  }
-
-  return 1;
-}
-
-int l_lovrModelMetaGetVertexCount(lua_State* L) {
-  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
-  lua_pushinteger(L, lovrModelMetadataGetTotalVertexCount(meta));
-  return 1;
-}
-
-int l_lovrModelMetaGetIndexCount(lua_State* L) {
-  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
-  lua_pushinteger(L, lovrModelMetadataGetTotalIndexCount(meta));
-  return 1;
-}
-
-static int l_lovrModelDataGetTriangles(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-
-  if (lua_isnoneornil(L, 2)) {
-    float* vertices = NULL;
-    uint32_t* indices = NULL;
-    uint32_t vertexCount = 0;
-    uint32_t indexCount = 0;
-    lovrModelDataGetTriangles(model, &vertices, &indices, &vertexCount, &indexCount);
-
-    lua_createtable(L, vertexCount * 3, 0);
-    for (uint32_t i = 0; i < vertexCount * 3; i++) {
-      lua_pushnumber(L, vertices[i]);
-      lua_rawseti(L, -2, i + 1);
-    }
-
-    lua_createtable(L, indexCount, 0);
-    for (uint32_t i = 0; i < indexCount; i++) {
-      lua_pushinteger(L, indices[i] + 1);
-      lua_rawseti(L, -2, i + 1);
-    }
-  } else {
-    uint32_t meshIndex = luax_checku32(L, 2) - 1;
-    luax_check(L, meshIndex < model->meta.meshCount, "Invalid mesh index '%d'", meshIndex + 1);
-
-    ModelMesh* mesh = &model->meta.meshes[meshIndex];
-    ModelVertex* vertex = model->vertices + mesh->vertexOffset;
-
-    lua_createtable(L, mesh->vertexCount, 0);
-    for (uint32_t i = 0; i < mesh->vertexCount; i++, vertex++) {
-      lua_pushnumber(L, vertex->position.x);
-      lua_rawseti(L, -2, 3 * i + 1);
-
-      lua_pushnumber(L, vertex->position.y);
-      lua_rawseti(L, -2, 3 * i + 2);
-
-      lua_pushnumber(L, vertex->position.z);
-      lua_rawseti(L, -2, 3 * i + 3);
-    }
-
-    if (mesh->indexCount > 0) {
-      void* indices = model->indices;
-      uint32_t base = mesh->parts->baseVertex;
-      lua_createtable(L, mesh->indexCount, 0);
-
-      for (uint32_t i = 0; i < mesh->indexCount; i++) {
-        uint32_t index = model->meta.indexSize == 4 ? ((uint32_t*) indices)[i] : ((uint16_t*) indices)[i];
-        lua_pushinteger(L, index - base + 1);
-        lua_rawseti(L, -2, i + 1);
-      }
-    } else {
-      for (uint32_t i = 0; i < mesh->vertexCount; i++) {
-        lua_pushinteger(L, i + 1);
-        lua_rawseti(L, -2, i + 1);
-      }
-    }
-  }
-
-  return 2;
-}
-
-static int l_lovrModelDataGetTriangleCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-
-  if (lua_isnoneornil(L, 2)) {
-    uint32_t vertexCount, indexCount;
-    lovrModelDataGetTriangles(model, NULL, NULL, &vertexCount, &indexCount);
-    lua_pushinteger(L, indexCount / 3);
-  } else {
-    uint32_t meshIndex = luax_checku32(L, 2) - 1;
-    luax_check(L, meshIndex < model->meta.meshCount, "Invalid mesh index '%d'", meshIndex + 1);
-    ModelMesh* mesh = &model->meta.meshes[meshIndex];
-    uint32_t count = 0;
-
-    for (uint32_t i = 0; i < mesh->partCount; i++) {
-      if (mesh->parts[i].mode == DRAW_TRIANGLE_LIST) {
-        count += mesh->parts[i].count / 3;
-      }
-    }
-
-    lua_pushinteger(L, count);
-  }
-
   return 1;
 }
 
@@ -913,21 +755,15 @@ const luaL_Reg lovrModelData[] = {
   { "getNodeMesh", l_lovrModelMetaGetNodeMesh },
   { "getNodeSkin", l_lovrModelMetaGetNodeSkin },
   { "getMeshCount", l_lovrModelMetaGetMeshCount },
+  { "getMeshVertexCount", l_lovrModelMetaGetMeshVertexCount },
+  { "getMeshIndexCount", l_lovrModelMetaGetMeshIndexCount },
+  { "getMeshVertex", l_lovrModelDataGetMeshVertex },
+  { "getMeshIndex", l_lovrModelDataGetMeshIndex },
   { "getMeshPartCount", l_lovrModelMetaGetMeshPartCount },
   { "getMeshDrawMode", l_lovrModelMetaGetMeshDrawMode },
   { "getMeshDrawRange", l_lovrModelMetaGetMeshDrawRange },
   { "getMeshBaseVertex", l_lovrModelMetaGetMeshBaseVertex },
   { "getMeshMaterial", l_lovrModelMetaGetMeshMaterial },
-  { "getMeshVertexCount", l_lovrModelMetaGetMeshVertexCount },
-  { "getMeshIndexCount", l_lovrModelMetaGetMeshIndexCount },
-  { "getMeshVertices", l_lovrModelDataGetMeshVertices },
-  { "getMeshIndices", l_lovrModelDataGetMeshIndices },
-  { "getMeshVertex", l_lovrModelDataGetMeshVertex },
-  { "getMeshIndex", l_lovrModelDataGetMeshIndex },
-  { "getVertexCount", l_lovrModelMetaGetVertexCount },
-  { "getIndexCount", l_lovrModelMetaGetIndexCount },
-  { "getTriangles", l_lovrModelDataGetTriangles },
-  { "getTriangleCount", l_lovrModelDataGetTriangleCount },
   { "getWidth", l_lovrModelMetaGetWidth },
   { "getHeight", l_lovrModelMetaGetHeight },
   { "getDepth", l_lovrModelMetaGetDepth },

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -73,20 +73,6 @@ static int l_lovrModelDataGetMetadata(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetImageCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  lua_pushinteger(L, model->imageCount);
-  return 1;
-}
-
-static int l_lovrModelDataGetImage(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->imageCount, "Invalid image index '%d'", index + 1);
-  luax_pushtype(L, Image, model->images[index]);
-  return 1;
-}
-
 static int l_lovrModelDataGetRootNode(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   lua_pushinteger(L, model->rootNode + 1);
@@ -401,6 +387,20 @@ static int l_lovrModelDataGetBoundingSphere(lua_State* L) {
   return 4;
 }
 
+static int l_lovrModelDataGetImageCount(lua_State* L) {
+  ModelData* model = luax_checktype(L, 1, ModelData);
+  lua_pushinteger(L, model->imageCount);
+  return 1;
+}
+
+static int l_lovrModelDataGetImage(lua_State* L) {
+  ModelData* model = luax_checktype(L, 1, ModelData);
+  uint32_t index = luax_checku32(L, 2) - 1;
+  luax_check(L, index < model->imageCount, "Invalid image index '%d'", index + 1);
+  luax_pushtype(L, Image, model->images[index]);
+  return 1;
+}
+
 static int l_lovrModelDataGetMaterialCount(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   lua_pushinteger(L, model->materialCount);
@@ -617,13 +617,11 @@ static int l_lovrModelDataGetBlendShapeName(lua_State* L) {
 
 const luaL_Reg lovrModelData[] = {
   { "getMetadata", l_lovrModelDataGetMetadata },
-  { "getImageCount", l_lovrModelDataGetImageCount },
-  { "getImage", l_lovrModelDataGetImage },
   { "getRootNode", l_lovrModelDataGetRootNode },
   { "getNodeCount", l_lovrModelDataGetNodeCount },
   { "getNodeName", l_lovrModelDataGetNodeName },
   { "getNodeChild", l_lovrModelDataGetNodeChild },
-  { "getNodeChildren", l_lovrModelDataGetNodeChildren },
+  { "getNodeChildren", l_lovrModelDataGetNodeChildren }, // Deprecated
   { "getNodeSibling", l_lovrModelDataGetNodeSibling },
   { "getNodeParent", l_lovrModelDataGetNodeParent },
   { "getNodePosition", l_lovrModelDataGetNodePosition },
@@ -644,6 +642,8 @@ const luaL_Reg lovrModelData[] = {
   { "getCenter", l_lovrModelDataGetCenter },
   { "getBoundingBox", l_lovrModelDataGetBoundingBox },
   { "getBoundingSphere", l_lovrModelDataGetBoundingSphere },
+  { "getImageCount", l_lovrModelDataGetImageCount },
+  { "getImage", l_lovrModelDataGetImage },
   { "getMaterialCount", l_lovrModelDataGetMaterialCount },
   { "getMaterialName", l_lovrModelDataGetMaterialName },
   { "getMaterial", l_lovrModelDataGetMaterial },

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -279,6 +279,14 @@ static int l_lovrModelDataGetMeshCount(lua_State* L) {
   return 1;
 }
 
+static int l_lovrModelDataGetMeshPartCount(lua_State* L) {
+  ModelData* model = luax_checktype(L, 1, ModelData);
+  uint32_t mesh = luax_checku32(L, 2) - 1;
+  luax_check(L, mesh < model->meshCount, "Invalid mesh index '%d'", mesh + 1);
+  lua_pushinteger(L, model->meshes[mesh].partCount);
+  return 1;
+}
+
 static int l_lovrModelDataGetTriangles(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
 
@@ -319,10 +327,29 @@ static int l_lovrModelDataGetVertexCount(lua_State* L) {
   return 1;
 }
 
+static void luax_checkboundingbox(lua_State* L, int index, ModelData* model, float bounds[6]) {
+  if (lua_type(L, index) == LUA_TNONE) {
+    lovrModelDataGetBoundingBox(model, bounds);
+    return;
+  }
+
+  uint32_t mesh = luax_checku32(L, index) - 1;
+  luax_check(L, mesh < model->meshCount, "Invalid mesh index '%d'", mesh + 1);
+
+  if (lua_type(L, index + 1) == LUA_TNONE) {
+    lovrModelDataGetMeshBoundingBox(model, mesh, bounds);
+    return;
+  }
+
+  uint32_t part = luax_checku32(L, index + 1) - 1;
+  luax_check(L, part < model->meshes[mesh].partCount, "Invalid part index '%d'", part + 1);
+  memcpy(bounds, model->meshes[mesh].parts[part].bounds, 6 * sizeof(float));
+}
+
 static int l_lovrModelDataGetWidth(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   float bounds[6];
-  lovrModelDataGetBoundingBox(model, bounds);
+  luax_checkboundingbox(L, 2, model, bounds);
   lua_pushnumber(L, bounds[1] - bounds[0]);
   return 1;
 }
@@ -330,7 +357,7 @@ static int l_lovrModelDataGetWidth(lua_State* L) {
 static int l_lovrModelDataGetHeight(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   float bounds[6];
-  lovrModelDataGetBoundingBox(model, bounds);
+  luax_checkboundingbox(L, 2, model, bounds);
   lua_pushnumber(L, bounds[3] - bounds[2]);
   return 1;
 }
@@ -338,7 +365,7 @@ static int l_lovrModelDataGetHeight(lua_State* L) {
 static int l_lovrModelDataGetDepth(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   float bounds[6];
-  lovrModelDataGetBoundingBox(model, bounds);
+  luax_checkboundingbox(L, 2, model, bounds);
   lua_pushnumber(L, bounds[5] - bounds[4]);
   return 1;
 }
@@ -346,7 +373,7 @@ static int l_lovrModelDataGetDepth(lua_State* L) {
 static int l_lovrModelDataGetDimensions(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   float bounds[6];
-  lovrModelDataGetBoundingBox(model, bounds);
+  luax_checkboundingbox(L, 2, model, bounds);
   lua_pushnumber(L, bounds[1] - bounds[0]);
   lua_pushnumber(L, bounds[3] - bounds[2]);
   lua_pushnumber(L, bounds[5] - bounds[4]);
@@ -356,7 +383,7 @@ static int l_lovrModelDataGetDimensions(lua_State* L) {
 static int l_lovrModelDataGetCenter(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   float bounds[6];
-  lovrModelDataGetBoundingBox(model, bounds);
+  luax_checkboundingbox(L, 2, model, bounds);
   lua_pushnumber(L, (bounds[0] + bounds[1]) / 2.f);
   lua_pushnumber(L, (bounds[2] + bounds[3]) / 2.f);
   lua_pushnumber(L, (bounds[4] + bounds[5]) / 2.f);
@@ -366,7 +393,7 @@ static int l_lovrModelDataGetCenter(lua_State* L) {
 static int l_lovrModelDataGetBoundingBox(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   float bounds[6];
-  lovrModelDataGetBoundingBox(model, bounds);
+  luax_checkboundingbox(L, 2, model, bounds);
   lua_pushnumber(L, bounds[0]);
   lua_pushnumber(L, bounds[1]);
   lua_pushnumber(L, bounds[2]);
@@ -379,7 +406,20 @@ static int l_lovrModelDataGetBoundingBox(lua_State* L) {
 static int l_lovrModelDataGetBoundingSphere(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   float sphere[4];
-  lovrModelDataGetBoundingSphere(model, sphere);
+  if (lua_type(L, 2) == LUA_TNONE) {
+    lovrModelDataGetBoundingSphere(model, sphere);
+  } else {
+    uint32_t mesh = luax_checku32(L, 2) - 1;
+    luax_check(L, mesh < model->meshCount, "Invalid mesh index '%d'", mesh + 1);
+
+    uint32_t part = ~0u;
+    if (lua_type(L, 3) != LUA_TNONE) {
+      part = luax_checku32(L, 3);
+      luax_check(L, part < model->meshes[mesh].partCount, "Invalid part index '%d'", part + 1);
+    }
+
+    lovrModelDataGetMeshBoundingSphere(model, mesh, part, sphere);
+  }
   lua_pushnumber(L, sphere[0]);
   lua_pushnumber(L, sphere[1]);
   lua_pushnumber(L, sphere[2]);
@@ -632,6 +672,7 @@ const luaL_Reg lovrModelData[] = {
   { "getNodeMesh", l_lovrModelDataGetNodeMesh },
   { "getNodeSkin", l_lovrModelDataGetNodeSkin },
   { "getMeshCount", l_lovrModelDataGetMeshCount },
+  { "getMeshPartCount", l_lovrModelDataGetMeshPartCount },
   { "getTriangles", l_lovrModelDataGetTriangles },
   { "getTriangleCount", l_lovrModelDataGetTriangleCount },
   { "getVertexCount", l_lovrModelDataGetVertexCount },

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -73,20 +73,6 @@ static int l_lovrModelDataGetMetadata(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetBlobCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  lua_pushinteger(L, model->blobCount);
-  return 1;
-}
-
-static int l_lovrModelDataGetBlob(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->blobCount, "Invalid blob index '%d'", index + 1);
-  luax_pushtype(L, Blob, model->blobs[index]);
-  return 1;
-}
-
 static int l_lovrModelDataGetImageCount(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   lua_pushinteger(L, model->imageCount);
@@ -279,13 +265,13 @@ static int l_lovrModelDataGetNodeTransform(lua_State* L) {
   return 10;
 }
 
-static int l_lovrModelDataGetNodeMeshes(lua_State* L) {
+static int l_lovrModelDataGetNodeMesh(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
-  lua_createtable(L, node->primitiveCount, 0);
-  for (uint32_t i = 0; i < node->primitiveCount; i++) {
-    lua_pushinteger(L, node->primitiveIndex + i + 1);
-    lua_rawseti(L, -2, i + 1);
+  if (node->mesh == ~0u) {
+    lua_pushnil(L);
+  } else {
+    lua_pushinteger(L, node->mesh + 1);
   }
   return 1;
 }
@@ -303,160 +289,8 @@ static int l_lovrModelDataGetNodeSkin(lua_State* L) {
 
 static int l_lovrModelDataGetMeshCount(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  lua_pushinteger(L, model->primitiveCount);
+  lua_pushinteger(L, model->meshCount);
   return 1;
-}
-
-static int l_lovrModelDataGetMeshDrawMode(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
-  ModelPrimitive* mesh = &model->primitives[index];
-  luax_pushenum(L, ModelDrawMode, mesh->mode);
-  return 1;
-}
-
-static int l_lovrModelDataGetMeshMaterial(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
-  ModelPrimitive* mesh = &model->primitives[index];
-  if (mesh->material == ~0u) {
-    lua_pushnil(L);
-  } else {
-    lua_pushinteger(L, mesh->material + 1);
-  }
-  return 1;
-}
-
-static int l_lovrModelDataGetMeshVertexCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
-  ModelPrimitive* mesh = &model->primitives[index];
-  lua_pushinteger(L, mesh->attributes[ATTR_POSITION] ? mesh->attributes[ATTR_POSITION]->count : 0);
-  return 1;
-}
-
-static int l_lovrModelDataGetMeshIndexCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
-  ModelPrimitive* mesh = &model->primitives[index];
-  lua_pushinteger(L, mesh->indices ? mesh->indices->count : 0);
-  return 1;
-}
-
-static int l_lovrModelDataGetMeshVertexFormat(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
-  ModelPrimitive* mesh = &model->primitives[index];
-  lua_newtable(L);
-  uint32_t count = 0;
-  for (uint32_t i = 0; i < MAX_DEFAULT_ATTRIBUTES; i++) {
-    ModelAttribute* attribute = mesh->attributes[i];
-    if (!attribute) continue;
-
-    lua_createtable(L, 6, 0);
-
-    luax_pushenum(L, DefaultAttribute, i);
-    lua_rawseti(L, -2, 1);
-
-    luax_pushenum(L, AttributeType, attribute->type);
-    lua_rawseti(L, -2, 2);
-
-    lua_pushinteger(L, attribute->components);
-    lua_rawseti(L, -2, 3);
-
-    lua_pushinteger(L, model->buffers[attribute->buffer].blob + 1);
-    lua_rawseti(L, -2, 4);
-
-    lua_pushinteger(L, model->buffers[attribute->buffer].offset + attribute->offset);
-    lua_rawseti(L, -2, 5);
-
-    lua_pushinteger(L, model->buffers[attribute->buffer].stride);
-    lua_rawseti(L, -2, 6);
-
-    lua_rawseti(L, -2, ++count);
-  }
-  return 1;
-}
-
-static int l_lovrModelDataGetMeshIndexFormat(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
-  ModelPrimitive* mesh = &model->primitives[index];
-  if (!mesh->indices) return lua_pushnil(L), 1;
-  luax_pushenum(L, AttributeType, mesh->indices->type);
-  lua_pushinteger(L, model->buffers[mesh->indices->buffer].blob + 1);
-  lua_pushinteger(L, model->buffers[mesh->indices->buffer].offset + mesh->indices->offset);
-  lua_pushinteger(L, model->buffers[mesh->indices->buffer].stride);
-  return 4;
-}
-
-static int l_lovrModelDataGetMeshVertex(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->primitiveCount, "Invalid mesh index '%d'", index + 1);
-  ModelPrimitive* mesh = &model->primitives[index];
-  uint32_t vertex = luax_checku32(L, 3) - 1;
-  uint32_t vertexCount = mesh->attributes[ATTR_POSITION] ? mesh->attributes[ATTR_POSITION]->count : 0;
-  luax_check(L, vertex < vertexCount, "Invalid vertex index '%d'", vertex + 1);
-  uint32_t total = 0;
-  for (uint32_t i = 0; i < MAX_DEFAULT_ATTRIBUTES; i++) {
-    ModelAttribute* attribute = mesh->attributes[i];
-    if (!attribute) continue;
-
-    size_t stride = model->buffers[attribute->buffer].stride;
-
-    if (!stride) {
-      switch (attribute->type) {
-        case I8: case U8: stride = attribute->components * 1; break;
-        case I16: case U16: stride = attribute->components * 2; break;
-        case I32: case U32: case F32: stride = attribute->components * 4; break;
-        default: break;
-      }
-    }
-
-    AttributeData data = { .raw = model->buffers[attribute->buffer].data };
-    data.u8 += attribute->offset;
-    data.u8 += vertex * stride;
-
-    for (uint32_t j = 0; j < attribute->components; j++) {
-      switch (attribute->type) {
-        case I8: lua_pushinteger(L, data.i8[j]); break;
-        case U8: lua_pushinteger(L, data.u8[j]); break;
-        case I16: lua_pushinteger(L, data.i16[j]); break;
-        case U16: lua_pushinteger(L, data.u16[j]); break;
-        case I32: lua_pushinteger(L, data.i32[j]); break;
-        case U32: lua_pushinteger(L, data.u32[j]); break;
-        case F32: lua_pushnumber(L, data.f32[j]); break;
-        default: break;
-      }
-    }
-
-    total += attribute->components;
-  }
-  return total;
-}
-
-static int l_lovrModelDataGetMeshIndex(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t meshIndex = luax_checku32(L, 2) - 1;
-  luax_check(L, meshIndex < model->primitiveCount, "Invalid mesh index '%d'", meshIndex + 1);
-  ModelPrimitive* mesh = &model->primitives[meshIndex];
-  uint32_t index = luax_checku32(L, 3) - 1;
-  uint32_t indexCount = mesh->indices ? mesh->indices->count : 0;
-  luax_check(L, index < indexCount, "Invalid index index '%d'", index + 1);
-  AttributeData data = { .raw = model->buffers[mesh->indices->buffer].data };
-  data.u8 += mesh->indices->offset;
-  switch (mesh->indices->type) {
-    case U16: lua_pushinteger(L, data.u16[index] + 1); return 1;
-    case U32: lua_pushinteger(L, data.u32[index] + 1); return 1;
-    default: lovrUnreachable();
-  }
 }
 
 static int l_lovrModelDataGetTriangles(lua_State* L) {
@@ -725,7 +559,7 @@ static int l_lovrModelDataGetAnimationKeyframe(lua_State* L) {
     case PROP_TRANSLATION: count = 3; break;
     case PROP_ROTATION: count = 4; break;
     case PROP_SCALE: count = 3; break;
-    case PROP_WEIGHTS: count = model->nodes[channel->nodeIndex].blendShapeCount; break;
+    case PROP_WEIGHTS: count = model->meshes[model->nodes[channel->nodeIndex].mesh].blendShapeCount; break;
   }
   for (int i = 0; i < count; i++) {
     lua_pushnumber(L, channel->data[keyframe * count + i]);
@@ -783,8 +617,6 @@ static int l_lovrModelDataGetBlendShapeName(lua_State* L) {
 
 const luaL_Reg lovrModelData[] = {
   { "getMetadata", l_lovrModelDataGetMetadata },
-  { "getBlobCount", l_lovrModelDataGetBlobCount },
-  { "getBlob", l_lovrModelDataGetBlob },
   { "getImageCount", l_lovrModelDataGetImageCount },
   { "getImage", l_lovrModelDataGetImage },
   { "getRootNode", l_lovrModelDataGetRootNode },
@@ -799,17 +631,9 @@ const luaL_Reg lovrModelData[] = {
   { "getNodeScale", l_lovrModelDataGetNodeScale },
   { "getNodePose", l_lovrModelDataGetNodePose },
   { "getNodeTransform", l_lovrModelDataGetNodeTransform },
-  { "getNodeMeshes", l_lovrModelDataGetNodeMeshes },
+  { "getNodeMesh", l_lovrModelDataGetNodeMesh },
   { "getNodeSkin", l_lovrModelDataGetNodeSkin },
   { "getMeshCount", l_lovrModelDataGetMeshCount },
-  { "getMeshDrawMode", l_lovrModelDataGetMeshDrawMode },
-  { "getMeshMaterial", l_lovrModelDataGetMeshMaterial },
-  { "getMeshVertexCount", l_lovrModelDataGetMeshVertexCount },
-  { "getMeshIndexCount", l_lovrModelDataGetMeshIndexCount },
-  { "getMeshVertexFormat", l_lovrModelDataGetMeshVertexFormat },
-  { "getMeshIndexFormat", l_lovrModelDataGetMeshIndexFormat },
-  { "getMeshVertex", l_lovrModelDataGetMeshVertex },
-  { "getMeshIndex", l_lovrModelDataGetMeshIndex },
   { "getTriangles", l_lovrModelDataGetTriangles },
   { "getTriangleCount", l_lovrModelDataGetTriangleCount },
   { "getVertexCount", l_lovrModelDataGetVertexCount },

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -321,6 +321,44 @@ int l_lovrModelMetaGetMeshCount(lua_State* L) {
   return 1;
 }
 
+int l_lovrModelMetaGetMeshBlendShapeCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  uint32_t mesh = luax_checkmeshindex(L, 2, meta);
+  lua_pushinteger(L, meta->meshes[mesh].blendShapeCount);
+  return 1;
+}
+
+int l_lovrModelMetaGetMeshBlendShapeName(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  uint32_t mesh = luax_checkmeshindex(L, 2, meta);
+  uint32_t blendShape = luax_checku32(L, 3) - 1;
+  luax_check(L, blendShape < meta->meshes[mesh].blendShapeCount, "Blend shape %d is out of range", blendShape + 1);
+  lua_pushstring(L, meta->meshes[mesh].blendShapes[blendShape].name);
+  return 1;
+}
+
+int l_lovrModelDataGetMeshBlendVertex(lua_State* L) {
+  ModelData* model = luax_checktype(L, 1, ModelData);
+  ModelMetadata* meta = &model->meta;
+  uint32_t meshIndex = luax_checkmeshindex(L, 2, meta);
+  uint32_t blendShape = luax_checku32(L, 3) - 1;
+  uint32_t vertex = luax_checku32(L, 4) - 1;
+  ModelMesh* mesh = &meta->meshes[meshIndex];
+  luax_check(L, blendShape < mesh->blendShapeCount, "Blend shape %d is out of range", blendShape + 1);
+  luax_check(L, vertex < mesh->vertexCount, "Vertex %d is out of range", vertex + 1);
+  BlendData* data = &model->blendData[mesh->blendDataOffset + blendShape * mesh->vertexCount + vertex];
+  lua_pushnumber(L, data->x);
+  lua_pushnumber(L, data->y);
+  lua_pushnumber(L, data->z);
+  lua_pushnumber(L, data->nx);
+  lua_pushnumber(L, data->ny);
+  lua_pushnumber(L, data->nz);
+  lua_pushnumber(L, data->tx);
+  lua_pushnumber(L, data->ty);
+  lua_pushnumber(L, data->tz);
+  return 9;
+}
+
 int l_lovrModelMetaGetMeshVertexCount(lua_State* L) {
   ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   uint32_t mesh = luax_checkmeshindex(L, 2, meta);
@@ -735,6 +773,9 @@ const luaL_Reg lovrModelData[] = {
   { "getNodeSkin", l_lovrModelMetaGetNodeSkin },
 
   { "getMeshCount", l_lovrModelMetaGetMeshCount },
+  { "getMeshBlendShapeCount", l_lovrModelMetaGetMeshBlendShapeCount },
+  { "getMeshBlendShapeName", l_lovrModelMetaGetMeshBlendShapeName },
+  { "getMeshBlendVertex", l_lovrModelDataGetMeshBlendVertex },
   { "getMeshVertexCount", l_lovrModelMetaGetMeshVertexCount },
   { "getMeshIndexCount", l_lovrModelMetaGetMeshIndexCount },
   { "getMeshVertex", l_lovrModelDataGetMeshVertex },
@@ -769,9 +810,6 @@ const luaL_Reg lovrModelData[] = {
   { "getSkinCount", l_lovrModelMetaGetSkinCount },
   { "getSkinJoints", l_lovrModelMetaGetSkinJoints },
   { "getSkinInverseBindMatrix", l_lovrModelMetaGetSkinInverseBindMatrix },
-
-  { "getBlendShapeCount", l_lovrModelMetaGetBlendShapeCount },
-  { "getBlendShapeName", l_lovrModelMetaGetBlendShapeName },
 
   { NULL, NULL }
 };

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -549,7 +549,7 @@ int l_lovrModelMetaGetMaterialCount(lua_State* L) {
 int l_lovrModelMetaGetMaterialName(lua_State* L) {
   ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < meta->nodeCount, "Invalid material index '%d'", index + 1);
+  luax_check(L, index < meta->materialCount, "Invalid material index '%d'", index + 1);
   lua_pushstring(L, meta->materials[index].name);
   return 1;
 }
@@ -590,9 +590,9 @@ static int l_lovrModelDataGetMaterial(lua_State* L) {
   lua_setfield(L, -2, "uvShift");
 
   lua_createtable(L, 2, 0);
-  lua_pushnumber(L, material->uvShift[0]);
+  lua_pushnumber(L, material->uvScale[0]);
   lua_rawseti(L, -2, 1);
-  lua_pushnumber(L, material->uvShift[1]);
+  lua_pushnumber(L, material->uvScale[1]);
   lua_rawseti(L, -2, 2);
   lua_setfield(L, -2, "uvScale");
 
@@ -731,7 +731,7 @@ int l_lovrModelMetaGetSkinInverseBindMatrix(lua_State* L) {
   luax_check(L, index < meta->skinCount, "Invalid skin index '%d'", index + 1);
   ModelSkin* skin = &meta->skins[index];
   uint32_t joint = luax_checku32(L, 3) - 1;
-  luax_check(L, index < skin->jointCount, "Invalid joint index '%d'", joint + 1);
+  luax_check(L, joint < skin->jointCount, "Invalid joint index '%d'", joint + 1);
   if (!skin->inverseBindMatrices) return lua_pushnil(L), 1;
   float* m = skin->inverseBindMatrices + joint * 16;
   for (uint32_t i = 0; i < 16; i++) {

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -323,41 +323,24 @@ int l_lovrModelMetaGetMeshCount(lua_State* L) {
 
 int l_lovrModelMetaGetMeshVertexCount(lua_State* L) {
   ModelMetadata* meta = luax_checkmodelmeta(L, 1);
-  if (lua_isnoneornil(L, 2)) {
-    lua_pushinteger(L, meta->vertexCount);
-  } else {
-    uint32_t mesh = luax_checkmeshindex(L, 2, meta);
-    lua_pushinteger(L, meta->meshes[mesh].vertexCount);
-  }
+  uint32_t mesh = luax_checkmeshindex(L, 2, meta);
+  lua_pushinteger(L, meta->meshes[mesh].vertexCount);
   return 1;
 }
 
 int l_lovrModelMetaGetMeshIndexCount(lua_State* L) {
   ModelMetadata* meta = luax_checkmodelmeta(L, 1);
-  if (lua_isnoneornil(L, 2)) {
-    lua_pushinteger(L, meta->indexCount);
-  } else {
-    uint32_t mesh = luax_checkmeshindex(L, 2, meta);
-    lua_pushinteger(L, meta->meshes[mesh].indexCount);
-  }
+  uint32_t mesh = luax_checkmeshindex(L, 2, meta);
+  lua_pushinteger(L, meta->meshes[mesh].indexCount);
   return 1;
 }
 
 static int l_lovrModelDataGetMeshVertex(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-
-  uint32_t index;
-  if (lua_isnil(L, 2)) {
-    index = luax_checku32(L, 3) - 1;
-    luax_check(L, index < model->meta.vertexCount, "Vertex %d is out of range", index + 1);
-  } else {
-    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
-    uint32_t index = luax_checku32(L, 3) - 1;
-    luax_check(L, index < model->meta.meshes[mesh].vertexCount, "Vertex %d is out of range", index + 1);
-    index += model->meta.meshes[mesh].vertexOffset;
-  }
-
-  ModelVertex* vertex = &model->vertices[index];
+  uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
+  uint32_t index = luax_checku32(L, 3) - 1;
+  luax_check(L, index < model->meta.meshes[mesh].vertexCount, "Vertex %d is out of range", index + 1);
+  ModelVertex* vertex = &model->vertices[model->meta.meshes[mesh].vertexOffset + index];
   lua_pushnumber(L, vertex->position.x);
   lua_pushnumber(L, vertex->position.y);
   lua_pushnumber(L, vertex->position.z);
@@ -378,21 +361,23 @@ static int l_lovrModelDataGetMeshVertex(lua_State* L) {
 
 static int l_lovrModelDataGetMeshIndex(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
+  uint32_t meshIndex = luax_checkmeshindex(L, 2, &model->meta);
+  ModelMesh* mesh = &model->meta.meshes[meshIndex];
 
-  uint32_t index;
-  if (lua_isnoneornil(L, 2)) {
-    index = luax_checku32(L, 3) - 1;
-    luax_check(L, index < model->meta.indexCount, "Index %d is out of range", index + 1);
-  } else {
-    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
-    index = luax_checku32(L, 3) - 1;
-    luax_check(L, index < model->meta.indexCount, "Index %d is out of range", index + 1);
+  uint32_t index = luax_checku32(L, 3) - 1;
+  luax_check(L, index < mesh->indexCount, "Index %d is out of range", index + 1);
+
+  // Add the part's base vertex to the index value, so that everything is relative to the beginning
+  // of the mesh and people don't have to worry about base vertex.  But we have to find the part...
+  uint32_t part = 0;
+  while (index < mesh->parts[part].start) {
+    part++;
   }
 
   if (model->meta.indexSize == 4) {
-    lua_pushinteger(L, ((uint32_t*) model->indices)[index]);
+    lua_pushinteger(L, ((uint32_t*) model->indices)[mesh->indexOffset + index] + mesh->parts[part].baseVertex);
   } else {
-    lua_pushinteger(L, ((uint16_t*) model->indices)[index]);
+    lua_pushinteger(L, ((uint16_t*) model->indices)[mesh->indexOffset + index] + mesh->parts[part].baseVertex);
   }
 
   return 1;
@@ -418,13 +403,6 @@ int l_lovrModelMetaGetMeshDrawRange(lua_State* L) {
   lua_pushinteger(L, part->start + 1);
   lua_pushinteger(L, part->count);
   return 2;
-}
-
-int l_lovrModelMetaGetMeshBaseVertex(lua_State* L) {
-  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
-  ModelPart* part = luax_checkmeshpart(L, 2, meta);
-  lua_pushinteger(L, part->baseVertex);
-  return 1;
 }
 
 int l_lovrModelMetaGetMeshMaterial(lua_State* L) {
@@ -740,6 +718,7 @@ int l_lovrModelMetaGetBlendShapeName(lua_State* L) {
 
 const luaL_Reg lovrModelData[] = {
   { "getMetadata", l_lovrModelMetaGetMetadata },
+
   { "getRootNode", l_lovrModelMetaGetRootNode },
   { "getNodeCount", l_lovrModelMetaGetNodeCount },
   { "getNodeName", l_lovrModelMetaGetNodeName },
@@ -754,6 +733,7 @@ const luaL_Reg lovrModelData[] = {
   { "getNodeTransform", l_lovrModelMetaGetNodeTransform },
   { "getNodeMesh", l_lovrModelMetaGetNodeMesh },
   { "getNodeSkin", l_lovrModelMetaGetNodeSkin },
+
   { "getMeshCount", l_lovrModelMetaGetMeshCount },
   { "getMeshVertexCount", l_lovrModelMetaGetMeshVertexCount },
   { "getMeshIndexCount", l_lovrModelMetaGetMeshIndexCount },
@@ -762,19 +742,21 @@ const luaL_Reg lovrModelData[] = {
   { "getMeshPartCount", l_lovrModelMetaGetMeshPartCount },
   { "getMeshDrawMode", l_lovrModelMetaGetMeshDrawMode },
   { "getMeshDrawRange", l_lovrModelMetaGetMeshDrawRange },
-  { "getMeshBaseVertex", l_lovrModelMetaGetMeshBaseVertex },
   { "getMeshMaterial", l_lovrModelMetaGetMeshMaterial },
+
   { "getWidth", l_lovrModelMetaGetWidth },
   { "getHeight", l_lovrModelMetaGetHeight },
   { "getDepth", l_lovrModelMetaGetDepth },
   { "getDimensions", l_lovrModelMetaGetDimensions },
   { "getCenter", l_lovrModelMetaGetCenter },
   { "getBoundingBox", l_lovrModelMetaGetBoundingBox },
+
   { "getImageCount", l_lovrModelMetaGetImageCount },
   { "getImage", l_lovrModelDataGetImage },
   { "getMaterialCount", l_lovrModelMetaGetMaterialCount },
   { "getMaterialName", l_lovrModelMetaGetMaterialName },
   { "getMaterial", l_lovrModelDataGetMaterial },
+
   { "getAnimationCount", l_lovrModelMetaGetAnimationCount },
   { "getAnimationName", l_lovrModelMetaGetAnimationName },
   { "getAnimationDuration", l_lovrModelMetaGetAnimationDuration },
@@ -787,7 +769,9 @@ const luaL_Reg lovrModelData[] = {
   { "getSkinCount", l_lovrModelMetaGetSkinCount },
   { "getSkinJoints", l_lovrModelMetaGetSkinJoints },
   { "getSkinInverseBindMatrix", l_lovrModelMetaGetSkinInverseBindMatrix },
+
   { "getBlendShapeCount", l_lovrModelMetaGetBlendShapeCount },
   { "getBlendShapeName", l_lovrModelMetaGetBlendShapeName },
+
   { NULL, NULL }
 };

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -331,22 +331,59 @@ static int l_lovrModelDataGetMeshMaterial(lua_State* L) {
 static int l_lovrModelDataGetTriangles(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
 
-  float* vertices = NULL;
-  uint32_t* indices = NULL;
-  uint32_t vertexCount = 0;
-  uint32_t indexCount = 0;
-  lovrModelDataGetTriangles(model, &vertices, &indices, &vertexCount, &indexCount);
+  if (lua_isnoneornil(L, 2)) {
+    float* vertices = NULL;
+    uint32_t* indices = NULL;
+    uint32_t vertexCount = 0;
+    uint32_t indexCount = 0;
+    lovrModelDataGetTriangles(model, &vertices, &indices, &vertexCount, &indexCount);
 
-  lua_createtable(L, vertexCount * 3, 0);
-  for (uint32_t i = 0; i < vertexCount * 3; i++) {
-    lua_pushnumber(L, vertices[i]);
-    lua_rawseti(L, -2, i + 1);
-  }
+    lua_createtable(L, vertexCount * 3, 0);
+    for (uint32_t i = 0; i < vertexCount * 3; i++) {
+      lua_pushnumber(L, vertices[i]);
+      lua_rawseti(L, -2, i + 1);
+    }
 
-  lua_createtable(L, indexCount, 0);
-  for (uint32_t i = 0; i < indexCount; i++) {
-    lua_pushinteger(L, indices[i] + 1);
-    lua_rawseti(L, -2, i + 1);
+    lua_createtable(L, indexCount, 0);
+    for (uint32_t i = 0; i < indexCount; i++) {
+      lua_pushinteger(L, indices[i] + 1);
+      lua_rawseti(L, -2, i + 1);
+    }
+  } else {
+    uint32_t meshIndex = luax_checku32(L, 2) - 1;
+    luax_check(L, meshIndex < model->meshCount, "Invalid mesh index '%d'", meshIndex + 1);
+
+    ModelMesh* mesh = &model->meshes[meshIndex];
+    ModelVertex* vertex = model->vertices + mesh->vertexOffset;
+
+    lua_createtable(L, mesh->vertexCount, 0);
+    for (uint32_t i = 0; i < mesh->vertexCount; i++, vertex++) {
+      lua_pushnumber(L, vertex->position.x);
+      lua_rawseti(L, -2, 3 * i + 1);
+
+      lua_pushnumber(L, vertex->position.y);
+      lua_rawseti(L, -2, 3 * i + 2);
+
+      lua_pushnumber(L, vertex->position.z);
+      lua_rawseti(L, -2, 3 * i + 3);
+    }
+
+    if (mesh->indexCount > 0) {
+      void* indices = model->indices;
+      uint32_t base = mesh->parts->baseVertex;
+      lua_createtable(L, mesh->indexCount, 0);
+
+      for (uint32_t i = 0; i < mesh->indexCount; i++) {
+        uint32_t index = model->indexSize == 4 ? ((uint32_t*) indices)[i] : ((uint16_t*) indices)[i];
+        lua_pushinteger(L, index - base + 1);
+        lua_rawseti(L, -2, i + 1);
+      }
+    } else {
+      for (uint32_t i = 0; i < mesh->vertexCount; i++) {
+        lua_pushinteger(L, i + 1);
+        lua_rawseti(L, -2, i + 1);
+      }
+    }
   }
 
   return 2;
@@ -354,9 +391,26 @@ static int l_lovrModelDataGetTriangles(lua_State* L) {
 
 static int l_lovrModelDataGetTriangleCount(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t vertexCount, indexCount;
-  lovrModelDataGetTriangles(model, NULL, NULL, &vertexCount, &indexCount);
-  lua_pushinteger(L, indexCount / 3);
+
+  if (lua_isnoneornil(L, 2)) {
+    uint32_t vertexCount, indexCount;
+    lovrModelDataGetTriangles(model, NULL, NULL, &vertexCount, &indexCount);
+    lua_pushinteger(L, indexCount / 3);
+  } else {
+    uint32_t meshIndex = luax_checku32(L, 2) - 1;
+    luax_check(L, meshIndex < model->meshCount, "Invalid mesh index '%d'", meshIndex + 1);
+    ModelMesh* mesh = &model->meshes[meshIndex];
+    uint32_t count = 0;
+
+    for (uint32_t i = 0; i < mesh->partCount; i++) {
+      if (mesh->parts[i].mode == DRAW_TRIANGLE_LIST) {
+        count += mesh->parts[i].count / 3;
+      }
+    }
+
+    lua_pushinteger(L, count);
+  }
+
   return 1;
 }
 

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -1,114 +1,143 @@
 #include "api.h"
 #include "data/modelData.h"
+#include "graphics/graphics.h"
 #include "core/maf.h"
 #include "util.h"
 #include <stdlib.h>
 
-uint32_t luax_checkanimationindex(lua_State* L, int index, ModelData* model) {
+ModelMetadata* luax_checkmodelmeta(lua_State* L, int index) {
+  ModelData* modelData = luax_totype(L, index, ModelData);
+
+  if (modelData) {
+    return &modelData->meta;
+  }
+
+#ifndef LOVR_DISABLE_GRAPHICS
+  Model* model = luax_totype(L, index, Model);
+
+  if (model) {
+    return lovrModelGetMetadata(model);
+  }
+#endif
+
+  luax_typeerror(L, index, "Model or ModelData");
+  return NULL;
+}
+
+uint32_t luax_checkanimationindex(lua_State* L, int index, ModelMetadata* meta) {
   switch (lua_type(L, index)) {
     case LUA_TNUMBER: {
       uint32_t animation = luax_checku32(L, index) - 1;
-      luax_check(L, animation < model->animationCount, "Invalid animation index '%d'", animation + 1);
+      luax_check(L, animation < meta->animationCount, "Invalid animation index '%d'", animation + 1);
       return animation;
     }
     case LUA_TSTRING: {
       size_t length;
       const char* name = lua_tolstring(L, index, &length);
-      uint64_t hash = hash64(name, length);
-      uint64_t entry = map_get(model->animationMap, hash);
-      luax_check(L, entry != MAP_NIL, "Model has no animation named '%s'", name);
-      return (uint32_t) entry;
+      uint32_t hash = (uint32_t) hash64(name, length);
+      for (uint32_t i = 0; i < meta->animationCount; i++) {
+        if (meta->animationLookup[i] == hash) {
+          return i;
+        }
+      }
+      return luaL_error(L, "Model has no animation named '%s'", name);
     }
     default: return luax_typeerror(L, index, "number or string"), ~0u;
   }
 }
 
-uint32_t luax_checkmaterialindex(lua_State* L, int index, ModelData* model) {
+uint32_t luax_checkmaterialindex(lua_State* L, int index, ModelMetadata* meta) {
   switch (lua_type(L, index)) {
     case LUA_TNUMBER: {
       uint32_t material = luax_checku32(L, index) - 1;
-      luax_check(L, material < model->materialCount, "Invalid material index '%d'", material + 1);
+      luax_check(L, material < meta->materialCount, "Invalid material index '%d'", material + 1);
       return material;
     }
     case LUA_TSTRING: {
       size_t length;
       const char* name = lua_tolstring(L, index, &length);
-      uint64_t hash = hash64(name, length);
-      uint64_t entry = map_get(model->materialMap, hash);
-      luax_check(L, entry != MAP_NIL, "Model has no material named '%s'", name);
-      return (uint32_t) entry;
+      uint32_t hash = (uint32_t) hash64(name, length);
+      for (uint32_t i = 0; i < meta->materialCount; i++) {
+        if (meta->materialLookup[i] == hash) {
+          return i;
+        }
+      }
+      return luaL_error(L, "Model has no material named '%s'", name);
     }
     default: return luax_typeerror(L, index, "number or string"), ~0u;
   }
 }
 
-uint32_t luax_checknodeindex(lua_State* L, int index, ModelData* model) {
+uint32_t luax_checknodeindex(lua_State* L, int index, ModelMetadata* meta) {
   switch (lua_type(L, index)) {
     case LUA_TNUMBER: {
       uint32_t node = luax_checku32(L, index) - 1;
-      luax_check(L, node < model->nodeCount, "Invalid node index '%d'", node + 1);
+      luax_check(L, node < meta->nodeCount, "Invalid node index '%d'", node + 1);
       return node;
     }
     case LUA_TSTRING: {
       size_t length;
       const char* name = lua_tolstring(L, index, &length);
-      uint64_t hash = hash64(name, length);
-      uint64_t entry = map_get(model->nodeMap, hash);
-      luax_check(L, entry != MAP_NIL, "Model has no node named '%s'", name);
-      return (uint32_t) entry;
+      uint32_t hash = (uint32_t) hash64(name, length);
+      for (uint32_t i = 0; i < meta->nodeCount; i++) {
+        if (meta->nodeLookup[i] == hash) {
+          return i;
+        }
+      }
+      return luaL_error(L, "Model has no node named '%s'", name);
     }
     default: return luax_typeerror(L, index, "number or string"), ~0u;
   }
 }
 
-uint32_t luax_checkmeshindex(lua_State* L, int index, ModelData* model) {
+static uint32_t luax_checkmeshindex(lua_State* L, int index, ModelMetadata* meta) {
   uint32_t mesh = luax_checku32(L, index) - 1;
-  luax_check(L, mesh < model->meshCount, "Invalid mesh index '%d'", mesh + 1);
-  return 1;
+  luax_check(L, mesh < meta->meshCount, "Invalid mesh index '%d'", mesh + 1);
+  return mesh;
 }
 
-ModelPart* luax_checkmeshpart(lua_State* L, int index, ModelData* model) {
-  uint32_t mesh = luax_checkmeshindex(L, index, model);
+static ModelPart* luax_checkmeshpart(lua_State* L, int index, ModelMetadata* meta) {
+  uint32_t mesh = luax_checkmeshindex(L, index, meta);
   uint32_t part = luax_optu32(L, index + 1, 1) - 1;
-  luax_check(L, part < model->meshes[mesh].partCount, "Invalid part index '%d'", part + 1);
-  return &model->meshes[mesh].parts[part];
+  luax_check(L, part < meta->meshes[mesh].partCount, "Invalid part index '%d'", part + 1);
+  return &meta->meshes[mesh].parts[part];
 }
 
-static int l_lovrModelDataGetMetadata(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetMetadata(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
 
-  if (!model->metadata || model->metadataSize == 0) {
+  if (!meta->comment || meta->commentLength == 0) {
     lua_pushnil(L);
   } else {
-    lua_pushlstring(L, model->metadata, model->metadataSize);
+    lua_pushlstring(L, meta->comment, meta->commentLength);
   }
 
   return 1;
 }
 
-static int l_lovrModelDataGetRootNode(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  lua_pushinteger(L, model->rootNode + 1);
+int l_lovrModelMetaGetRootNode(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  lua_pushinteger(L, meta->rootNode + 1);
   return 1;
 }
 
-static int l_lovrModelDataGetNodeCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  lua_pushinteger(L, model->nodeCount);
+int l_lovrModelMetaGetNodeCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  lua_pushinteger(L, meta->nodeCount);
   return 1;
 }
 
-static int l_lovrModelDataGetNodeName(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetNodeName(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->nodeCount, "Invalid node index '%d'", index + 1);
-  lua_pushstring(L, model->nodes[index].name);
+  luax_check(L, index < meta->nodeCount, "Invalid node index '%d'", index + 1);
+  lua_pushstring(L, meta->nodes[index].name);
   return 1;
 }
 
-static int l_lovrModelDataGetNodeChild(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
+int l_lovrModelMetaGetNodeChild(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelNode* node = &meta->nodes[luax_checknodeindex(L, 2, meta)];
   if (node->child != ~0u) {
     lua_pushinteger(L, node->child + 1);
   } else {
@@ -117,20 +146,20 @@ static int l_lovrModelDataGetNodeChild(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetNodeChildren(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
+int l_lovrModelMetaGetNodeChildren(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelNode* node = &meta->nodes[luax_checknodeindex(L, 2, meta)];
   lua_newtable(L);
-  for (uint32_t i = node->child; i != ~0u; i = model->nodes[i].sibling) {
+  for (uint32_t i = node->child; i != ~0u; i = meta->nodes[i].sibling) {
     lua_pushinteger(L, i + 1);
     lua_rawseti(L, -2, i + 1);
   }
   return 1;
 }
 
-static int l_lovrModelDataGetNodeSibling(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
+int l_lovrModelMetaGetNodeSibling(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelNode* node = &meta->nodes[luax_checknodeindex(L, 2, meta)];
   if (node->sibling != ~0u) {
     lua_pushinteger(L, node->sibling + 1);
   } else {
@@ -139,9 +168,9 @@ static int l_lovrModelDataGetNodeSibling(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetNodeParent(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
+int l_lovrModelMetaGetNodeParent(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelNode* node = &meta->nodes[luax_checknodeindex(L, 2, meta)];
   if (node->parent != ~0u) {
     lua_pushinteger(L, node->parent + 1);
   } else {
@@ -150,9 +179,9 @@ static int l_lovrModelDataGetNodeParent(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetNodePosition(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
+int l_lovrModelMetaGetNodePosition(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelNode* node = &meta->nodes[luax_checknodeindex(L, 2, meta)];
   if (node->hasMatrix) {
     float position[3];
     mat4_getPosition(node->transform.matrix, position);
@@ -168,9 +197,9 @@ static int l_lovrModelDataGetNodePosition(lua_State* L) {
   }
 }
 
-static int l_lovrModelDataGetNodeOrientation(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
+int l_lovrModelMetaGetNodeOrientation(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelNode* node = &meta->nodes[luax_checknodeindex(L, 2, meta)];
   float angle, ax, ay, az;
   if (node->hasMatrix) {
     mat4_getAngleAxis(node->transform.matrix, &angle, &ax, &ay, &az);
@@ -184,9 +213,9 @@ static int l_lovrModelDataGetNodeOrientation(lua_State* L) {
   return 4;
 }
 
-static int l_lovrModelDataGetNodeScale(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
+int l_lovrModelMetaGetNodeScale(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelNode* node = &meta->nodes[luax_checknodeindex(L, 2, meta)];
   if (node->hasMatrix) {
     float scale[3];
     mat4_getScale(node->transform.matrix, scale);
@@ -201,9 +230,9 @@ static int l_lovrModelDataGetNodeScale(lua_State* L) {
   return 3;
 }
 
-static int l_lovrModelDataGetNodePose(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
+int l_lovrModelMetaGetNodePose(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelNode* node = &meta->nodes[luax_checknodeindex(L, 2, meta)];
   if (node->hasMatrix) {
     float position[3], angle, ax, ay, az;
     mat4_getPosition(node->transform.matrix, position);
@@ -229,9 +258,9 @@ static int l_lovrModelDataGetNodePose(lua_State* L) {
   return 7;
 }
 
-static int l_lovrModelDataGetNodeTransform(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
+int l_lovrModelMetaGetNodeTransform(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelNode* node = &meta->nodes[luax_checknodeindex(L, 2, meta)];
   if (node->hasMatrix) {
     float position[3], scale[4], angle, ax, ay, az;
     mat4_getPosition(node->transform.matrix, position);
@@ -264,9 +293,9 @@ static int l_lovrModelDataGetNodeTransform(lua_State* L) {
   return 10;
 }
 
-static int l_lovrModelDataGetNodeMesh(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
+int l_lovrModelMetaGetNodeMesh(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelNode* node = &meta->nodes[luax_checknodeindex(L, 2, meta)];
   if (node->mesh == ~0u) {
     lua_pushnil(L);
   } else {
@@ -275,9 +304,9 @@ static int l_lovrModelDataGetNodeMesh(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetNodeSkin(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelNode* node = &model->nodes[luax_checknodeindex(L, 2, model)];
+int l_lovrModelMetaGetNodeSkin(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelNode* node = &meta->nodes[luax_checknodeindex(L, 2, meta)];
   if (node->skin == ~0u) {
     lua_pushnil(L);
   } else {
@@ -286,44 +315,44 @@ static int l_lovrModelDataGetNodeSkin(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetMeshCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  lua_pushinteger(L, model->meshCount);
+int l_lovrModelMetaGetMeshCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  lua_pushinteger(L, meta->meshCount);
   return 1;
 }
 
-static int l_lovrModelDataGetMeshPartCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t mesh = luax_checkmeshindex(L, 2, model);
-  lua_pushinteger(L, model->meshes[mesh].partCount);
+int l_lovrModelMetaGetMeshPartCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  uint32_t mesh = luax_checkmeshindex(L, 2, meta);
+  lua_pushinteger(L, meta->meshes[mesh].partCount);
   return 1;
 }
 
-static int l_lovrModelDataGetMeshDrawMode(lua_State* L) {
-  ModelData* model = luax_checktype(L,  1, ModelData);
-  ModelPart* part = luax_checkmeshpart(L, 2, model);
+int l_lovrModelMetaGetMeshDrawMode(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelPart* part = luax_checkmeshpart(L, 2, meta);
   luax_pushenum(L, ModelDrawMode, part->mode);
   return 1;
 }
 
-static int l_lovrModelDataGetMeshDrawRange(lua_State* L) {
-  ModelData* model = luax_checktype(L,  1, ModelData);
-  ModelPart* part = luax_checkmeshpart(L, 2, model);
+int l_lovrModelMetaGetMeshDrawRange(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L,  1);
+  ModelPart* part = luax_checkmeshpart(L, 2, meta);
   lua_pushinteger(L, part->start + 1);
   lua_pushinteger(L, part->count);
   return 2;
 }
 
-static int l_lovrModelDataGetMeshBaseVertex(lua_State* L) {
-  ModelData* model = luax_checktype(L,  1, ModelData);
-  ModelPart* part = luax_checkmeshpart(L, 2, model);
+int l_lovrModelMetaGetMeshBaseVertex(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelPart* part = luax_checkmeshpart(L, 2, meta);
   lua_pushinteger(L, part->baseVertex);
   return 1;
 }
 
-static int l_lovrModelDataGetMeshMaterial(lua_State* L) {
-  ModelData* model = luax_checktype(L,  1, ModelData);
-  ModelPart* part = luax_checkmeshpart(L, 2, model);
+int l_lovrModelMetaGetMeshMaterial(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelPart* part = luax_checkmeshpart(L, 2, meta);
   lua_pushinteger(L, part->material + 1);
   return 1;
 }
@@ -351,9 +380,9 @@ static int l_lovrModelDataGetTriangles(lua_State* L) {
     }
   } else {
     uint32_t meshIndex = luax_checku32(L, 2) - 1;
-    luax_check(L, meshIndex < model->meshCount, "Invalid mesh index '%d'", meshIndex + 1);
+    luax_check(L, meshIndex < model->meta.meshCount, "Invalid mesh index '%d'", meshIndex + 1);
 
-    ModelMesh* mesh = &model->meshes[meshIndex];
+    ModelMesh* mesh = &model->meta.meshes[meshIndex];
     ModelVertex* vertex = model->vertices + mesh->vertexOffset;
 
     lua_createtable(L, mesh->vertexCount, 0);
@@ -374,7 +403,7 @@ static int l_lovrModelDataGetTriangles(lua_State* L) {
       lua_createtable(L, mesh->indexCount, 0);
 
       for (uint32_t i = 0; i < mesh->indexCount; i++) {
-        uint32_t index = model->indexSize == 4 ? ((uint32_t*) indices)[i] : ((uint16_t*) indices)[i];
+        uint32_t index = model->meta.indexSize == 4 ? ((uint32_t*) indices)[i] : ((uint16_t*) indices)[i];
         lua_pushinteger(L, index - base + 1);
         lua_rawseti(L, -2, i + 1);
       }
@@ -398,8 +427,8 @@ static int l_lovrModelDataGetTriangleCount(lua_State* L) {
     lua_pushinteger(L, indexCount / 3);
   } else {
     uint32_t meshIndex = luax_checku32(L, 2) - 1;
-    luax_check(L, meshIndex < model->meshCount, "Invalid mesh index '%d'", meshIndex + 1);
-    ModelMesh* mesh = &model->meshes[meshIndex];
+    luax_check(L, meshIndex < model->meta.meshCount, "Invalid mesh index '%d'", meshIndex + 1);
+    ModelMesh* mesh = &model->meta.meshes[meshIndex];
     uint32_t count = 0;
 
     for (uint32_t i = 0; i < mesh->partCount; i++) {
@@ -414,7 +443,7 @@ static int l_lovrModelDataGetTriangleCount(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetVertexCount(lua_State* L) {
+int l_lovrModelMetaGetVertexCount(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   uint32_t vertexCount, indexCount;
   lovrModelDataGetTriangles(model, NULL, NULL, &vertexCount, &indexCount);
@@ -422,73 +451,73 @@ static int l_lovrModelDataGetVertexCount(lua_State* L) {
   return 1;
 }
 
-static void luax_checkboundingbox(lua_State* L, int index, ModelData* model, float bounds[6]) {
+static void luax_checkboundingbox(lua_State* L, int index, ModelMetadata* meta, float bounds[6]) {
   if (lua_type(L, index) == LUA_TNONE) {
-    lovrModelDataGetBoundingBox(model, bounds);
+    lovrModelMetadataGetBoundingBox(meta, bounds);
     return;
   }
 
   uint32_t mesh = luax_checku32(L, index) - 1;
-  luax_check(L, mesh < model->meshCount, "Invalid mesh index '%d'", mesh + 1);
+  luax_check(L, mesh < meta->meshCount, "Invalid mesh index '%d'", mesh + 1);
 
   if (lua_type(L, index + 1) == LUA_TNONE) {
-    lovrModelDataGetMeshBoundingBox(model, mesh, bounds);
+    lovrModelMetadataGetMeshBoundingBox(meta, mesh, bounds);
     return;
   }
 
   uint32_t part = luax_checku32(L, index + 1) - 1;
-  luax_check(L, part < model->meshes[mesh].partCount, "Invalid part index '%d'", part + 1);
-  memcpy(bounds, model->meshes[mesh].parts[part].bounds, 6 * sizeof(float));
+  luax_check(L, part < meta->meshes[mesh].partCount, "Invalid part index '%d'", part + 1);
+  memcpy(bounds, meta->meshes[mesh].parts[part].bounds, 6 * sizeof(float));
 }
 
-static int l_lovrModelDataGetWidth(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetWidth(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   float bounds[6];
-  luax_checkboundingbox(L, 2, model, bounds);
+  luax_checkboundingbox(L, 2, meta, bounds);
   lua_pushnumber(L, bounds[1] - bounds[0]);
   return 1;
 }
 
-static int l_lovrModelDataGetHeight(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetHeight(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   float bounds[6];
-  luax_checkboundingbox(L, 2, model, bounds);
+  luax_checkboundingbox(L, 2, meta, bounds);
   lua_pushnumber(L, bounds[3] - bounds[2]);
   return 1;
 }
 
-static int l_lovrModelDataGetDepth(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetDepth(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   float bounds[6];
-  luax_checkboundingbox(L, 2, model, bounds);
+  luax_checkboundingbox(L, 2, meta, bounds);
   lua_pushnumber(L, bounds[5] - bounds[4]);
   return 1;
 }
 
-static int l_lovrModelDataGetDimensions(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetDimensions(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   float bounds[6];
-  luax_checkboundingbox(L, 2, model, bounds);
+  luax_checkboundingbox(L, 2, meta, bounds);
   lua_pushnumber(L, bounds[1] - bounds[0]);
   lua_pushnumber(L, bounds[3] - bounds[2]);
   lua_pushnumber(L, bounds[5] - bounds[4]);
   return 3;
 }
 
-static int l_lovrModelDataGetCenter(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetCenter(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   float bounds[6];
-  luax_checkboundingbox(L, 2, model, bounds);
+  luax_checkboundingbox(L, 2, meta, bounds);
   lua_pushnumber(L, (bounds[0] + bounds[1]) / 2.f);
   lua_pushnumber(L, (bounds[2] + bounds[3]) / 2.f);
   lua_pushnumber(L, (bounds[4] + bounds[5]) / 2.f);
   return 3;
 }
 
-static int l_lovrModelDataGetBoundingBox(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetBoundingBox(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   float bounds[6];
-  luax_checkboundingbox(L, 2, model, bounds);
+  luax_checkboundingbox(L, 2, meta, bounds);
   lua_pushnumber(L, bounds[0]);
   lua_pushnumber(L, bounds[1]);
   lua_pushnumber(L, bounds[2]);
@@ -498,61 +527,37 @@ static int l_lovrModelDataGetBoundingBox(lua_State* L) {
   return 6;
 }
 
-static int l_lovrModelDataGetBoundingSphere(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  float sphere[4];
-  if (lua_type(L, 2) == LUA_TNONE) {
-    lovrModelDataGetBoundingSphere(model, sphere);
-  } else {
-    uint32_t mesh = luax_checku32(L, 2) - 1;
-    luax_check(L, mesh < model->meshCount, "Invalid mesh index '%d'", mesh + 1);
-
-    uint32_t part = ~0u;
-    if (lua_type(L, 3) != LUA_TNONE) {
-      part = luax_checku32(L, 3);
-      luax_check(L, part < model->meshes[mesh].partCount, "Invalid part index '%d'", part + 1);
-    }
-
-    lovrModelDataGetMeshBoundingSphere(model, mesh, part, sphere);
-  }
-  lua_pushnumber(L, sphere[0]);
-  lua_pushnumber(L, sphere[1]);
-  lua_pushnumber(L, sphere[2]);
-  lua_pushnumber(L, sphere[3]);
-  return 4;
-}
-
-static int l_lovrModelDataGetImageCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  lua_pushinteger(L, model->imageCount);
+int l_lovrModelMetaGetImageCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  lua_pushinteger(L, meta->imageCount);
   return 1;
 }
 
 static int l_lovrModelDataGetImage(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
   uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->imageCount, "Invalid image index '%d'", index + 1);
+  luax_check(L, index < model->meta.imageCount, "Invalid image index '%d'", index + 1);
   luax_pushtype(L, Image, model->images[index]);
   return 1;
 }
 
-static int l_lovrModelDataGetMaterialCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  lua_pushinteger(L, model->materialCount);
+int l_lovrModelMetaGetMaterialCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  lua_pushinteger(L, meta->materialCount);
   return 1;
 }
 
-static int l_lovrModelDataGetMaterialName(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetMaterialName(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->nodeCount, "Invalid material index '%d'", index + 1);
-  lua_pushstring(L, model->materials[index].name);
+  luax_check(L, index < meta->nodeCount, "Invalid material index '%d'", index + 1);
+  lua_pushstring(L, meta->materials[index].name);
   return 1;
 }
 
 static int l_lovrModelDataGetMaterial(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelMaterial* material = &model->materials[luax_checkmaterialindex(L, 2, model)];
+  ModelMaterial* material = &model->meta.materials[luax_checkmaterialindex(L, 2, &model->meta)];
 
   lua_newtable(L);
 
@@ -612,37 +617,37 @@ static int l_lovrModelDataGetMaterial(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetAnimationCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  lua_pushinteger(L, model->animationCount);
+int l_lovrModelMetaGetAnimationCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  lua_pushinteger(L, meta->animationCount);
   return 1;
 }
 
-static int l_lovrModelDataGetAnimationName(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetAnimationName(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->animationCount, "Invalid animation index '%d'", index + 1);
-  lua_pushstring(L, model->animations[index].name);
+  luax_check(L, index < meta->animationCount, "Invalid animation index '%d'", index + 1);
+  lua_pushstring(L, meta->animations[index].name);
   return 1;
 }
 
-static int l_lovrModelDataGetAnimationDuration(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelAnimation* animation = &model->animations[luax_checkanimationindex(L, 2, model)];
+int l_lovrModelMetaGetAnimationDuration(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelAnimation* animation = &meta->animations[luax_checkanimationindex(L, 2, meta)];
   lua_pushnumber(L, animation->duration);
   return 1;
 }
 
-static int l_lovrModelDataGetAnimationChannelCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelAnimation* animation = &model->animations[luax_checkanimationindex(L, 2, model)];
+int l_lovrModelMetaGetAnimationChannelCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelAnimation* animation = &meta->animations[luax_checkanimationindex(L, 2, meta)];
   lua_pushinteger(L, animation->channelCount);
   return 1;
 }
 
-static int l_lovrModelDataGetAnimationNode(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelAnimation* animation = &model->animations[luax_checkanimationindex(L, 2, model)];
+int l_lovrModelMetaGetAnimationNode(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelAnimation* animation = &meta->animations[luax_checkanimationindex(L, 2, meta)];
   uint32_t index = luax_checku32(L, 3) - 1;
   luax_check(L, index < animation->channelCount, "Invalid channel index '%d'", index + 1);
   ModelAnimationChannel* channel = &animation->channels[index];
@@ -650,9 +655,9 @@ static int l_lovrModelDataGetAnimationNode(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetAnimationProperty(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelAnimation* animation = &model->animations[luax_checkanimationindex(L, 2, model)];
+int l_lovrModelMetaGetAnimationProperty(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelAnimation* animation = &meta->animations[luax_checkanimationindex(L, 2, meta)];
   uint32_t index = luax_checku32(L, 3) - 1;
   luax_check(L, index < animation->channelCount, "Invalid channel index '%d'", index + 1);
   ModelAnimationChannel* channel = &animation->channels[index];
@@ -660,9 +665,9 @@ static int l_lovrModelDataGetAnimationProperty(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetAnimationSmoothMode(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelAnimation* animation = &model->animations[luax_checkanimationindex(L, 2, model)];
+int l_lovrModelMetaGetAnimationSmoothMode(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelAnimation* animation = &meta->animations[luax_checkanimationindex(L, 2, meta)];
   uint32_t index = luax_checku32(L, 3) - 1;
   luax_check(L, index < animation->channelCount, "Invalid channel index '%d'", index + 1);
   ModelAnimationChannel* channel = &animation->channels[index];
@@ -670,9 +675,9 @@ static int l_lovrModelDataGetAnimationSmoothMode(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetAnimationKeyframeCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelAnimation* animation = &model->animations[luax_checkanimationindex(L, 2, model)];
+int l_lovrModelMetaGetAnimationKeyframeCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  ModelAnimation* animation = &meta->animations[luax_checkanimationindex(L, 2, meta)];
   uint32_t index = luax_checku32(L, 3) - 1;
   luax_check(L, index < animation->channelCount, "Invalid channel index '%d'", index + 1);
   ModelAnimationChannel* channel = &animation->channels[index];
@@ -682,7 +687,7 @@ static int l_lovrModelDataGetAnimationKeyframeCount(lua_State* L) {
 
 static int l_lovrModelDataGetAnimationKeyframe(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
-  ModelAnimation* animation = &model->animations[luax_checkanimationindex(L, 2, model)];
+  ModelAnimation* animation = &model->meta.animations[luax_checkanimationindex(L, 2, &model->meta)];
   uint32_t index = luax_checku32(L, 3) - 1;
   luax_check(L, index < animation->channelCount, "Invalid channel index '%d'", index + 1);
   ModelAnimationChannel* channel = &animation->channels[index];
@@ -694,7 +699,7 @@ static int l_lovrModelDataGetAnimationKeyframe(lua_State* L) {
     case PROP_TRANSLATION: count = 3; break;
     case PROP_ROTATION: count = 4; break;
     case PROP_SCALE: count = 3; break;
-    case PROP_WEIGHTS: count = model->meshes[model->nodes[channel->nodeIndex].mesh].blendShapeCount; break;
+    case PROP_WEIGHTS: count = model->meta.meshes[model->meta.nodes[channel->nodeIndex].mesh].blendShapeCount; break;
   }
   for (int i = 0; i < count; i++) {
     lua_pushnumber(L, channel->data[keyframe * count + i]);
@@ -702,17 +707,17 @@ static int l_lovrModelDataGetAnimationKeyframe(lua_State* L) {
   return count + 1;
 }
 
-static int l_lovrModelDataGetSkinCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  lua_pushinteger(L, model->skinCount);
+int l_lovrModelMetaGetSkinCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  lua_pushinteger(L, meta->skinCount);
   return 1;
 }
 
-static int l_lovrModelDataGetSkinJoints(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetSkinJoints(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->skinCount, "Invalid skin index '%d'", index + 1);
-  ModelSkin* skin = &model->skins[index];
+  luax_check(L, index < meta->skinCount, "Invalid skin index '%d'", index + 1);
+  ModelSkin* skin = &meta->skins[index];
   lua_createtable(L, skin->jointCount, 0);
   for (uint32_t i = 0; i < skin->jointCount; i++) {
     lua_pushinteger(L, skin->joints[i]);
@@ -721,11 +726,11 @@ static int l_lovrModelDataGetSkinJoints(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelDataGetSkinInverseBindMatrix(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetSkinInverseBindMatrix(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->skinCount, "Invalid skin index '%d'", index + 1);
-  ModelSkin* skin = &model->skins[index];
+  luax_check(L, index < meta->skinCount, "Invalid skin index '%d'", index + 1);
+  ModelSkin* skin = &meta->skins[index];
   uint32_t joint = luax_checku32(L, 3) - 1;
   luax_check(L, index < skin->jointCount, "Invalid joint index '%d'", joint + 1);
   if (!skin->inverseBindMatrices) return lua_pushnil(L), 1;
@@ -736,70 +741,69 @@ static int l_lovrModelDataGetSkinInverseBindMatrix(lua_State* L) {
   return 16;
 }
 
-static int l_lovrModelDataGetBlendShapeCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  lua_pushinteger(L, model->blendShapeCount);
+int l_lovrModelMetaGetBlendShapeCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  lua_pushinteger(L, meta->blendShapeCount);
   return 1;
 }
 
-static int l_lovrModelDataGetBlendShapeName(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
+int l_lovrModelMetaGetBlendShapeName(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   uint32_t index = luax_checku32(L, 2) - 1;
-  luax_check(L, index < model->blendShapeCount, "Invalid blend shape index '%d'", index + 1);
-  lua_pushstring(L, model->blendShapes[index].name);
+  luax_check(L, index < meta->blendShapeCount, "Invalid blend shape index '%d'", index + 1);
+  lua_pushstring(L, meta->blendShapes[index].name);
   return 1;
 }
 
 const luaL_Reg lovrModelData[] = {
-  { "getMetadata", l_lovrModelDataGetMetadata },
-  { "getRootNode", l_lovrModelDataGetRootNode },
-  { "getNodeCount", l_lovrModelDataGetNodeCount },
-  { "getNodeName", l_lovrModelDataGetNodeName },
-  { "getNodeChild", l_lovrModelDataGetNodeChild },
-  { "getNodeChildren", l_lovrModelDataGetNodeChildren }, // Deprecated
-  { "getNodeSibling", l_lovrModelDataGetNodeSibling },
-  { "getNodeParent", l_lovrModelDataGetNodeParent },
-  { "getNodePosition", l_lovrModelDataGetNodePosition },
-  { "getNodeOrientation", l_lovrModelDataGetNodeOrientation },
-  { "getNodeScale", l_lovrModelDataGetNodeScale },
-  { "getNodePose", l_lovrModelDataGetNodePose },
-  { "getNodeTransform", l_lovrModelDataGetNodeTransform },
-  { "getNodeMesh", l_lovrModelDataGetNodeMesh },
-  { "getNodeSkin", l_lovrModelDataGetNodeSkin },
-  { "getMeshCount", l_lovrModelDataGetMeshCount },
-  { "getMeshPartCount", l_lovrModelDataGetMeshPartCount },
-  { "getMeshDrawMode", l_lovrModelDataGetMeshDrawMode },
-  { "getMeshDrawRange", l_lovrModelDataGetMeshDrawRange },
-  { "getMeshBaseVertex", l_lovrModelDataGetMeshBaseVertex },
-  { "getMeshMaterial", l_lovrModelDataGetMeshMaterial },
+  { "getMetadata", l_lovrModelMetaGetMetadata },
+  { "getRootNode", l_lovrModelMetaGetRootNode },
+  { "getNodeCount", l_lovrModelMetaGetNodeCount },
+  { "getNodeName", l_lovrModelMetaGetNodeName },
+  { "getNodeChild", l_lovrModelMetaGetNodeChild },
+  { "getNodeChildren", l_lovrModelMetaGetNodeChildren }, // Deprecated
+  { "getNodeSibling", l_lovrModelMetaGetNodeSibling },
+  { "getNodeParent", l_lovrModelMetaGetNodeParent },
+  { "getNodePosition", l_lovrModelMetaGetNodePosition },
+  { "getNodeOrientation", l_lovrModelMetaGetNodeOrientation },
+  { "getNodeScale", l_lovrModelMetaGetNodeScale },
+  { "getNodePose", l_lovrModelMetaGetNodePose },
+  { "getNodeTransform", l_lovrModelMetaGetNodeTransform },
+  { "getNodeMesh", l_lovrModelMetaGetNodeMesh },
+  { "getNodeSkin", l_lovrModelMetaGetNodeSkin },
+  { "getMeshCount", l_lovrModelMetaGetMeshCount },
+  { "getMeshPartCount", l_lovrModelMetaGetMeshPartCount },
+  { "getMeshDrawMode", l_lovrModelMetaGetMeshDrawMode },
+  { "getMeshDrawRange", l_lovrModelMetaGetMeshDrawRange },
+  { "getMeshBaseVertex", l_lovrModelMetaGetMeshBaseVertex },
+  { "getMeshMaterial", l_lovrModelMetaGetMeshMaterial },
   { "getTriangles", l_lovrModelDataGetTriangles },
   { "getTriangleCount", l_lovrModelDataGetTriangleCount },
-  { "getVertexCount", l_lovrModelDataGetVertexCount },
-  { "getWidth", l_lovrModelDataGetWidth },
-  { "getHeight", l_lovrModelDataGetHeight },
-  { "getDepth", l_lovrModelDataGetDepth },
-  { "getDimensions", l_lovrModelDataGetDimensions },
-  { "getCenter", l_lovrModelDataGetCenter },
-  { "getBoundingBox", l_lovrModelDataGetBoundingBox },
-  { "getBoundingSphere", l_lovrModelDataGetBoundingSphere },
-  { "getImageCount", l_lovrModelDataGetImageCount },
+  { "getVertexCount", l_lovrModelMetaGetVertexCount },
+  { "getWidth", l_lovrModelMetaGetWidth },
+  { "getHeight", l_lovrModelMetaGetHeight },
+  { "getDepth", l_lovrModelMetaGetDepth },
+  { "getDimensions", l_lovrModelMetaGetDimensions },
+  { "getCenter", l_lovrModelMetaGetCenter },
+  { "getBoundingBox", l_lovrModelMetaGetBoundingBox },
+  { "getImageCount", l_lovrModelMetaGetImageCount },
   { "getImage", l_lovrModelDataGetImage },
-  { "getMaterialCount", l_lovrModelDataGetMaterialCount },
-  { "getMaterialName", l_lovrModelDataGetMaterialName },
+  { "getMaterialCount", l_lovrModelMetaGetMaterialCount },
+  { "getMaterialName", l_lovrModelMetaGetMaterialName },
   { "getMaterial", l_lovrModelDataGetMaterial },
-  { "getAnimationCount", l_lovrModelDataGetAnimationCount },
-  { "getAnimationName", l_lovrModelDataGetAnimationName },
-  { "getAnimationDuration", l_lovrModelDataGetAnimationDuration },
-  { "getAnimationChannelCount", l_lovrModelDataGetAnimationChannelCount },
-  { "getAnimationNode", l_lovrModelDataGetAnimationNode },
-  { "getAnimationProperty", l_lovrModelDataGetAnimationProperty },
-  { "getAnimationSmoothMode", l_lovrModelDataGetAnimationSmoothMode },
-  { "getAnimationKeyframeCount", l_lovrModelDataGetAnimationKeyframeCount },
+  { "getAnimationCount", l_lovrModelMetaGetAnimationCount },
+  { "getAnimationName", l_lovrModelMetaGetAnimationName },
+  { "getAnimationDuration", l_lovrModelMetaGetAnimationDuration },
+  { "getAnimationChannelCount", l_lovrModelMetaGetAnimationChannelCount },
+  { "getAnimationNode", l_lovrModelMetaGetAnimationNode },
+  { "getAnimationProperty", l_lovrModelMetaGetAnimationProperty },
+  { "getAnimationSmoothMode", l_lovrModelMetaGetAnimationSmoothMode },
+  { "getAnimationKeyframeCount", l_lovrModelMetaGetAnimationKeyframeCount },
   { "getAnimationKeyframe", l_lovrModelDataGetAnimationKeyframe },
-  { "getSkinCount", l_lovrModelDataGetSkinCount },
-  { "getSkinJoints", l_lovrModelDataGetSkinJoints },
-  { "getSkinInverseBindMatrix", l_lovrModelDataGetSkinInverseBindMatrix },
-  { "getBlendShapeCount", l_lovrModelDataGetBlendShapeCount },
-  { "getBlendShapeName", l_lovrModelDataGetBlendShapeName },
+  { "getSkinCount", l_lovrModelMetaGetSkinCount },
+  { "getSkinJoints", l_lovrModelMetaGetSkinJoints },
+  { "getSkinInverseBindMatrix", l_lovrModelMetaGetSkinInverseBindMatrix },
+  { "getBlendShapeCount", l_lovrModelMetaGetBlendShapeCount },
+  { "getBlendShapeName", l_lovrModelMetaGetBlendShapeName },
   { NULL, NULL }
 };

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -103,6 +103,25 @@ static ModelPart* luax_checkmeshpart(lua_State* L, int index, ModelMetadata* met
   return &meta->meshes[mesh].parts[part];
 }
 
+static int luax_pushmodelvertex(lua_State* L, ModelVertex* vertex) {
+  lua_pushnumber(L, vertex->position.x);
+  lua_pushnumber(L, vertex->position.y);
+  lua_pushnumber(L, vertex->position.z);
+  lua_pushnumber(L, (float) ((vertex->normal >>  0) & 0x3ff) / 511.f);
+  lua_pushnumber(L, (float) ((vertex->normal >> 10) & 0x3ff) / 511.f);
+  lua_pushnumber(L, (float) ((vertex->normal >> 20) & 0x3ff) / 511.f);
+  lua_pushnumber(L, vertex->uv.u);
+  lua_pushnumber(L, vertex->uv.v);
+  lua_pushinteger(L, vertex->color.r);
+  lua_pushinteger(L, vertex->color.g);
+  lua_pushinteger(L, vertex->color.b);
+  lua_pushinteger(L, vertex->color.a);
+  lua_pushnumber(L, (float) ((vertex->tangent >>  0) & 0x3ff) / 511.f);
+  lua_pushnumber(L, (float) ((vertex->tangent >> 10) & 0x3ff) / 511.f);
+  lua_pushnumber(L, (float) ((vertex->tangent >> 20) & 0x3ff) / 511.f);
+  return 15;
+}
+
 int l_lovrModelMetaGetMetadata(lua_State* L) {
   ModelMetadata* meta = luax_checkmodelmeta(L, 1);
 
@@ -357,6 +376,136 @@ int l_lovrModelMetaGetMeshMaterial(lua_State* L) {
   return 1;
 }
 
+int l_lovrModelMetaGetMeshVertexCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  if (lua_isnoneornil(L, 2)) {
+    lua_pushinteger(L, meta->vertexCount);
+  } else {
+    uint32_t mesh = luax_checkmeshindex(L, 2, meta);
+    lua_pushinteger(L, meta->meshes[mesh].vertexCount);
+  }
+  return 1;
+}
+
+int l_lovrModelMetaGetMeshIndexCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  if (lua_isnoneornil(L, 2)) {
+    lua_pushinteger(L, meta->indexCount);
+  } else {
+    uint32_t mesh = luax_checkmeshindex(L, 2, meta);
+    lua_pushinteger(L, meta->meshes[mesh].indexCount);
+  }
+  return 1;
+}
+
+static int l_lovrModelDataGetMeshVertices(lua_State* L) {
+  ModelData* model = luax_checktype(L, 1, ModelData);
+
+  uint32_t start, count;
+  if (lua_isnoneornil(L, 2)) {
+    start = 0;
+    count = model->meta.vertexCount;
+  } else {
+    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
+    start = model->meta.meshes[mesh].vertexOffset;
+    count = model->meta.meshes[mesh].vertexCount;
+  }
+
+  lua_createtable(L, (int) count, 0);
+  for (uint32_t i = 0; i < count; i++) {
+    lua_createtable(L, 15, 0);
+    luax_pushmodelvertex(L, &model->vertices[start + i]);
+    for (int j = 15; j >= 1; j--) {
+      lua_rawseti(L, -j - 1, j);
+    }
+    lua_rawseti(L, -2, (int) i + 1);
+  }
+
+  return 1;
+}
+
+static int l_lovrModelDataGetMeshIndices(lua_State* L) {
+  ModelData* model = luax_checktype(L, 1, ModelData);
+
+  uint32_t start, count;
+  if (lua_isnoneornil(L, 2)) {
+    start = 0;
+    count = model->meta.indexCount;
+  } else {
+    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
+    start = model->meta.meshes[mesh].indexOffset;
+    count = model->meta.meshes[mesh].indexCount;
+  }
+
+  lua_createtable(L, (int) count, 0);
+  if (model->meta.indexSize == 4) {
+    uint32_t* indices = (uint32_t*) model->indices + start;
+    for (uint32_t i = 0; i < count; i++) {
+      lua_pushinteger(L, indices[i]);
+      lua_rawseti(L, -2, i + 1);
+    }
+  } else {
+    uint16_t* indices = (uint16_t*) model->indices + start;
+    for (uint32_t i = 0; i < count; i++) {
+      lua_pushinteger(L, indices[i]);
+      lua_rawseti(L, -2, i + 1);
+    }
+  }
+
+  return 1;
+}
+
+static int l_lovrModelDataGetMeshVertex(lua_State* L) {
+  ModelData* model = luax_checktype(L, 1, ModelData);
+
+  uint32_t index;
+  if (lua_isnil(L, 2)) {
+    index = luax_checku32(L, 3) - 1;
+    luax_check(L, index < model->meta.vertexCount, "Vertex %d is out of range", index + 1);
+  } else {
+    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
+    uint32_t index = luax_checku32(L, 3) - 1;
+    luax_check(L, index < model->meta.meshes[mesh].vertexCount, "Vertex %d is out of range", index + 1);
+    index += model->meta.meshes[mesh].vertexOffset;
+  }
+
+  return luax_pushmodelvertex(L, &model->vertices[index]);
+}
+
+static int l_lovrModelDataGetMeshIndex(lua_State* L) {
+  ModelData* model = luax_checktype(L, 1, ModelData);
+
+  uint32_t index;
+  if (lua_isnoneornil(L, 2)) {
+    index = luax_checku32(L, 3) - 1;
+    luax_check(L, index < model->meta.indexCount, "Index %d is out of range", index + 1);
+  } else {
+    uint32_t mesh = luax_checkmeshindex(L, 2, &model->meta);
+    index = luax_checku32(L, 3) - 1;
+    luax_check(L, index < model->meta.indexCount, "Index %d is out of range", index + 1);
+  }
+
+  if (model->meta.indexSize == 4) {
+    lua_pushinteger(L, ((uint32_t*) model->indices)[index]);
+  } else {
+    lua_pushinteger(L, ((uint16_t*) model->indices)[index]);
+  }
+
+  return 1;
+}
+
+int l_lovrModelMetaGetVertexCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  lua_pushinteger(L, lovrModelMetadataGetTotalVertexCount(meta));
+  return 1;
+}
+
+int l_lovrModelMetaGetIndexCount(lua_State* L) {
+  ModelMetadata* meta = luax_checkmodelmeta(L, 1);
+  lua_pushinteger(L, lovrModelMetadataGetTotalIndexCount(meta));
+  return 1;
+}
+
 static int l_lovrModelDataGetTriangles(lua_State* L) {
   ModelData* model = luax_checktype(L, 1, ModelData);
 
@@ -440,14 +589,6 @@ static int l_lovrModelDataGetTriangleCount(lua_State* L) {
     lua_pushinteger(L, count);
   }
 
-  return 1;
-}
-
-int l_lovrModelMetaGetVertexCount(lua_State* L) {
-  ModelData* model = luax_checktype(L, 1, ModelData);
-  uint32_t vertexCount, indexCount;
-  lovrModelDataGetTriangles(model, NULL, NULL, &vertexCount, &indexCount);
-  lua_pushinteger(L, vertexCount);
   return 1;
 }
 
@@ -777,9 +918,16 @@ const luaL_Reg lovrModelData[] = {
   { "getMeshDrawRange", l_lovrModelMetaGetMeshDrawRange },
   { "getMeshBaseVertex", l_lovrModelMetaGetMeshBaseVertex },
   { "getMeshMaterial", l_lovrModelMetaGetMeshMaterial },
+  { "getMeshVertexCount", l_lovrModelMetaGetMeshVertexCount },
+  { "getMeshIndexCount", l_lovrModelMetaGetMeshIndexCount },
+  { "getMeshVertices", l_lovrModelDataGetMeshVertices },
+  { "getMeshIndices", l_lovrModelDataGetMeshIndices },
+  { "getMeshVertex", l_lovrModelDataGetMeshVertex },
+  { "getMeshIndex", l_lovrModelDataGetMeshIndex },
+  { "getVertexCount", l_lovrModelMetaGetVertexCount },
+  { "getIndexCount", l_lovrModelMetaGetIndexCount },
   { "getTriangles", l_lovrModelDataGetTriangles },
   { "getTriangleCount", l_lovrModelDataGetTriangleCount },
-  { "getVertexCount", l_lovrModelMetaGetVertexCount },
   { "getWidth", l_lovrModelMetaGetWidth },
   { "getHeight", l_lovrModelMetaGetHeight },
   { "getDepth", l_lovrModelMetaGetDepth },

--- a/src/api/l_data_modelData.c
+++ b/src/api/l_data_modelData.c
@@ -446,7 +446,11 @@ int l_lovrModelMetaGetMeshDrawRange(lua_State* L) {
 int l_lovrModelMetaGetMeshMaterial(lua_State* L) {
   ModelMetadata* meta = luax_checkmodelmeta(L, 1);
   ModelPart* part = luax_checkmeshpart(L, 2, meta);
-  lua_pushinteger(L, part->material + 1);
+  if (part->material == ~0u) {
+    lua_pushnil(L);
+  } else {
+    lua_pushinteger(L, part->material + 1);
+  }
   return 1;
 }
 

--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -1603,6 +1603,9 @@ static const luaL_Reg lovrGraphics[] = {
   { NULL, NULL }
 };
 
+extern int l_lovrModelMeshes(lua_State* L);
+extern int luax_modelmeshiterator(lua_State* L);
+
 extern const luaL_Reg lovrBuffer[];
 extern const luaL_Reg lovrTexture[];
 extern const luaL_Reg lovrSampler[];
@@ -1627,5 +1630,12 @@ int luaopen_lovr_graphics(lua_State* L) {
   luax_registertype(L, Model);
   luax_registertype(L, Readback);
   luax_registertype(L, Pass);
+
+  luaL_getmetatable(L, "Model");
+  lua_pushcfunction(L, luax_modelmeshiterator);
+  lua_pushcclosure(L, l_lovrModelMeshes, 1);
+  lua_setfield(L, -2, "meshes");
+  lua_pop(L, 1);
+
   return 1;
 }

--- a/src/api/l_graphics_mesh.c
+++ b/src/api/l_graphics_mesh.c
@@ -248,8 +248,10 @@ static int l_lovrMeshSetDrawMode(lua_State* L) {
 static int l_lovrMeshGetDrawRange(lua_State* L) {
   Mesh* mesh = luax_checktype(L, 1, Mesh);
 
-  uint32_t start, count, offset;
-  lovrMeshGetDrawRange(mesh, &start, &count, &offset);
+  uint32_t start, count;
+  lovrMeshGetDrawRange(mesh, &start, &count);
+
+  uint32_t offset = lovrMeshGetBaseVertex(mesh);
 
   if (count == 0) {
     return 0;
@@ -265,14 +267,30 @@ static int l_lovrMeshSetDrawRange(lua_State* L) {
   Mesh* mesh = luax_checktype(L, 1, Mesh);
 
   if (lua_isnoneornil(L, 2)) {
-    lovrMeshSetDrawRange(mesh, 0, 0, 0);
+    lovrMeshSetDrawRange(mesh, 0, 0);
+    lovrMeshSetBaseVertex(mesh, 0);
   } else {
     uint32_t start = luax_checku32(L, 2) - 1;
     uint32_t count = luax_checku32(L, 3);
     uint32_t offset = luax_optu32(L, 4, 0);
-    luax_assert(L, lovrMeshSetDrawRange(mesh, start, count, offset));
+    luax_assert(L, lovrMeshSetDrawRange(mesh, start, count));
+    lovrMeshSetBaseVertex(mesh, offset);
   }
 
+  return 0;
+}
+
+static int l_lovrMeshGetBaseVertex(lua_State* L) {
+  Mesh* mesh = luax_checktype(L, 1, Mesh);
+  uint32_t base = lovrMeshGetBaseVertex(mesh);
+  lua_pushinteger(L, base);
+  return 1;
+}
+
+static int l_lovrMeshSetBaseVertex(lua_State* L) {
+  Mesh* mesh = luax_checktype(L, 1, Mesh);
+  uint32_t base = luax_optu32(L, 2, 0);
+  lovrMeshSetBaseVertex(mesh, base);
   return 0;
 }
 
@@ -308,6 +326,8 @@ const luaL_Reg lovrMesh[] = {
   { "setDrawMode", l_lovrMeshSetDrawMode },
   { "getDrawRange", l_lovrMeshGetDrawRange },
   { "setDrawRange", l_lovrMeshSetDrawRange },
+  { "getBaseVertex", l_lovrMeshGetBaseVertex },
+  { "setBaseVertex", l_lovrMeshSetBaseVertex },
   { "getMaterial", l_lovrMeshGetMaterial },
   { "setMaterial", l_lovrMeshSetMaterial },
   { NULL, NULL }

--- a/src/api/l_graphics_model.c
+++ b/src/api/l_graphics_model.c
@@ -307,6 +307,8 @@ int l_lovrModelMetaGetDimensions(lua_State* L);
 int l_lovrModelMetaGetCenter(lua_State* L);
 int l_lovrModelMetaGetBoundingBox(lua_State* L);
 int l_lovrModelMetaGetMeshCount(lua_State* L);
+int l_lovrModelMetaGetMeshVertexCount(lua_State* L);
+int l_lovrModelMetaGetMeshIndexCount(lua_State* L);
 int l_lovrModelMetaGetMeshPartCount(lua_State* L);
 int l_lovrModelMetaGetMeshDrawMode(lua_State* L);
 int l_lovrModelMetaGetMeshDrawRange(lua_State* L);
@@ -354,6 +356,8 @@ const luaL_Reg lovrModel[] = {
   { "getCenter", l_lovrModelMetaGetCenter },
   { "getBoundingBox", l_lovrModelMetaGetBoundingBox },
   { "getMeshCount", l_lovrModelMetaGetMeshCount },
+  { "getMeshVertexCount", l_lovrModelMetaGetMeshVertexCount },
+  { "getMeshIndexCount", l_lovrModelMetaGetMeshIndexCount },
   { "getMeshPartCount", l_lovrModelMetaGetMeshPartCount },
   { "getMeshDrawMode", l_lovrModelMetaGetMeshDrawMode },
   { "getMeshDrawRange", l_lovrModelMetaGetMeshDrawRange },

--- a/src/api/l_graphics_model.c
+++ b/src/api/l_graphics_model.c
@@ -248,8 +248,7 @@ int luax_modelmeshiterator(lua_State* L) {
   } else {
     lua_pushinteger(L, next + 1);
     lua_pushinteger(L, meta->nodes[next].mesh + 1);
-    luax_pushtype(L, Mesh, lovrModelGetMesh(model, meta->nodes[next].mesh));
-    return 3;
+    return 2;
   }
 }
 

--- a/src/api/l_graphics_model.c
+++ b/src/api/l_graphics_model.c
@@ -270,8 +270,9 @@ int luax_modelmeshiterator(lua_State* L) {
     return 1;
   } else {
     lua_pushinteger(L, next + 1);
+    lua_pushinteger(L, meta->nodes[next].mesh + 1);
     luax_pushtype(L, Mesh, lovrModelGetMesh(model, meta->nodes[next].mesh));
-    return 2;
+    return 3;
   }
 }
 
@@ -292,6 +293,7 @@ int l_lovrModelMetaGetNodeChild(lua_State* L);
 int l_lovrModelMetaGetNodeChildren(lua_State* L);
 int l_lovrModelMetaGetNodeSibling(lua_State* L);
 int l_lovrModelMetaGetNodeParent(lua_State* L);
+int l_lovrModelMetaGetNodeMesh(lua_State* L);
 int l_lovrModelMetaGetAnimationCount(lua_State* L);
 int l_lovrModelMetaGetAnimationName(lua_State* L);
 int l_lovrModelMetaGetAnimationDuration(lua_State* L);
@@ -304,6 +306,11 @@ int l_lovrModelMetaGetDimensions(lua_State* L);
 int l_lovrModelMetaGetCenter(lua_State* L);
 int l_lovrModelMetaGetBoundingBox(lua_State* L);
 int l_lovrModelMetaGetMeshCount(lua_State* L);
+int l_lovrModelMetaGetMeshPartCount(lua_State* L);
+int l_lovrModelMetaGetMeshDrawMode(lua_State* L);
+int l_lovrModelMetaGetMeshDrawRange(lua_State* L);
+int l_lovrModelMetaGetMeshBaseVertex(lua_State* L);
+int l_lovrModelMetaGetMeshMaterial(lua_State* L);
 int l_lovrModelMetaGetImageCount(lua_State* L);
 int l_lovrModelMetaGetMaterialCount(lua_State* L);
 int l_lovrModelMetaGetMaterialName(lua_State* L);
@@ -318,6 +325,7 @@ const luaL_Reg lovrModel[] = {
   { "getNodeChildren", l_lovrModelMetaGetNodeChildren },
   { "getNodeSibling", l_lovrModelMetaGetNodeSibling },
   { "getNodeParent", l_lovrModelMetaGetNodeParent },
+  { "getNodeMesh", l_lovrModelMetaGetNodeMesh },
   { "getNodePosition", l_lovrModelGetNodePosition },
   { "setNodePosition", l_lovrModelSetNodePosition },
   { "getNodeOrientation", l_lovrModelGetNodeOrientation },
@@ -348,6 +356,11 @@ const luaL_Reg lovrModel[] = {
   { "getVertexBuffer", l_lovrModelGetVertexBuffer },
   { "getIndexBuffer", l_lovrModelGetIndexBuffer },
   { "getMeshCount", l_lovrModelMetaGetMeshCount },
+  { "getMeshPartCount", l_lovrModelMetaGetMeshPartCount },
+  { "getMeshDrawMode", l_lovrModelMetaGetMeshDrawMode },
+  { "getMeshDrawRange", l_lovrModelMetaGetMeshDrawRange },
+  { "getMeshBaseVertex", l_lovrModelMetaGetMeshBaseVertex },
+  { "getMeshMaterial", l_lovrModelMetaGetMeshMaterial },
   { "getMesh", l_lovrModelGetMesh },
   { "getTextureCount", l_lovrModelMetaGetImageCount },
   { "getTexture", l_lovrModelGetTexture },

--- a/src/api/l_graphics_model.c
+++ b/src/api/l_graphics_model.c
@@ -218,29 +218,6 @@ static int l_lovrModelResetBlendShapes(lua_State* L) {
   return 0;
 }
 
-static int l_lovrModelGetVertexBuffer(lua_State* L) {
-  Model* model = luax_checktype(L, 1, Model);
-  Buffer* buffer = lovrModelGetVertexBuffer(model);
-  luax_pushtype(L, Buffer, buffer);
-  return 1;
-}
-
-static int l_lovrModelGetIndexBuffer(lua_State* L) {
-  Model* model = luax_checktype(L, 1, Model);
-  Buffer* buffer = lovrModelGetIndexBuffer(model);
-  luax_pushtype(L, Buffer, buffer);
-  return 1;
-}
-
-static int l_lovrModelGetMesh(lua_State* L) {
-  Model* model = luax_checktype(L, 1, Model);
-  uint32_t index = luax_checku32(L, 2) - 1;
-  Mesh* mesh = lovrModelGetMesh(model, index);
-  luax_assert(L, mesh);
-  luax_pushtype(L, Mesh, mesh);
-  return 1;
-}
-
 static int l_lovrModelGetTexture(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
   uint32_t index = luax_checku32(L, 2) - 1;
@@ -282,6 +259,31 @@ int l_lovrModelMeshes(lua_State* L) {
   lua_pushvalue(L, 1);
   lua_pushnil(L);
   return 3;
+}
+
+// Deprecated
+
+static int l_lovrModelGetVertexBuffer(lua_State* L) {
+  Model* model = luax_checktype(L, 1, Model);
+  Buffer* buffer = lovrModelGetVertexBuffer(model);
+  luax_pushtype(L, Buffer, buffer);
+  return 1;
+}
+
+static int l_lovrModelGetIndexBuffer(lua_State* L) {
+  Model* model = luax_checktype(L, 1, Model);
+  Buffer* buffer = lovrModelGetIndexBuffer(model);
+  luax_pushtype(L, Buffer, buffer);
+  return 1;
+}
+
+static int l_lovrModelGetMesh(lua_State* L) {
+  Model* model = luax_checktype(L, 1, Model);
+  uint32_t index = luax_checku32(L, 2) - 1;
+  Mesh* mesh = lovrModelGetMesh(model, index);
+  luax_assert(L, mesh);
+  luax_pushtype(L, Mesh, mesh);
+  return 1;
 }
 
 // Shared Model/ModelData methods
@@ -353,19 +355,21 @@ const luaL_Reg lovrModel[] = {
   { "getDimensions", l_lovrModelMetaGetDimensions },
   { "getCenter", l_lovrModelMetaGetCenter },
   { "getBoundingBox", l_lovrModelMetaGetBoundingBox },
-  { "getVertexBuffer", l_lovrModelGetVertexBuffer },
-  { "getIndexBuffer", l_lovrModelGetIndexBuffer },
   { "getMeshCount", l_lovrModelMetaGetMeshCount },
   { "getMeshPartCount", l_lovrModelMetaGetMeshPartCount },
   { "getMeshDrawMode", l_lovrModelMetaGetMeshDrawMode },
   { "getMeshDrawRange", l_lovrModelMetaGetMeshDrawRange },
   { "getMeshBaseVertex", l_lovrModelMetaGetMeshBaseVertex },
   { "getMeshMaterial", l_lovrModelMetaGetMeshMaterial },
-  { "getMesh", l_lovrModelGetMesh },
   { "getTextureCount", l_lovrModelMetaGetImageCount },
   { "getTexture", l_lovrModelGetTexture },
   { "getMaterialCount", l_lovrModelMetaGetMaterialCount },
   { "getMaterialName", l_lovrModelMetaGetMaterialName },
   { "getMaterial", l_lovrModelGetMaterial },
+
+  { "getVertexBuffer", l_lovrModelGetVertexBuffer }, // Deprecated
+  { "getIndexBuffer", l_lovrModelGetIndexBuffer }, // Deprecated
+  { "getMesh", l_lovrModelGetMesh }, // Deprecated
+
   { NULL, NULL }
 };

--- a/src/api/l_graphics_model.c
+++ b/src/api/l_graphics_model.c
@@ -310,7 +310,6 @@ int l_lovrModelMetaGetMeshCount(lua_State* L);
 int l_lovrModelMetaGetMeshPartCount(lua_State* L);
 int l_lovrModelMetaGetMeshDrawMode(lua_State* L);
 int l_lovrModelMetaGetMeshDrawRange(lua_State* L);
-int l_lovrModelMetaGetMeshBaseVertex(lua_State* L);
 int l_lovrModelMetaGetMeshMaterial(lua_State* L);
 int l_lovrModelMetaGetImageCount(lua_State* L);
 int l_lovrModelMetaGetMaterialCount(lua_State* L);
@@ -358,7 +357,6 @@ const luaL_Reg lovrModel[] = {
   { "getMeshPartCount", l_lovrModelMetaGetMeshPartCount },
   { "getMeshDrawMode", l_lovrModelMetaGetMeshDrawMode },
   { "getMeshDrawRange", l_lovrModelMetaGetMeshDrawRange },
-  { "getMeshBaseVertex", l_lovrModelMetaGetMeshBaseVertex },
   { "getMeshMaterial", l_lovrModelMetaGetMeshMaterial },
   { "getTextureCount", l_lovrModelMetaGetImageCount },
   { "getTexture", l_lovrModelGetTexture },

--- a/src/api/l_graphics_model.c
+++ b/src/api/l_graphics_model.c
@@ -4,34 +4,23 @@
 #include "core/maf.h"
 #include "util.h"
 
-// This adds about 2-3us of overhead, which sucks, but the reduction in complexity is large
-static int luax_callmodeldata(lua_State* L, const char* method, int nrets) {
-  int nargs = lua_gettop(L);
-  Model* model = luax_checktype(L, 1, Model);
-  ModelData* data = lovrModelGetInfo(model)->data;
-  luax_pushtype(L, ModelData, data);
-  lua_pushstring(L, method);
-  lua_gettable(L, -2);
-  lua_insert(L, 1);
-  lua_replace(L, 2);
-  lua_call(L, nargs, nrets);
-  return nrets;
-}
-
 uint32_t luax_checkblendshape(lua_State* L, int index, Model* model) {
+  const ModelMetadata* meta = lovrModelGetMetadata(model);
   switch (lua_type(L, index)) {
     case LUA_TSTRING: {
       size_t length;
       const char* name = lua_tolstring(L, index, &length);
-      ModelData* data = lovrModelGetInfo(model)->data;
-      uint64_t blendShapeIndex = map_get(data->blendShapeMap, hash64(name, length));
-      luax_check(L, blendShapeIndex != MAP_NIL, "ModelData has no blend shape named '%s'", name);
-      return (uint32_t) blendShapeIndex;
+      uint32_t hash = (uint32_t) hash64(name, length);
+      for (uint32_t i = 0; i < meta->animationCount; i++) {
+        if (meta->animationLookup[i] == hash) {
+          return i;
+        }
+      }
+      return luaL_error(L, "Model has no blend shape named '%s'", name);
     }
     case LUA_TNUMBER: {
       uint32_t blendShape = luax_checku32(L, index) - 1;
-      ModelData* data = lovrModelGetInfo(model)->data;
-      luax_check(L, blendShape < data->blendShapeCount, "Invalid blend shape index '%d'", blendShape + 1);
+      luax_check(L, blendShape < meta->blendShapeCount, "Invalid blend shape index '%d'", blendShape + 1);
       return blendShape;
     }
     default: return luax_typeerror(L, index, "number or string"), ~0u;
@@ -46,48 +35,9 @@ static int l_lovrModelClone(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelGetData(lua_State* L) {
-  Model* model = luax_checktype(L, 1, Model);
-  ModelData* data = lovrModelGetInfo(model)->data;
-  luax_pushtype(L, ModelData, data);
-  return 1;
-}
-
-static int l_lovrModelGetMetadata(lua_State* L) {
-  return luax_callmodeldata(L, "getMetadata", 1);
-}
-
-static int l_lovrModelGetRootNode(lua_State* L) {
-  return luax_callmodeldata(L, "getRootNode", 1);
-}
-
-static int l_lovrModelGetNodeCount(lua_State* L) {
-  return luax_callmodeldata(L, "getNodeCount", 1);
-}
-
-static int l_lovrModelGetNodeName(lua_State* L) {
-  return luax_callmodeldata(L, "getNodeName", 1);
-}
-
-static int l_lovrModelGetNodeChild(lua_State* L) {
-  return luax_callmodeldata(L, "getNodeChild", 1);
-}
-
-static int l_lovrModelGetNodeChildren(lua_State* L) {
-  return luax_callmodeldata(L, "getNodeChildren", 1);
-}
-
-static int l_lovrModelGetNodeSibling(lua_State* L) {
-  return luax_callmodeldata(L, "getNodeSibling", 1);
-}
-
-static int l_lovrModelGetNodeParent(lua_State* L) {
-  return luax_callmodeldata(L, "getNodeParent", 1);
-}
-
 static int l_lovrModelGetNodePosition(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetMetadata(model));
   OriginType origin = luax_checkenum(L, 3, OriginType, "root");
   float position[3], scale[3], rotation[4];
   lovrModelGetNodeTransform(model, node, position, scale, rotation, origin);
@@ -99,7 +49,7 @@ static int l_lovrModelGetNodePosition(lua_State* L) {
 
 static int l_lovrModelSetNodePosition(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetMetadata(model));
   float position[3];
   int index = luax_readvec3(L, 3, position, NULL);
   float alpha = luax_optfloat(L, index, 1.f);
@@ -109,7 +59,7 @@ static int l_lovrModelSetNodePosition(lua_State* L) {
 
 static int l_lovrModelGetNodeScale(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetMetadata(model));
   OriginType origin = luax_checkenum(L, 3, OriginType, "root");
   float position[3], scale[3], rotation[4];
   lovrModelGetNodeTransform(model, node, position, scale, rotation, origin);
@@ -121,7 +71,7 @@ static int l_lovrModelGetNodeScale(lua_State* L) {
 
 static int l_lovrModelSetNodeScale(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetMetadata(model));
   float scale[3];
   int index = luax_readscale(L, 3, scale, 3, NULL);
   float alpha = luax_optfloat(L, index, 1.f);
@@ -131,7 +81,7 @@ static int l_lovrModelSetNodeScale(lua_State* L) {
 
 static int l_lovrModelGetNodeOrientation(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetMetadata(model));
   OriginType origin = luax_checkenum(L, 3, OriginType, "root");
   float position[3], scale[3], rotation[4], angle, ax, ay, az;
   lovrModelGetNodeTransform(model, node, position, scale, rotation, origin);
@@ -145,7 +95,7 @@ static int l_lovrModelGetNodeOrientation(lua_State* L) {
 
 static int l_lovrModelSetNodeOrientation(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetMetadata(model));
   float rotation[4];
   int index = luax_readquat(L, 3, rotation, NULL);
   float alpha = luax_optfloat(L, index, 1.f);
@@ -155,7 +105,7 @@ static int l_lovrModelSetNodeOrientation(lua_State* L) {
 
 static int l_lovrModelGetNodePose(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetMetadata(model));
   OriginType origin = luax_checkenum(L, 3, OriginType, "root");
   float position[3], scale[3], rotation[4], angle, ax, ay, az;
   lovrModelGetNodeTransform(model, node, position, scale, rotation, origin);
@@ -172,7 +122,7 @@ static int l_lovrModelGetNodePose(lua_State* L) {
 
 static int l_lovrModelSetNodePose(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetMetadata(model));
   int index = 3;
   float position[3], rotation[4];
   index = luax_readvec3(L, index, position, NULL);
@@ -184,7 +134,7 @@ static int l_lovrModelSetNodePose(lua_State* L) {
 
 static int l_lovrModelGetNodeTransform(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetMetadata(model));
   OriginType origin = luax_checkenum(L, 3, OriginType, "root");
   float position[3], scale[3], rotation[4], angle, ax, ay, az;
   lovrModelGetNodeTransform(model, node, position, scale, rotation, origin);
@@ -204,7 +154,7 @@ static int l_lovrModelGetNodeTransform(lua_State* L) {
 
 static int l_lovrModelSetNodeTransform(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t node = luax_checknodeindex(L, 2, lovrModelGetMetadata(model));
   int index = 3;
   VectorType type;
   float position[3], scale[3], rotation[4];
@@ -230,40 +180,20 @@ static int l_lovrModelResetNodeTransforms(lua_State* L) {
   return 0;
 }
 
-static int l_lovrModelGetAnimationCount(lua_State* L) {
-  return luax_callmodeldata(L, "getAnimationCount", 1);
-}
-
-static int l_lovrModelGetAnimationName(lua_State* L) {
-  return luax_callmodeldata(L, "getAnimationName", 1);
-}
-
-static int l_lovrModelGetAnimationDuration(lua_State* L) {
-  return luax_callmodeldata(L, "getAnimationDuration", 1);
-}
-
 static int l_lovrModelHasJoints(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  ModelData* data = lovrModelGetInfo(model)->data;
-  lua_pushboolean(L, data->skinCount > 0);
+  const ModelMetadata* meta = lovrModelGetMetadata(model);
+  lua_pushboolean(L, meta->skinCount > 0);
   return 1;
 }
 
 static int l_lovrModelAnimate(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t animation = luax_checkanimationindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t animation = luax_checkanimationindex(L, 2, lovrModelGetMetadata(model));
   float time = luax_checkfloat(L, 3);
   float alpha = luax_optfloat(L, 4, 1.f);
   luax_assert(L, lovrModelAnimate(model, animation, time, alpha));
   return 0;
-}
-
-static int l_lovrModelGetBlendShapeCount(lua_State* L) {
-  return luax_callmodeldata(L, "getBlendShapeCount", 1);
-}
-
-static int l_lovrModelGetBlendShapeName(lua_State* L) {
-  return luax_callmodeldata(L, "getBlendShapeName", 1);
 }
 
 static int l_lovrModelGetBlendShapeWeight(lua_State* L) {
@@ -288,46 +218,6 @@ static int l_lovrModelResetBlendShapes(lua_State* L) {
   return 0;
 }
 
-static int l_lovrModelGetTriangles(lua_State* L) {
-  return luax_callmodeldata(L, "getTriangles", 2);
-}
-
-static int l_lovrModelGetTriangleCount(lua_State* L) {
-  return luax_callmodeldata(L, "getTriangleCount", 1);
-}
-
-static int l_lovrModelGetVertexCount(lua_State* L) {
-  return luax_callmodeldata(L, "getVertexCount", 1);
-}
-
-static int l_lovrModelGetWidth(lua_State* L) {
-  return luax_callmodeldata(L, "getWidth", 1);
-}
-
-static int l_lovrModelGetHeight(lua_State* L) {
-  return luax_callmodeldata(L, "getHeight", 1);
-}
-
-static int l_lovrModelGetDepth(lua_State* L) {
-  return luax_callmodeldata(L, "getDepth", 1);
-}
-
-static int l_lovrModelGetDimensions(lua_State* L) {
-  return luax_callmodeldata(L, "getDimensions", 3);
-}
-
-static int l_lovrModelGetCenter(lua_State* L) {
-  return luax_callmodeldata(L, "getCenter", 3);
-}
-
-static int l_lovrModelGetBoundingBox(lua_State* L) {
-  return luax_callmodeldata(L, "getBoundingBox", 6);
-}
-
-static int l_lovrModelGetBoundingSphere(lua_State* L) {
-  return luax_callmodeldata(L, "getBoundingSphere", 4);
-}
-
 static int l_lovrModelGetVertexBuffer(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
   Buffer* buffer = lovrModelGetVertexBuffer(model);
@@ -342,10 +232,6 @@ static int l_lovrModelGetIndexBuffer(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelGetMeshCount(lua_State* L) {
-  return luax_callmodeldata(L, "getMeshCount", 1);
-}
-
 static int l_lovrModelGetMesh(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
   uint32_t index = luax_checku32(L, 2) - 1;
@@ -353,10 +239,6 @@ static int l_lovrModelGetMesh(lua_State* L) {
   luax_assert(L, mesh);
   luax_pushtype(L, Mesh, mesh);
   return 1;
-}
-
-static int l_lovrModelGetTextureCount(lua_State* L) {
-  return luax_callmodeldata(L, "getImageCount", 1);
 }
 
 static int l_lovrModelGetTexture(lua_State* L) {
@@ -368,17 +250,9 @@ static int l_lovrModelGetTexture(lua_State* L) {
   return 1;
 }
 
-static int l_lovrModelGetMaterialCount(lua_State* L) {
-  return luax_callmodeldata(L, "getMaterialCount", 1);
-}
-
-static int l_lovrModelGetMaterialName(lua_State* L) {
-  return luax_callmodeldata(L, "getMaterialName", 1);
-}
-
 static int l_lovrModelGetMaterial(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  uint32_t index = luax_checkmaterialindex(L, 2, lovrModelGetInfo(model)->data);
+  uint32_t index = luax_checkmaterialindex(L, 2, lovrModelGetMetadata(model));
   Material* material = lovrModelGetMaterial(model, index);
   luax_assert(L, material);
   luax_pushtype(L, Material, material);
@@ -387,16 +261,16 @@ static int l_lovrModelGetMaterial(lua_State* L) {
 
 int luax_modelmeshiterator(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
-  ModelData* data = lovrModelGetInfo(model)->data;
+  ModelMetadata* meta = lovrModelGetMetadata(model);
   lua_settop(L, 2);
   uint32_t node = lua_type(L, 2) == LUA_TNIL ? ~0u : (uint32_t) lua_tonumber(L, 2) - 1;
-  uint32_t next = lovrModelDataNextNodeWithMesh(data, node);
+  uint32_t next = lovrModelMetadataNextNodeWithMesh(meta, node);
   if (next == ~0u) {
     lua_pushnil(L);
     return 1;
   } else {
     lua_pushinteger(L, next + 1);
-    luax_pushtype(L, Mesh, lovrModelGetMesh(model, data->nodes[next].mesh));
+    luax_pushtype(L, Mesh, lovrModelGetMesh(model, meta->nodes[next].mesh));
     return 2;
   }
 }
@@ -409,17 +283,41 @@ int l_lovrModelMeshes(lua_State* L) {
   return 3;
 }
 
+// Shared Model/ModelData methods
+int l_lovrModelMetaGetMetadata(lua_State* L);
+int l_lovrModelMetaGetRootNode(lua_State* L);
+int l_lovrModelMetaGetNodeCount(lua_State* L);
+int l_lovrModelMetaGetNodeName(lua_State* L);
+int l_lovrModelMetaGetNodeChild(lua_State* L);
+int l_lovrModelMetaGetNodeChildren(lua_State* L);
+int l_lovrModelMetaGetNodeSibling(lua_State* L);
+int l_lovrModelMetaGetNodeParent(lua_State* L);
+int l_lovrModelMetaGetAnimationCount(lua_State* L);
+int l_lovrModelMetaGetAnimationName(lua_State* L);
+int l_lovrModelMetaGetAnimationDuration(lua_State* L);
+int l_lovrModelMetaGetBlendShapeCount(lua_State* L);
+int l_lovrModelMetaGetBlendShapeName(lua_State* L);
+int l_lovrModelMetaGetWidth(lua_State* L);
+int l_lovrModelMetaGetHeight(lua_State* L);
+int l_lovrModelMetaGetDepth(lua_State* L);
+int l_lovrModelMetaGetDimensions(lua_State* L);
+int l_lovrModelMetaGetCenter(lua_State* L);
+int l_lovrModelMetaGetBoundingBox(lua_State* L);
+int l_lovrModelMetaGetMeshCount(lua_State* L);
+int l_lovrModelMetaGetImageCount(lua_State* L);
+int l_lovrModelMetaGetMaterialCount(lua_State* L);
+int l_lovrModelMetaGetMaterialName(lua_State* L);
+
 const luaL_Reg lovrModel[] = {
   { "clone", l_lovrModelClone },
-  { "getData", l_lovrModelGetData },
-  { "getMetadata", l_lovrModelGetMetadata },
-  { "getRootNode", l_lovrModelGetRootNode },
-  { "getNodeCount", l_lovrModelGetNodeCount },
-  { "getNodeName", l_lovrModelGetNodeName },
-  { "getNodeChild", l_lovrModelGetNodeChild },
-  { "getNodeChildren", l_lovrModelGetNodeChildren },
-  { "getNodeSibling", l_lovrModelGetNodeSibling },
-  { "getNodeParent", l_lovrModelGetNodeParent },
+  { "getMetadata", l_lovrModelMetaGetMetadata },
+  { "getRootNode", l_lovrModelMetaGetRootNode },
+  { "getNodeCount", l_lovrModelMetaGetNodeCount },
+  { "getNodeName", l_lovrModelMetaGetNodeName },
+  { "getNodeChild", l_lovrModelMetaGetNodeChild },
+  { "getNodeChildren", l_lovrModelMetaGetNodeChildren },
+  { "getNodeSibling", l_lovrModelMetaGetNodeSibling },
+  { "getNodeParent", l_lovrModelMetaGetNodeParent },
   { "getNodePosition", l_lovrModelGetNodePosition },
   { "setNodePosition", l_lovrModelSetNodePosition },
   { "getNodeOrientation", l_lovrModelGetNodeOrientation },
@@ -431,34 +329,30 @@ const luaL_Reg lovrModel[] = {
   { "getNodeTransform", l_lovrModelGetNodeTransform },
   { "setNodeTransform", l_lovrModelSetNodeTransform },
   { "resetNodeTransforms", l_lovrModelResetNodeTransforms },
-  { "getAnimationCount", l_lovrModelGetAnimationCount },
-  { "getAnimationName", l_lovrModelGetAnimationName },
-  { "getAnimationDuration", l_lovrModelGetAnimationDuration },
+  { "getAnimationCount", l_lovrModelMetaGetAnimationCount },
+  { "getAnimationName", l_lovrModelMetaGetAnimationName },
+  { "getAnimationDuration", l_lovrModelMetaGetAnimationDuration },
   { "hasJoints", l_lovrModelHasJoints },
   { "animate", l_lovrModelAnimate },
-  { "getBlendShapeCount", l_lovrModelGetBlendShapeCount },
-  { "getBlendShapeName", l_lovrModelGetBlendShapeName },
+  { "getBlendShapeCount", l_lovrModelMetaGetBlendShapeCount },
+  { "getBlendShapeName", l_lovrModelMetaGetBlendShapeName },
   { "getBlendShapeWeight", l_lovrModelGetBlendShapeWeight },
   { "setBlendShapeWeight", l_lovrModelSetBlendShapeWeight },
   { "resetBlendShapes", l_lovrModelResetBlendShapes },
-  { "getTriangles", l_lovrModelGetTriangles },
-  { "getTriangleCount", l_lovrModelGetTriangleCount },
-  { "getVertexCount", l_lovrModelGetVertexCount },
-  { "getWidth", l_lovrModelGetWidth },
-  { "getHeight", l_lovrModelGetHeight },
-  { "getDepth", l_lovrModelGetDepth },
-  { "getDimensions", l_lovrModelGetDimensions },
-  { "getCenter", l_lovrModelGetCenter },
-  { "getBoundingBox", l_lovrModelGetBoundingBox },
-  { "getBoundingSphere", l_lovrModelGetBoundingSphere },
+  { "getWidth", l_lovrModelMetaGetWidth },
+  { "getHeight", l_lovrModelMetaGetHeight },
+  { "getDepth", l_lovrModelMetaGetDepth },
+  { "getDimensions", l_lovrModelMetaGetDimensions },
+  { "getCenter", l_lovrModelMetaGetCenter },
+  { "getBoundingBox", l_lovrModelMetaGetBoundingBox },
   { "getVertexBuffer", l_lovrModelGetVertexBuffer },
   { "getIndexBuffer", l_lovrModelGetIndexBuffer },
-  { "getMeshCount", l_lovrModelGetMeshCount },
+  { "getMeshCount", l_lovrModelMetaGetMeshCount },
   { "getMesh", l_lovrModelGetMesh },
-  { "getTextureCount", l_lovrModelGetTextureCount },
+  { "getTextureCount", l_lovrModelMetaGetImageCount },
   { "getTexture", l_lovrModelGetTexture },
-  { "getMaterialCount", l_lovrModelGetMaterialCount },
-  { "getMaterialName", l_lovrModelGetMaterialName },
+  { "getMaterialCount", l_lovrModelMetaGetMaterialCount },
+  { "getMaterialName", l_lovrModelMetaGetMaterialName },
   { "getMaterial", l_lovrModelGetMaterial },
   { NULL, NULL }
 };

--- a/src/api/l_graphics_model.c
+++ b/src/api/l_graphics_model.c
@@ -385,6 +385,30 @@ static int l_lovrModelGetMaterial(lua_State* L) {
   return 1;
 }
 
+int luax_modelmeshiterator(lua_State* L) {
+  Model* model = luax_checktype(L, 1, Model);
+  ModelData* data = lovrModelGetInfo(model)->data;
+  lua_settop(L, 2);
+  uint32_t node = lua_type(L, 2) == LUA_TNIL ? ~0u : (uint32_t) lua_tonumber(L, 2) - 1;
+  uint32_t next = lovrModelDataNextNodeWithMesh(data, node);
+  if (next == ~0u) {
+    lua_pushnil(L);
+    return 1;
+  } else {
+    lua_pushinteger(L, next + 1);
+    luax_pushtype(L, Mesh, lovrModelGetMesh(model, data->nodes[next].mesh));
+    return 2;
+  }
+}
+
+int l_lovrModelMeshes(lua_State* L) {
+  Model* model = luax_checktype(L, 1, Model);
+  lua_pushvalue(L, lua_upvalueindex(1));
+  lua_pushvalue(L, 1);
+  lua_pushnil(L);
+  return 3;
+}
+
 const luaL_Reg lovrModel[] = {
   { "clone", l_lovrModelClone },
   { "getData", l_lovrModelGetData },

--- a/src/api/l_graphics_pass.c
+++ b/src/api/l_graphics_pass.c
@@ -1041,6 +1041,18 @@ static int l_lovrPassDraw(lua_State* L) {
   return luax_typeerror(L, 2, "Mesh, Model, or Texture");
 }
 
+static int l_lovrPassDrawPart(lua_State* L) {
+  Pass* pass = luax_checktype(L, 1, Pass);
+  Model* model = luax_checktype(L, 2, Model);
+  uint32_t mesh = luax_checku32(L, 3) - 1;
+  uint32_t part = lua_isnoneornil(L, 4) ? ~0u : luax_checku32(L, 4) - 1;
+  float transform[16];
+  int index = luax_readmat4(L, 5, transform, 1);
+  uint32_t instances = luax_optu32(L, index, 1);
+  luax_assert(L, lovrPassDrawPart(pass, model, mesh, part, transform, instances));
+  return 0;
+}
+
 static int l_lovrPassMesh(lua_State* L) {
   Pass* pass = luax_checktype(L, 1, Pass);
   Buffer* vertices = (!lua_toboolean(L, 2) || lua_type(L, 2) == LUA_TNUMBER) ? NULL : luax_checktype(L, 2, Buffer);
@@ -1207,6 +1219,7 @@ const luaL_Reg lovrPass[] = {
   { "fill", l_lovrPassFill },
   { "monkey", l_lovrPassMonkey },
   { "draw", l_lovrPassDraw },
+  { "drawPart", l_lovrPassDrawPart },
   { "mesh", l_lovrPassMesh },
 
   { "beginTally", l_lovrPassBeginTally },

--- a/src/api/l_physics_shapes.c
+++ b/src/api/l_physics_shapes.c
@@ -95,11 +95,10 @@ Shape* luax_newconvexshape(lua_State* L, int index) {
 
   float* points;
   uint32_t count;
-  bool shouldFree;
-  index = luax_readmesh(L, index, &points, &count, NULL, NULL, &shouldFree);
+  index = luax_readmesh(L, index, &points, &count, NULL, NULL);
   float scale = luax_optfloat(L, index, 1.f);
   ConvexShape* shape = lovrConvexShapeCreate(points, count, scale);
-  if (shouldFree) lovrFree(points);
+  lovrFree(points);
   luax_assert(L, shape);
   return shape;
 }
@@ -116,18 +115,14 @@ Shape* luax_newmeshshape(lua_State* L, int index) {
   uint32_t* indices;
   uint32_t vertexCount;
   uint32_t indexCount;
-  bool shouldFree;
 
-  index = luax_readmesh(L, index, &vertices, &vertexCount, &indices, &indexCount, &shouldFree);
+  index = luax_readmesh(L, index, &vertices, &vertexCount, &indices, &indexCount);
 
   float scale = luax_optfloat(L, index, 1.f);
   Shape* shape = lovrMeshShapeCreate(vertexCount, vertices, indexCount, indices, scale);
 
-  if (shouldFree) {
-    lovrFree(vertices);
-    lovrFree(indices);
-  }
-
+  lovrFree(vertices);
+  lovrFree(indices);
   luax_assert(L, shape);
   return shape;
 }

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -385,7 +385,7 @@ static void countVertices(ModelData* model, uint32_t nodeIndex, uint32_t* vertex
 
   if (node->mesh != ~0u) {
     ModelMesh* mesh = &model->meshes[node->mesh];
-    ModelPart* part = model->parts;
+    ModelPart* part = mesh->parts;
 
     model->triangleVertexCount += mesh->vertexCount;
 
@@ -471,11 +471,11 @@ void lovrModelDataGetTriangles(ModelData* model, float** vertices, uint32_t** in
     countVertices(model, model->rootNode, vertexCount, indexCount);
   }
 
-  if (vertices && !model->vertices) {
+  if (vertices && !model->triangleVertices) {
     uint32_t* tempIndices;
     uint32_t baseIndex = 0;
-    model->vertices = lovrMalloc(model->triangleVertexCount * 3 * sizeof(float));
-    model->indices = lovrMalloc(model->triangleIndexCount * sizeof(uint32_t));
+    model->triangleVertices = lovrMalloc(model->triangleVertexCount * 3 * sizeof(float));
+    model->triangleIndices = lovrMalloc(model->triangleIndexCount * sizeof(uint32_t));
     *vertices = model->triangleVertices;
     tempIndices = model->triangleIndices;
     collectVertices(model, model->rootNode, vertices, &tempIndices, &baseIndex, (float[16]) MAT4_IDENTITY);

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -153,10 +153,10 @@ void lovrModelDataAllocate(ModelData* model) {
   }
 
   meta->bounds[0] = FLT_MAX;
-  meta->bounds[1] = FLT_MAX;
+  meta->bounds[1] = -FLT_MAX;
   meta->bounds[2] = FLT_MAX;
   meta->bounds[3] = -FLT_MAX;
-  meta->bounds[4] = -FLT_MAX;
+  meta->bounds[4] = FLT_MAX;
   meta->bounds[5] = -FLT_MAX;
 }
 

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -5,6 +5,7 @@
 #include "util.h"
 #include <stdlib.h>
 #include <string.h>
+#include <float.h>
 
 static void* nullIO(const char* path, size_t* count) {
   return NULL;
@@ -54,11 +55,11 @@ void lovrModelDataAllocate(ModelData* model) {
   totalSize += sizes[0] = ALIGN(model->meshCount * sizeof(ModelMesh), alignment);
   totalSize += sizes[1] = ALIGN(model->imageCount * sizeof(Image*), alignment);
   totalSize += sizes[2] = ALIGN(model->materialCount * sizeof(ModelMaterial), alignment);
-  totalSize += sizes[3] = ALIGN(model->blendShapeCount * sizeof(ModelBlendShape), alignment);
-  totalSize += sizes[4] = ALIGN(model->animationCount * sizeof(ModelAnimation), alignment);
-  totalSize += sizes[5] = ALIGN(model->skinCount * sizeof(ModelSkin), alignment);
-  totalSize += sizes[6] = ALIGN(model->nodeCount * sizeof(ModelNode), alignment);
-  totalSize += sizes[7] = ALIGN(model->primitiveCount * sizeof(ModelPrimitive), alignment);
+  totalSize += sizes[3] = ALIGN(model->animationCount * sizeof(ModelAnimation), alignment);
+  totalSize += sizes[4] = ALIGN(model->skinCount * sizeof(ModelSkin), alignment);
+  totalSize += sizes[5] = ALIGN(model->nodeCount * sizeof(ModelNode), alignment);
+  totalSize += sizes[6] = ALIGN(model->partCount * sizeof(ModelPart), alignment);
+  totalSize += sizes[7] = ALIGN(model->blendShapeCount * sizeof(ModelBlendShape), alignment);
   totalSize += sizes[8] = ALIGN(model->channelCount * sizeof(ModelAnimationChannel), alignment);
   totalSize += sizes[9] = ALIGN(model->keyframeDataCount * sizeof(float), alignment);
   totalSize += sizes[10] = ALIGN(model->jointCount * 16 * sizeof(float), alignment);
@@ -74,11 +75,11 @@ void lovrModelDataAllocate(ModelData* model) {
   model->meshes = (ModelMesh*) (p + offset), offset += sizes[0];
   model->images = (Image**) (p + offset), offset += sizes[1];
   model->materials = (ModelMaterial*) (p + offset), offset += sizes[2];
-  model->blendShapes = (ModelBlendShape*) (p + offset), offset += sizes[3];
-  model->animations = (ModelAnimation*) (p + offset), offset += sizes[4];
-  model->skins = (ModelSkin*) (p + offset), offset += sizes[5];
-  model->nodes = (ModelNode*) (p + offset), offset += sizes[6];
-  model->primitives = (ModelPrimitive*) (p + offset), offset += sizes[7];
+  model->animations = (ModelAnimation*) (p + offset), offset += sizes[3];
+  model->skins = (ModelSkin*) (p + offset), offset += sizes[4];
+  model->nodes = (ModelNode*) (p + offset), offset += sizes[5];
+  model->parts = (ModelPart*) (p + offset), offset += sizes[6];
+  model->blendShapes = (ModelBlendShape*) (p + offset), offset += sizes[7];
   model->channels = (ModelAnimationChannel*) (p + offset), offset += sizes[8];
   model->keyframeData = (float*) (p + offset), offset += sizes[9];
   model->inverseBindMatrices = (float*) (p + offset), offset += sizes[10];
@@ -99,9 +100,19 @@ void lovrModelDataAllocate(ModelData* model) {
   map_init(model->materialMap, model->materialCount);
   map_init(model->nodeMap, model->nodeCount);
 
-  for (uint32_t i = 0; i < model->primitiveCount; i++) {
-    model->primitives[i].mode = DRAW_TRIANGLE_LIST;
-    model->primitives[i].material = ~0u;
+  for (uint32_t i = 0; i < model->meshCount; i++) {
+    model->meshes[i].vertexOffset = ~0u;
+    model->meshes[i].indexOffset = ~0u;
+    model->meshes[i].skinDataOffset = ~0u;
+    model->meshes[i].blendDataOffset = ~0u;
+  }
+
+  for (uint32_t i = 0; i < model->partCount; i++) {
+    model->parts[i].mode = DRAW_TRIANGLE_LIST;
+    model->parts[i].material = ~0u;
+    model->parts[i].bounds[3] = FLT_MAX;
+    model->parts[i].bounds[4] = FLT_MAX;
+    model->parts[i].bounds[5] = FLT_MAX;
   }
 
   for (uint32_t i = 0; i < model->materialCount; i++) {
@@ -143,12 +154,13 @@ void lovrModelDataAllocate(ModelData* model) {
 bool lovrModelDataFinalize(ModelData* model) {
   for (uint32_t i = 0; i < model->meshCount; i++) {
     uint32_t skin = ~0u;
-    for (uint32_t j = 0; j < model->nodeCount; j++) {
-      if (model->nodes[j].mesh == i) {
+    ModelNode* node = model->nodes;
+    for (uint32_t j = 0; j < model->nodeCount; j++, node++) {
+      if (node->mesh == i) {
         if (skin == ~0u) {
-          skin = model->nodes[j].skin;
+          skin = node->skin;
         } else {
-          lovrAssert(model->nodes[j].skin == skin, "Model has mesh used with multiple different skins, which is not currently supported");
+          lovrAssert(node->skin == skin, "Model has mesh used with multiple different skins, which is not currently supported");
         }
       }
     }
@@ -176,12 +188,12 @@ static void boundingBoxHelper(ModelData* model, uint32_t nodeIndex, float* paren
   if (node->mesh != ~0u) {
     ModelMesh* mesh = &model->meshes[node->mesh];
 
-    for (uint32_t i = 0; i < mesh->primitiveCount; i++) {
-      ModelPrimitive* primitive = &mesh->primitives[i];
+    for (uint32_t i = 0; i < mesh->partCount; i++) {
+      ModelPart* part = &mesh->parts[i];
 
-      float xmin = primitive->bounds[0], xmax = primitive->bounds[1];
-      float ymin = primitive->bounds[2], ymax = primitive->bounds[3];
-      float zmin = primitive->bounds[4], zmax = primitive->bounds[5];
+      float xmin = part->bounds[0], xmax = part->bounds[1];
+      float ymin = part->bounds[2], ymax = part->bounds[3];
+      float zmin = part->bounds[4], zmax = part->bounds[5];
 
       float xa[3] = { xmin * m[0], xmin * m[1], xmin * m[2] };
       float xb[3] = { xmax * m[0], xmax * m[1], xmax * m[2] };
@@ -245,13 +257,12 @@ static void boundingSphereHelper(ModelData* model, uint32_t nodeIndex, uint32_t*
 
   if (node->mesh != ~0u) {
     ModelMesh* mesh = &model->meshes[node->mesh];
+    ModelPart* part = mesh->parts;
 
-    for (uint32_t i = 0; i < mesh->primitiveCount; i++) {
-      ModelPrimitive* primitive = &mesh->primitives[i];
-
-      float xmin = primitive->bounds[0], xmax = primitive->bounds[1];
-      float ymin = primitive->bounds[2], ymax = primitive->bounds[3];
-      float zmin = primitive->bounds[4], zmax = primitive->bounds[5];
+    for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
+      float xmin = part->bounds[0], xmax = part->bounds[1];
+      float ymin = part->bounds[2], ymax = part->bounds[3];
+      float zmin = part->bounds[4], zmax = part->bounds[5];
 
       float corners[8][3] = {
         { xmin, ymin, zmin },
@@ -278,15 +289,13 @@ static void boundingSphereHelper(ModelData* model, uint32_t nodeIndex, uint32_t*
 
 void lovrModelDataGetBoundingSphere(ModelData* model, float sphere[4]) {
   if (model->boundingSphere[3] == 0.f) {
-    uint32_t totalPrimitiveCount = 0;
+    uint32_t totalPartCount = 0;
 
     for (uint32_t i = 0; i < model->nodeCount; i++) {
-      if (model->nodes[i].mesh != ~0u) {
-        totalPrimitiveCount += model->meshes[model->nodes[i].mesh].primitiveCount;
-      }
+      totalPartCount += model->meshes[model->nodes[i].mesh].partCount;
     }
 
-    uint32_t pointCount = totalPrimitiveCount * 8;
+    uint32_t pointCount = totalPartCount * 8;
     float* points = lovrMalloc(pointCount * 3 * sizeof(float));
 
     uint32_t pointIndex = 0;
@@ -353,15 +362,14 @@ static void countVertices(ModelData* model, uint32_t nodeIndex, uint32_t* vertex
 
   if (node->mesh != ~0u) {
     ModelMesh* mesh = &model->meshes[node->mesh];
-    for (uint32_t i = 0; i < mesh->primitiveCount; i++) {
-      ModelPrimitive* primitive = &mesh->primitives[i];
+    ModelPart* part = model->parts;
 
-      if (primitive->mode != DRAW_TRIANGLE_LIST) {
-        continue;
+    model->triangleVertexCount += mesh->vertexCount;
+
+    for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
+      if (part->mode == DRAW_TRIANGLE_LIST) {
+        model->triangleIndexCount += part->count;
       }
-
-      model->triangleVertexCount += primitive->vertexCount;
-      model->triangleIndexCount += primitive->indexCount > 0 ? primitive->count : primitive->vertexCount;
     }
   }
 
@@ -387,56 +395,47 @@ static void collectVertices(ModelData* model, uint32_t nodeIndex, float** vertic
     mat4_scale(m, S[0], S[1], S[2]);
   }
 
-  uint32_t nodeBase = *baseIndex;
-
   if (node->mesh != ~0u) {
     ModelMesh* mesh = &model->meshes[node->mesh];
-    ModelVertex* vertex = mesh->vertices;
-    void* index = mesh->indices;
+    ModelVertex* vertex = model->vertices + mesh->vertexOffset;
+    ModelPart* part = mesh->parts;
 
-    for (uint32_t i = 0; i < mesh->primitiveCount; i++) {
-      ModelPrimitive* primitive = &mesh->primitives[i];
+    for (uint32_t i = 0; i < mesh->vertexCount; i++, vertex++) {
+      float v[3] = { vertex->position.x, vertex->position.y, vertex->position.z };
+      vec3_init(*vertices, mat4_mulPoint(m, v));
+      *vertices += 3;
+    }
 
-      if (primitive->mode != DRAW_TRIANGLE_LIST) {
+    for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
+      if (part->mode != DRAW_TRIANGLE_LIST) {
         continue;
       }
 
-      uint32_t base = nodeBase;
-
-      if (base == *baseIndex) {
-        for (uint32_t j = 0; j < primitive->vertexCount; j++) {
-          float v[3] = { vertex->position.x, vertex->position.y, vertex->position.z };
-          vec3_init(*vertices, mat4_mulPoint(m, v));
-          *vertices += 3;
-          vertex++;
-        }
-
-        *baseIndex += primitive->vertexCount;
-      }
-
-      if (primitive->indexCount > 0) {
+      if (mesh->indexCount > 0) {
         if (model->indexSize == 4) {
-          for (uint32_t j = 0; j < primitive->indexCount; j++) {
-            **indices = *(uint32_t*) index + base;
+          uint32_t* indexData = (uint32_t*) model->indices + part->start;
+          for (uint32_t j = 0; j < part->count; j++) {
+            **indices = indexData[j] + *baseIndex;
             *indices += 1;
-            index = (char*) index + 4;
           }
         } else if (model->indexSize == 2) {
-          for (uint32_t j = 0; j < primitive->indexCount; j++) {
-            **indices = (uint32_t) *(uint16_t*) index + base;
+          uint16_t* indexData = (uint16_t*) model->indices + part->start;
+          for (uint32_t j = 0; j < part->count; j++) {
+            **indices = (uint32_t) indexData[j] + *baseIndex;
             *indices += 1;
-            index = (char*) index + 2;
           }
         } else {
           lovrUnreachable();
         }
       } else {
-        for (uint32_t j = 0; j < primitive->vertexCount; j++) {
-          **indices = j + base;
+        for (uint32_t j = 0; j < part->count; j++) {
+          **indices = *baseIndex + j;
           *indices += 1;
         }
       }
     }
+
+    *baseIndex += mesh->vertexCount;
   }
 
   for (uint32_t i = node->child; i != ~0u; i = model->nodes[i].sibling) {

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -110,9 +110,6 @@ void lovrModelDataAllocate(ModelData* model) {
   for (uint32_t i = 0; i < model->partCount; i++) {
     model->parts[i].mode = DRAW_TRIANGLE_LIST;
     model->parts[i].material = ~0u;
-    model->parts[i].bounds[3] = FLT_MAX;
-    model->parts[i].bounds[4] = FLT_MAX;
-    model->parts[i].bounds[5] = FLT_MAX;
   }
 
   for (uint32_t i = 0; i < model->materialCount; i++) {
@@ -238,7 +235,20 @@ void lovrModelDataGetBoundingBox(ModelData* model, float box[6]) {
   memcpy(box, model->boundingBox, sizeof(model->boundingBox));
 }
 
-static void boundingSphereHelper(ModelData* model, uint32_t nodeIndex, uint32_t* pointIndex, float* points, float* parentTransform) {
+void lovrModelDataGetMeshBoundingBox(ModelData* model, uint32_t index, float box[6]) {
+  ModelMesh* mesh = &model->meshes[index];
+  memcpy(box, mesh->parts[0].bounds, 6 * sizeof(float));
+  for (uint32_t i = 1; i < mesh->partCount; i++) {
+    box[0] = MIN(box[0], mesh->parts[i].bounds[0]);
+    box[1] = MAX(box[1], mesh->parts[i].bounds[1]);
+    box[2] = MIN(box[2], mesh->parts[i].bounds[2]);
+    box[3] = MAX(box[3], mesh->parts[i].bounds[3]);
+    box[4] = MIN(box[4], mesh->parts[i].bounds[4]);
+    box[5] = MAX(box[5], mesh->parts[i].bounds[5]);
+  }
+}
+
+static void gatherBoundingBoxCorners(ModelData* model, uint32_t nodeIndex, uint32_t* pointIndex, float* points, float* parentTransform) {
   ModelNode* node = &model->nodes[nodeIndex];
 
   float m[16];
@@ -283,8 +293,60 @@ static void boundingSphereHelper(ModelData* model, uint32_t nodeIndex, uint32_t*
   }
 
   for (uint32_t i = node->child; i != ~0u; i = model->nodes[i].sibling) {
-    boundingSphereHelper(model, i, pointIndex, points, m);
+    gatherBoundingBoxCorners(model, i, pointIndex, points, m);
   }
+}
+
+static void computeBoundingSphere(float* points, uint32_t pointCount, size_t stride, float sphere[4]) {
+
+  // Find point furthest away from first point
+
+  float max = 0.f;
+  float* a = NULL;
+  for (uint32_t i = 1; i < pointCount; i++) {
+    float d2 = vec3_distance2(&points[i * stride], &points[0]);
+    if (d2 > max) {
+      a = &points[i * stride];
+      max = d2;
+    }
+  }
+
+  // Find point furthest away from that point
+
+  max = 0.f;
+  float* b = NULL;
+  for (uint32_t i = 0; i < pointCount; i++) {
+    float d2 = vec3_distance2(&points[i * stride], a);
+    if (d2 > max) {
+      b = &points[i * stride];
+      max = d2;
+    }
+  }
+
+  // Create and refine sphere
+
+  float dx = a[0] - b[0];
+  float dy = a[1] - b[1];
+  float dz = a[2] - b[2];
+  float cx = (a[0] + b[0]) / 2.f;
+  float cy = (a[1] + b[1]) / 2.f;
+  float cz = (a[2] + b[2]) / 2.f;
+  float r2 = (dx * dx + dy * dy + dz * dz) / 4.f; // Initial radius is half the distance between points
+
+  for (uint32_t i = 0; i < pointCount; i++) {
+    float dx = points[i * stride + 0] - cx;
+    float dy = points[i * stride + 1] - cy;
+    float dz = points[i * stride + 2] - cz;
+    float d2 = dx * dx + dy * dy + dz * dz;
+    if (d2 > r2) {
+      r2 = d2; // beep boop
+    }
+  }
+
+  sphere[0] = cx;
+  sphere[1] = cy;
+  sphere[2] = cz;
+  sphere[3] = sqrtf(r2);
 }
 
 void lovrModelDataGetBoundingSphere(ModelData* model, float sphere[4]) {
@@ -292,69 +354,30 @@ void lovrModelDataGetBoundingSphere(ModelData* model, float sphere[4]) {
     uint32_t totalPartCount = 0;
 
     for (uint32_t i = 0; i < model->nodeCount; i++) {
-      totalPartCount += model->meshes[model->nodes[i].mesh].partCount;
+      if (model->nodes[i].mesh != ~0u) {
+        totalPartCount += model->meshes[model->nodes[i].mesh].partCount;
+      }
     }
 
     uint32_t pointCount = totalPartCount * 8;
     float* points = lovrMalloc(pointCount * 3 * sizeof(float));
 
     uint32_t pointIndex = 0;
-    boundingSphereHelper(model, model->rootNode, &pointIndex, points, (float[16]) MAT4_IDENTITY);
-
-    // Find point furthest away from first point
-
-    float max = 0.f;
-    float* a = NULL;
-    for (uint32_t i = 1; i < pointCount; i++) {
-      float d2 = vec3_distance2(&points[3 * i], &points[0]);
-      if (d2 > max) {
-        a = &points[3 * i];
-        max = d2;
-      }
-    }
-
-    // Find point furthest away from that point
-
-    max = 0.f;
-    float* b = NULL;
-    for (uint32_t i = 0; i < pointCount; i++) {
-      float d2 = vec3_distance2(&points[3 * i], a);
-      if (d2 > max) {
-        b = &points[3 * i];
-        max = d2;
-      }
-    }
-
-    // Create and refine sphere
-
-    float dx = a[0] - b[0];
-    float dy = a[1] - b[1];
-    float dz = a[2] - b[2];
-    float x = (a[0] + b[0]) / 2.f;
-    float y = (a[1] + b[1]) / 2.f;
-    float z = (a[2] + b[2]) / 2.f;
-    float r = sqrtf(dx * dx + dy * dy + dz * dz) / 2.f;
-    float r2 = r * r;
-
-    for (uint32_t i = 0; i < pointCount; i++) {
-      float dx = points[3 * i + 0] - x;
-      float dy = points[3 * i + 1] - y;
-      float dz = points[3 * i + 2] - z;
-      float d2 = dx * dx + dy * dy + dz * dz;
-      if (d2 > r2) {
-        r = sqrtf(d2);
-        r2 = r * r;
-      }
-    }
-
-    model->boundingSphere[0] = x;
-    model->boundingSphere[1] = y;
-    model->boundingSphere[2] = z;
-    model->boundingSphere[3] = r;
+    gatherBoundingBoxCorners(model, model->rootNode, &pointIndex, points, (float[16]) MAT4_IDENTITY);
+    computeBoundingSphere(points, pointCount, 3, model->boundingSphere);
     lovrFree(points);
   }
 
   memcpy(sphere, model->boundingSphere, sizeof(model->boundingSphere));
+}
+
+void lovrModelDataGetMeshBoundingSphere(ModelData* model, uint32_t index, uint32_t part, float sphere[4]) {
+  ModelMesh* mesh = &model->meshes[index];
+  uint32_t nextVertexOffset = part == mesh->partCount - 1 ? mesh->vertexOffset + mesh->vertexCount : mesh->parts[part + 1].baseVertex;
+  uint32_t start = part == ~0u ? mesh->vertexOffset : mesh->parts[part].baseVertex;
+  uint32_t count = part == ~0u ? mesh->vertexCount : nextVertexOffset - start;
+  float* vertex = &model->vertices[start].position.x;
+  computeBoundingSphere(vertex, count, sizeof(ModelVertex) / sizeof(float), sphere);
 }
 
 static void countVertices(ModelData* model, uint32_t nodeIndex, uint32_t* vertexCount, uint32_t* indexCount) {

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -49,10 +49,10 @@ void lovrModelDataDestroy(void* ref) {
 // Batches allocations for all the ModelData arrays
 void lovrModelDataAllocate(ModelData* model) {
   size_t totalSize = 0;
-  size_t sizes[16];
+  size_t sizes[17];
   size_t alignment = 8;
-  totalSize += sizes[0] = ALIGN(model->imageCount * sizeof(Image*), alignment);
-  totalSize += sizes[1] = ALIGN(model->meshCount * sizeof(ModelMesh), alignment);
+  totalSize += sizes[0] = ALIGN(model->meshCount * sizeof(ModelMesh), alignment);
+  totalSize += sizes[1] = ALIGN(model->imageCount * sizeof(Image*), alignment);
   totalSize += sizes[2] = ALIGN(model->materialCount * sizeof(ModelMaterial), alignment);
   totalSize += sizes[3] = ALIGN(model->blendShapeCount * sizeof(ModelBlendShape), alignment);
   totalSize += sizes[4] = ALIGN(model->animationCount * sizeof(ModelAnimation), alignment);
@@ -60,18 +60,19 @@ void lovrModelDataAllocate(ModelData* model) {
   totalSize += sizes[6] = ALIGN(model->nodeCount * sizeof(ModelNode), alignment);
   totalSize += sizes[7] = ALIGN(model->primitiveCount * sizeof(ModelPrimitive), alignment);
   totalSize += sizes[8] = ALIGN(model->channelCount * sizeof(ModelAnimationChannel), alignment);
-  totalSize += sizes[9] = ALIGN(model->jointCount * 16 * sizeof(float), alignment);
-  totalSize += sizes[10] = ALIGN(model->jointCount * sizeof(uint32_t), alignment);
-  totalSize += sizes[11] = ALIGN(model->charCount * sizeof(char), alignment);
-  totalSize += sizes[12] = ALIGN(sizeof(map_t), alignment);
+  totalSize += sizes[9] = ALIGN(model->keyframeDataCount * sizeof(float), alignment);
+  totalSize += sizes[10] = ALIGN(model->jointCount * 16 * sizeof(float), alignment);
+  totalSize += sizes[11] = ALIGN(model->jointCount * sizeof(uint32_t), alignment);
+  totalSize += sizes[12] = ALIGN(model->charCount * sizeof(char), alignment);
   totalSize += sizes[13] = ALIGN(sizeof(map_t), alignment);
   totalSize += sizes[14] = ALIGN(sizeof(map_t), alignment);
   totalSize += sizes[15] = ALIGN(sizeof(map_t), alignment);
+  totalSize += sizes[16] = ALIGN(sizeof(map_t), alignment);
 
   size_t offset = 0;
   char* p = model->data = lovrCalloc(totalSize);
-  model->images = (Image**) (p + offset), offset += sizes[0];
-  model->meshes = (ModelMesh*) (p + offset), offset += sizes[1];
+  model->meshes = (ModelMesh*) (p + offset), offset += sizes[0];
+  model->images = (Image**) (p + offset), offset += sizes[1];
   model->materials = (ModelMaterial*) (p + offset), offset += sizes[2];
   model->blendShapes = (ModelBlendShape*) (p + offset), offset += sizes[3];
   model->animations = (ModelAnimation*) (p + offset), offset += sizes[4];
@@ -79,13 +80,14 @@ void lovrModelDataAllocate(ModelData* model) {
   model->nodes = (ModelNode*) (p + offset), offset += sizes[6];
   model->primitives = (ModelPrimitive*) (p + offset), offset += sizes[7];
   model->channels = (ModelAnimationChannel*) (p + offset), offset += sizes[8];
-  model->inverseBindMatrices = (float*) (p + offset), offset += sizes[9];
-  model->joints = (uint32_t*) (p + offset), offset += sizes[10];
-  model->chars = (char*) (p + offset), offset += sizes[11];
-  model->blendShapeMap = (map_t*) (p + offset), offset += sizes[12];
-  model->animationMap = (map_t*) (p + offset), offset += sizes[13];
-  model->materialMap = (map_t*) (p + offset), offset += sizes[14];
-  model->nodeMap = (map_t*) (p + offset), offset += sizes[15];
+  model->keyframeData = (float*) (p + offset), offset += sizes[9];
+  model->inverseBindMatrices = (float*) (p + offset), offset += sizes[10];
+  model->joints = (uint32_t*) (p + offset), offset += sizes[11];
+  model->chars = (char*) (p + offset), offset += sizes[12];
+  model->blendShapeMap = (map_t*) (p + offset), offset += sizes[13];
+  model->animationMap = (map_t*) (p + offset), offset += sizes[14];
+  model->materialMap = (map_t*) (p + offset), offset += sizes[15];
+  model->nodeMap = (map_t*) (p + offset), offset += sizes[16];
 
   model->vertices = model->vertexCount > 0 ? lovrMalloc(model->vertexCount * sizeof(ModelVertex)) : NULL;
   model->indices = model->indexCount > 0 ? lovrMalloc(model->indexCount * model->indexSize) : NULL;

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -31,91 +31,94 @@ ModelData* lovrModelDataCreate(Blob* source, ModelDataIO* io) {
 
 void lovrModelDataDestroy(void* ref) {
   ModelData* model = ref;
-  for (uint32_t i = 0; model->images && i < model->imageCount; i++) {
+  for (uint32_t i = 0; model->images && i < model->meta.imageCount; i++) {
     lovrRelease(model->images[i], lovrImageDestroy);
   }
-  map_free(model->blendShapeMap);
-  map_free(model->animationMap);
-  map_free(model->materialMap);
-  map_free(model->nodeMap);
-  lovrFree(model->triangleVertices);
-  lovrFree(model->triangleIndices);
+  lovrRelease(model->meta.blob, lovrBlobDestroy);
   lovrFree(model->vertices);
   lovrFree(model->indices);
   lovrFree(model->skinData);
   lovrFree(model->blendData);
-  lovrFree(model->metadata);
-  lovrFree(model->data);
+  lovrFree(model->images);
   lovrFree(model);
+}
+
+static uint32_t nextPo2(uint32_t x) {
+  x--;
+  x |= x >> 1;
+  x |= x >> 2;
+  x |= x >> 4;
+  x |= x >> 8;
+  x |= x >> 16;
+  return x + 1;
 }
 
 // Batches allocations for all the ModelData arrays
 void lovrModelDataAllocate(ModelData* model) {
+  ModelMetadata* meta = &model->meta;
+
   size_t totalSize = 0;
   size_t sizes[17];
   size_t alignment = 8;
-  totalSize += sizes[0] = ALIGN(model->meshCount * sizeof(ModelMesh), alignment);
-  totalSize += sizes[1] = ALIGN(model->imageCount * sizeof(Image*), alignment);
-  totalSize += sizes[2] = ALIGN(model->materialCount * sizeof(ModelMaterial), alignment);
-  totalSize += sizes[3] = ALIGN(model->animationCount * sizeof(ModelAnimation), alignment);
-  totalSize += sizes[4] = ALIGN(model->skinCount * sizeof(ModelSkin), alignment);
-  totalSize += sizes[5] = ALIGN(model->nodeCount * sizeof(ModelNode), alignment);
-  totalSize += sizes[6] = ALIGN(model->partCount * sizeof(ModelPart), alignment);
-  totalSize += sizes[7] = ALIGN(model->blendShapeCount * sizeof(ModelBlendShape), alignment);
-  totalSize += sizes[8] = ALIGN(model->channelCount * sizeof(ModelAnimationChannel), alignment);
-  totalSize += sizes[9] = ALIGN(model->keyframeDataCount * sizeof(float), alignment);
-  totalSize += sizes[10] = ALIGN(model->jointCount * 16 * sizeof(float), alignment);
-  totalSize += sizes[11] = ALIGN(model->jointCount * sizeof(uint32_t), alignment);
-  totalSize += sizes[12] = ALIGN(model->charCount * sizeof(char), alignment);
-  totalSize += sizes[13] = ALIGN(sizeof(map_t), alignment);
-  totalSize += sizes[14] = ALIGN(sizeof(map_t), alignment);
-  totalSize += sizes[15] = ALIGN(sizeof(map_t), alignment);
-  totalSize += sizes[16] = ALIGN(sizeof(map_t), alignment);
+  totalSize += sizes[0] = ALIGN(meta->meshCount * sizeof(ModelMesh), alignment);
+  totalSize += sizes[1] = ALIGN(meta->materialCount * sizeof(ModelMaterial), alignment);
+  totalSize += sizes[2] = ALIGN(meta->animationCount * sizeof(ModelAnimation), alignment);
+  totalSize += sizes[3] = ALIGN(meta->skinCount * sizeof(ModelSkin), alignment);
+  totalSize += sizes[4] = ALIGN(meta->nodeCount * sizeof(ModelNode), alignment);
+  totalSize += sizes[5] = ALIGN(meta->partCount * sizeof(ModelPart), alignment);
+  totalSize += sizes[6] = ALIGN(meta->blendShapeCount * sizeof(ModelBlendShape), alignment);
+  totalSize += sizes[7] = ALIGN(meta->channelCount * sizeof(ModelAnimationChannel), alignment);
+  totalSize += sizes[8] = ALIGN(meta->keyframeDataCount * sizeof(float), alignment);
+  totalSize += sizes[9] = ALIGN(meta->jointCount * 16 * sizeof(float), alignment);
+  totalSize += sizes[10] = ALIGN(meta->jointCount * sizeof(uint32_t), alignment);
+  totalSize += sizes[11] = ALIGN(meta->charCount * sizeof(char), alignment);
+  totalSize += sizes[12] = ALIGN(meta->blendShapeCount * sizeof(uint32_t), alignment);
+  totalSize += sizes[13] = ALIGN(meta->animationCount * sizeof(uint32_t), alignment);
+  totalSize += sizes[14] = ALIGN(meta->materialCount * sizeof(uint32_t), alignment);
+  totalSize += sizes[15] = ALIGN(meta->nodeCount * sizeof(uint32_t), alignment);
+  totalSize += sizes[16] = ALIGN(meta->commentLength, alignment);
 
   size_t offset = 0;
-  char* p = model->data = lovrCalloc(totalSize);
-  model->meshes = (ModelMesh*) (p + offset), offset += sizes[0];
-  model->images = (Image**) (p + offset), offset += sizes[1];
-  model->materials = (ModelMaterial*) (p + offset), offset += sizes[2];
-  model->animations = (ModelAnimation*) (p + offset), offset += sizes[3];
-  model->skins = (ModelSkin*) (p + offset), offset += sizes[4];
-  model->nodes = (ModelNode*) (p + offset), offset += sizes[5];
-  model->parts = (ModelPart*) (p + offset), offset += sizes[6];
-  model->blendShapes = (ModelBlendShape*) (p + offset), offset += sizes[7];
-  model->channels = (ModelAnimationChannel*) (p + offset), offset += sizes[8];
-  model->keyframeData = (float*) (p + offset), offset += sizes[9];
-  model->inverseBindMatrices = (float*) (p + offset), offset += sizes[10];
-  model->joints = (uint32_t*) (p + offset), offset += sizes[11];
-  model->chars = (char*) (p + offset), offset += sizes[12];
-  model->blendShapeMap = (map_t*) (p + offset), offset += sizes[13];
-  model->animationMap = (map_t*) (p + offset), offset += sizes[14];
-  model->materialMap = (map_t*) (p + offset), offset += sizes[15];
-  model->nodeMap = (map_t*) (p + offset), offset += sizes[16];
+  char* p = lovrCalloc(totalSize);
+  meta->blob = lovrBlobCreate(p, totalSize, "Model Metadata");
+  meta->meshes = (ModelMesh*) (p + offset), offset += sizes[0];
+  meta->materials = (ModelMaterial*) (p + offset), offset += sizes[1];
+  meta->animations = (ModelAnimation*) (p + offset), offset += sizes[2];
+  meta->skins = (ModelSkin*) (p + offset), offset += sizes[3];
+  meta->nodes = (ModelNode*) (p + offset), offset += sizes[4];
+  meta->parts = (ModelPart*) (p + offset), offset += sizes[5];
+  meta->blendShapes = (ModelBlendShape*) (p + offset), offset += sizes[6];
+  meta->channels = (ModelAnimationChannel*) (p + offset), offset += sizes[7];
+  meta->keyframeData = (float*) (p + offset), offset += sizes[8];
+  meta->inverseBindMatrices = (float*) (p + offset), offset += sizes[9];
+  meta->joints = (uint32_t*) (p + offset), offset += sizes[10];
+  meta->chars = (char*) (p + offset), offset += sizes[11];
+  meta->blendShapeLookup = (uint32_t*) (p + offset), offset += sizes[12];
+  meta->animationLookup = (uint32_t*) (p + offset), offset += sizes[13];
+  meta->materialLookup = (uint32_t*) (p + offset), offset += sizes[14];
+  meta->nodeLookup = (uint32_t*) (p + offset), offset += sizes[15];
+  meta->comment = (char*) (p + offset), offset += sizes[16];
 
-  model->vertices = model->vertexCount > 0 ? lovrMalloc(model->vertexCount * sizeof(ModelVertex)) : NULL;
-  model->indices = model->indexCount > 0 ? lovrMalloc(model->indexCount * model->indexSize) : NULL;
-  model->skinData = model->skinnedVertexCount > 0 ? lovrMalloc(model->skinnedVertexCount * sizeof(SkinData)) : NULL;
-  model->blendData = model->blendedVertexCount > 0 ? lovrMalloc(model->blendedVertexCount * sizeof(BlendData)) : NULL;
+  model->vertices = meta->vertexCount > 0 ? lovrMalloc(meta->vertexCount * sizeof(ModelVertex)) : NULL;
+  model->indices = meta->indexCount > 0 ? lovrMalloc(meta->indexCount * meta->indexSize) : NULL;
+  model->skinData = meta->skinnedVertexCount > 0 ? lovrMalloc(meta->skinnedVertexCount * sizeof(SkinData)) : NULL;
+  model->blendData = meta->blendedVertexCount > 0 ? lovrMalloc(meta->blendedVertexCount * sizeof(BlendData)) : NULL;
+  model->images = meta->imageCount > 0 ? lovrMalloc(meta->imageCount * sizeof(Image*)) : NULL;
 
-  map_init(model->blendShapeMap, model->blendShapeCount);
-  map_init(model->animationMap, model->animationCount);
-  map_init(model->materialMap, model->materialCount);
-  map_init(model->nodeMap, model->nodeCount);
-
-  for (uint32_t i = 0; i < model->meshCount; i++) {
-    model->meshes[i].vertexOffset = ~0u;
-    model->meshes[i].indexOffset = ~0u;
-    model->meshes[i].skinDataOffset = ~0u;
-    model->meshes[i].blendDataOffset = ~0u;
+  for (uint32_t i = 0; i < meta->meshCount; i++) {
+    meta->meshes[i].vertexOffset = ~0u;
+    meta->meshes[i].indexOffset = ~0u;
+    meta->meshes[i].skinDataOffset = ~0u;
+    meta->meshes[i].blendDataOffset = ~0u;
   }
 
-  for (uint32_t i = 0; i < model->partCount; i++) {
-    model->parts[i].mode = DRAW_TRIANGLE_LIST;
-    model->parts[i].material = ~0u;
+  for (uint32_t i = 0; i < meta->partCount; i++) {
+    meta->parts[i].mode = DRAW_TRIANGLE_LIST;
+    meta->parts[i].material = ~0u;
   }
 
-  for (uint32_t i = 0; i < model->materialCount; i++) {
-    model->materials[i] = (ModelMaterial) {
+  for (uint32_t i = 0; i < meta->materialCount; i++) {
+    meta->materials[i] = (ModelMaterial) {
       .color = { 1.f, 1.f, 1.f, 1.f },
       .glow = { 0.f, 0.f, 0.f, 1.f },
       .uvShift = { 0.f, 0.f },
@@ -137,24 +140,33 @@ void lovrModelDataAllocate(ModelData* model) {
     };
   }
 
-  for (uint32_t i = 0; i < model->nodeCount; i++) {
-    vec3_set(model->nodes[i].transform.translation, 0.f, 0.f, 0.f);
-    quat_identity(model->nodes[i].transform.rotation);
-    vec3_set(model->nodes[i].transform.scale, 1.f, 1.f, 1.f);
-    model->nodes[i].hasMatrix = false;
-    model->nodes[i].child = ~0u;
-    model->nodes[i].sibling = ~0u;
-    model->nodes[i].parent = ~0u;
-    model->nodes[i].mesh = ~0u;
-    model->nodes[i].skin = ~0u;
+  for (uint32_t i = 0; i < meta->nodeCount; i++) {
+    vec3_set(meta->nodes[i].transform.translation, 0.f, 0.f, 0.f);
+    quat_identity(meta->nodes[i].transform.rotation);
+    vec3_set(meta->nodes[i].transform.scale, 1.f, 1.f, 1.f);
+    meta->nodes[i].hasMatrix = false;
+    meta->nodes[i].child = ~0u;
+    meta->nodes[i].sibling = ~0u;
+    meta->nodes[i].parent = ~0u;
+    meta->nodes[i].mesh = ~0u;
+    meta->nodes[i].skin = ~0u;
   }
+
+  meta->bounds[0] = FLT_MAX;
+  meta->bounds[1] = FLT_MAX;
+  meta->bounds[2] = FLT_MAX;
+  meta->bounds[3] = -FLT_MAX;
+  meta->bounds[4] = -FLT_MAX;
+  meta->bounds[5] = -FLT_MAX;
 }
 
 bool lovrModelDataFinalize(ModelData* model) {
-  for (uint32_t i = 0; i < model->meshCount; i++) {
+  ModelMetadata* meta = &model->meta;
+
+  for (uint32_t i = 0; i < meta->meshCount; i++) {
     uint32_t skin = ~0u;
-    ModelNode* node = model->nodes;
-    for (uint32_t j = 0; j < model->nodeCount; j++, node++) {
+    ModelNode* node = meta->nodes;
+    for (uint32_t j = 0; j < meta->nodeCount; j++, node++) {
       if (node->mesh == i) {
         if (skin == ~0u) {
           skin = node->skin;
@@ -165,11 +177,139 @@ bool lovrModelDataFinalize(ModelData* model) {
     }
   }
 
+  for (uint32_t i = 0; i < meta->blendShapeCount; i++) {
+    const char* name = meta->blendShapes[i].name;
+    meta->blendShapeLookup[i] = name ? (uint32_t) hash64(name, strlen(name)) : ~0u;
+  }
+
+  for (uint32_t i = 0; i < meta->animationCount; i++) {
+    const char* name = meta->animations[i].name;
+    meta->animationLookup[i] = name ? (uint32_t) hash64(name, strlen(name)) : ~0u;
+  }
+
+  for (uint32_t i = 0; i < meta->materialCount; i++) {
+    const char* name = meta->materials[i].name;
+    meta->materialLookup[i] = name ? (uint32_t) hash64(name, strlen(name)) : ~0u;
+  }
+
+  for (uint32_t i = 0; i < meta->nodeCount; i++) {
+    const char* name = meta->nodes[i].name;
+    meta->nodeLookup[i] = name ? (uint32_t) hash64(name, strlen(name)) : ~0u;
+  }
+
   return true;
 }
 
-static void boundingBoxHelper(ModelData* model, uint32_t nodeIndex, float* parentTransform) {
-  ModelNode* node = &model->nodes[nodeIndex];
+static void countVertices(ModelData* model, uint32_t nodeIndex, uint32_t* vertexCount, uint32_t* indexCount) {
+  ModelNode* node = &model->meta.nodes[nodeIndex];
+
+  if (node->mesh != ~0u) {
+    ModelMesh* mesh = &model->meta.meshes[node->mesh];
+    ModelPart* part = mesh->parts;
+
+    model->triangleVertexCount += mesh->vertexCount;
+
+    for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
+      if (part->mode == DRAW_TRIANGLE_LIST) {
+        model->triangleIndexCount += part->count;
+      }
+    }
+  }
+
+  for (uint32_t i = node->child; i != ~0u; i = model->meta.nodes[i].sibling) {
+    countVertices(model, i, vertexCount, indexCount);
+  }
+}
+
+static void collectVertices(ModelData* model, uint32_t nodeIndex, float** vertices, uint32_t** indices, uint32_t* baseIndex, float* parentTransform) {
+  ModelNode* node = &model->meta.nodes[nodeIndex];
+
+  float m[16];
+  mat4_init(m, parentTransform);
+
+  if (node->hasMatrix) {
+    mat4_mul(m, node->transform.matrix);
+  } else {
+    float* T = node->transform.translation;
+    float* R = node->transform.rotation;
+    float* S = node->transform.scale;
+    mat4_translate(m, T[0], T[1], T[2]);
+    mat4_rotateQuat(m, R);
+    mat4_scale(m, S[0], S[1], S[2]);
+  }
+
+  if (node->mesh != ~0u) {
+    ModelMesh* mesh = &model->meta.meshes[node->mesh];
+    ModelVertex* vertex = model->vertices + mesh->vertexOffset;
+    ModelPart* part = mesh->parts;
+
+    for (uint32_t i = 0; i < mesh->vertexCount; i++, vertex++) {
+      float v[3] = { vertex->position.x, vertex->position.y, vertex->position.z };
+      vec3_init(*vertices, mat4_mulPoint(m, v));
+      *vertices += 3;
+    }
+
+    for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
+      if (part->mode != DRAW_TRIANGLE_LIST) {
+        continue;
+      }
+
+      if (mesh->indexCount > 0) {
+        if (model->meta.indexSize == 4) {
+          uint32_t* indexData = (uint32_t*) model->indices + part->start;
+          for (uint32_t j = 0; j < part->count; j++) {
+            **indices = indexData[j] + *baseIndex;
+            *indices += 1;
+          }
+        } else if (model->meta.indexSize == 2) {
+          uint16_t* indexData = (uint16_t*) model->indices + part->start;
+          for (uint32_t j = 0; j < part->count; j++) {
+            **indices = (uint32_t) indexData[j] + *baseIndex;
+            *indices += 1;
+          }
+        } else {
+          lovrUnreachable();
+        }
+      } else {
+        for (uint32_t j = 0; j < part->count; j++) {
+          **indices = *baseIndex + j;
+          *indices += 1;
+        }
+      }
+    }
+
+    *baseIndex += mesh->vertexCount;
+  }
+
+  for (uint32_t i = node->child; i != ~0u; i = model->meta.nodes[i].sibling) {
+    collectVertices(model, i, vertices, indices, baseIndex, m);
+  }
+}
+
+void lovrModelDataGetTriangles(ModelData* model, float** vertices, uint32_t** indices, uint32_t* vertexCount, uint32_t* indexCount) {
+  if (model->triangleVertexCount == 0) {
+    countVertices(model, model->meta.rootNode, vertexCount, indexCount);
+  }
+
+  if (vertices && !model->triangleVertices) {
+    uint32_t* tempIndices;
+    uint32_t baseIndex = 0;
+    model->triangleVertices = lovrMalloc(model->triangleVertexCount * 3 * sizeof(float));
+    model->triangleIndices = lovrMalloc(model->triangleIndexCount * sizeof(uint32_t));
+    *vertices = model->triangleVertices;
+    tempIndices = model->triangleIndices;
+    collectVertices(model, model->meta.rootNode, vertices, &tempIndices, &baseIndex, (float[16]) MAT4_IDENTITY);
+  }
+
+  if (vertexCount) *vertexCount = model->triangleVertexCount;
+  if (indexCount) *indexCount = model->triangleIndexCount;
+
+  if (vertices) *vertices = model->triangleVertices;
+  if (indices) *indices = model->triangleIndices;
+}
+
+static void boundingBoxHelper(ModelMetadata* meta, uint32_t nodeIndex, float* parentTransform) {
+  ModelNode* node = &meta->nodes[nodeIndex];
 
   float m[16];
   mat4_init(m, parentTransform);
@@ -185,7 +325,7 @@ static void boundingBoxHelper(ModelData* model, uint32_t nodeIndex, float* paren
   }
 
   if (node->mesh != ~0u) {
-    ModelMesh* mesh = &model->meshes[node->mesh];
+    ModelMesh* mesh = &meta->meshes[node->mesh];
 
     for (uint32_t i = 0; i < mesh->partCount; i++) {
       ModelPart* part = &mesh->parts[i];
@@ -215,30 +355,30 @@ static void boundingBoxHelper(ModelData* model, uint32_t nodeIndex, float* paren
         MAX(xa[2], xb[2]) + MAX(ya[2], yb[2]) + MAX(za[2], zb[2]) + m[14]
       };
 
-      model->boundingBox[0] = MIN(model->boundingBox[0], min[0]);
-      model->boundingBox[1] = MAX(model->boundingBox[1], max[0]);
-      model->boundingBox[2] = MIN(model->boundingBox[2], min[1]);
-      model->boundingBox[3] = MAX(model->boundingBox[3], max[1]);
-      model->boundingBox[4] = MIN(model->boundingBox[4], min[2]);
-      model->boundingBox[5] = MAX(model->boundingBox[5], max[2]);
+      meta->bounds[0] = MIN(meta->bounds[0], min[0]);
+      meta->bounds[1] = MAX(meta->bounds[1], max[0]);
+      meta->bounds[2] = MIN(meta->bounds[2], min[1]);
+      meta->bounds[3] = MAX(meta->bounds[3], max[1]);
+      meta->bounds[4] = MIN(meta->bounds[4], min[2]);
+      meta->bounds[5] = MAX(meta->bounds[5], max[2]);
     }
   }
 
-  for (uint32_t i = node->child; i != ~0u; i = model->nodes[i].sibling) {
-    boundingBoxHelper(model, i, m);
+  for (uint32_t i = node->child; i != ~0u; i = meta->nodes[i].sibling) {
+    boundingBoxHelper(meta, i, m);
   }
 }
 
-void lovrModelDataGetBoundingBox(ModelData* model, float box[6]) {
-  if (model->boundingBox[1] - model->boundingBox[0] == 0.f) {
-    boundingBoxHelper(model, model->rootNode, (float[16]) MAT4_IDENTITY);
+void lovrModelMetadataGetBoundingBox(ModelMetadata* meta, float box[6]) {
+  if (meta->bounds[1] < meta->bounds[0]) {
+    boundingBoxHelper(meta, meta->rootNode, (float[16]) MAT4_IDENTITY);
   }
 
-  memcpy(box, model->boundingBox, sizeof(model->boundingBox));
+  memcpy(box, meta->bounds, sizeof(meta->bounds));
 }
 
-void lovrModelDataGetMeshBoundingBox(ModelData* model, uint32_t index, float box[6]) {
-  ModelMesh* mesh = &model->meshes[index];
+void lovrModelMetadataGetMeshBoundingBox(ModelMetadata* meta, uint32_t index, float box[6]) {
+  ModelMesh* mesh = &meta->meshes[index];
   memcpy(box, mesh->parts[0].bounds, 6 * sizeof(float));
   for (uint32_t i = 1; i < mesh->partCount; i++) {
     box[0] = MIN(box[0], mesh->parts[i].bounds[0]);
@@ -250,249 +390,9 @@ void lovrModelDataGetMeshBoundingBox(ModelData* model, uint32_t index, float box
   }
 }
 
-static void gatherBoundingBoxCorners(ModelData* model, uint32_t nodeIndex, uint32_t* pointIndex, float* points, float* parentTransform) {
-  ModelNode* node = &model->nodes[nodeIndex];
-
-  float m[16];
-  mat4_init(m, parentTransform);
-
-  if (node->hasMatrix) {
-    mat4_mul(m, node->transform.matrix);
-  } else {
-    float* T = node->transform.translation;
-    float* R = node->transform.rotation;
-    float* S = node->transform.scale;
-    mat4_translate(m, T[0], T[1], T[2]);
-    mat4_rotateQuat(m, R);
-    mat4_scale(m, S[0], S[1], S[2]);
-  }
-
-  if (node->mesh != ~0u) {
-    ModelMesh* mesh = &model->meshes[node->mesh];
-    ModelPart* part = mesh->parts;
-
-    for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
-      float xmin = part->bounds[0], xmax = part->bounds[1];
-      float ymin = part->bounds[2], ymax = part->bounds[3];
-      float zmin = part->bounds[4], zmax = part->bounds[5];
-
-      float corners[8][3] = {
-        { xmin, ymin, zmin },
-        { xmin, ymin, zmax },
-        { xmin, ymax, zmin },
-        { xmin, ymax, zmax },
-        { xmax, ymin, zmin },
-        { xmax, ymin, zmax },
-        { xmax, ymax, zmin },
-        { xmax, ymax, zmax }
-      };
-
-      for (uint32_t j = 0; j < 8; j++) {
-        mat4_mulPoint(m, corners[j]);
-        vec3_init(points + 3 * (*pointIndex)++, corners[j]);
-      }
-    }
-  }
-
-  for (uint32_t i = node->child; i != ~0u; i = model->nodes[i].sibling) {
-    gatherBoundingBoxCorners(model, i, pointIndex, points, m);
-  }
-}
-
-static void computeBoundingSphere(float* points, uint32_t pointCount, size_t stride, float sphere[4]) {
-
-  // Find point furthest away from first point
-
-  float max = 0.f;
-  float* a = NULL;
-  for (uint32_t i = 1; i < pointCount; i++) {
-    float d2 = vec3_distance2(&points[i * stride], &points[0]);
-    if (d2 > max) {
-      a = &points[i * stride];
-      max = d2;
-    }
-  }
-
-  // Find point furthest away from that point
-
-  max = 0.f;
-  float* b = NULL;
-  for (uint32_t i = 0; i < pointCount; i++) {
-    float d2 = vec3_distance2(&points[i * stride], a);
-    if (d2 > max) {
-      b = &points[i * stride];
-      max = d2;
-    }
-  }
-
-  // Create and refine sphere
-
-  float dx = a[0] - b[0];
-  float dy = a[1] - b[1];
-  float dz = a[2] - b[2];
-  float cx = (a[0] + b[0]) / 2.f;
-  float cy = (a[1] + b[1]) / 2.f;
-  float cz = (a[2] + b[2]) / 2.f;
-  float r2 = (dx * dx + dy * dy + dz * dz) / 4.f; // Initial radius is half the distance between points
-
-  for (uint32_t i = 0; i < pointCount; i++) {
-    float dx = points[i * stride + 0] - cx;
-    float dy = points[i * stride + 1] - cy;
-    float dz = points[i * stride + 2] - cz;
-    float d2 = dx * dx + dy * dy + dz * dz;
-    if (d2 > r2) {
-      r2 = d2; // beep boop
-    }
-  }
-
-  sphere[0] = cx;
-  sphere[1] = cy;
-  sphere[2] = cz;
-  sphere[3] = sqrtf(r2);
-}
-
-void lovrModelDataGetBoundingSphere(ModelData* model, float sphere[4]) {
-  if (model->boundingSphere[3] == 0.f) {
-    uint32_t totalPartCount = 0;
-
-    for (uint32_t i = 0; i < model->nodeCount; i++) {
-      if (model->nodes[i].mesh != ~0u) {
-        totalPartCount += model->meshes[model->nodes[i].mesh].partCount;
-      }
-    }
-
-    uint32_t pointCount = totalPartCount * 8;
-    float* points = lovrMalloc(pointCount * 3 * sizeof(float));
-
-    uint32_t pointIndex = 0;
-    gatherBoundingBoxCorners(model, model->rootNode, &pointIndex, points, (float[16]) MAT4_IDENTITY);
-    computeBoundingSphere(points, pointCount, 3, model->boundingSphere);
-    lovrFree(points);
-  }
-
-  memcpy(sphere, model->boundingSphere, sizeof(model->boundingSphere));
-}
-
-void lovrModelDataGetMeshBoundingSphere(ModelData* model, uint32_t index, uint32_t part, float sphere[4]) {
-  ModelMesh* mesh = &model->meshes[index];
-  uint32_t nextVertexOffset = part == mesh->partCount - 1 ? mesh->vertexOffset + mesh->vertexCount : mesh->parts[part + 1].baseVertex;
-  uint32_t start = part == ~0u ? mesh->vertexOffset : mesh->parts[part].baseVertex;
-  uint32_t count = part == ~0u ? mesh->vertexCount : nextVertexOffset - start;
-  float* vertex = &model->vertices[start].position.x;
-  computeBoundingSphere(vertex, count, sizeof(ModelVertex) / sizeof(float), sphere);
-}
-
-static void countVertices(ModelData* model, uint32_t nodeIndex, uint32_t* vertexCount, uint32_t* indexCount) {
-  ModelNode* node = &model->nodes[nodeIndex];
-
-  if (node->mesh != ~0u) {
-    ModelMesh* mesh = &model->meshes[node->mesh];
-    ModelPart* part = mesh->parts;
-
-    model->triangleVertexCount += mesh->vertexCount;
-
-    for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
-      if (part->mode == DRAW_TRIANGLE_LIST) {
-        model->triangleIndexCount += part->count;
-      }
-    }
-  }
-
-  for (uint32_t i = node->child; i != ~0u; i = model->nodes[i].sibling) {
-    countVertices(model, i, vertexCount, indexCount);
-  }
-}
-
-static void collectVertices(ModelData* model, uint32_t nodeIndex, float** vertices, uint32_t** indices, uint32_t* baseIndex, float* parentTransform) {
-  ModelNode* node = &model->nodes[nodeIndex];
-
-  float m[16];
-  mat4_init(m, parentTransform);
-
-  if (node->hasMatrix) {
-    mat4_mul(m, node->transform.matrix);
-  } else {
-    float* T = node->transform.translation;
-    float* R = node->transform.rotation;
-    float* S = node->transform.scale;
-    mat4_translate(m, T[0], T[1], T[2]);
-    mat4_rotateQuat(m, R);
-    mat4_scale(m, S[0], S[1], S[2]);
-  }
-
-  if (node->mesh != ~0u) {
-    ModelMesh* mesh = &model->meshes[node->mesh];
-    ModelVertex* vertex = model->vertices + mesh->vertexOffset;
-    ModelPart* part = mesh->parts;
-
-    for (uint32_t i = 0; i < mesh->vertexCount; i++, vertex++) {
-      float v[3] = { vertex->position.x, vertex->position.y, vertex->position.z };
-      vec3_init(*vertices, mat4_mulPoint(m, v));
-      *vertices += 3;
-    }
-
-    for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
-      if (part->mode != DRAW_TRIANGLE_LIST) {
-        continue;
-      }
-
-      if (mesh->indexCount > 0) {
-        if (model->indexSize == 4) {
-          uint32_t* indexData = (uint32_t*) model->indices + part->start;
-          for (uint32_t j = 0; j < part->count; j++) {
-            **indices = indexData[j] + *baseIndex;
-            *indices += 1;
-          }
-        } else if (model->indexSize == 2) {
-          uint16_t* indexData = (uint16_t*) model->indices + part->start;
-          for (uint32_t j = 0; j < part->count; j++) {
-            **indices = (uint32_t) indexData[j] + *baseIndex;
-            *indices += 1;
-          }
-        } else {
-          lovrUnreachable();
-        }
-      } else {
-        for (uint32_t j = 0; j < part->count; j++) {
-          **indices = *baseIndex + j;
-          *indices += 1;
-        }
-      }
-    }
-
-    *baseIndex += mesh->vertexCount;
-  }
-
-  for (uint32_t i = node->child; i != ~0u; i = model->nodes[i].sibling) {
-    collectVertices(model, i, vertices, indices, baseIndex, m);
-  }
-}
-
-void lovrModelDataGetTriangles(ModelData* model, float** vertices, uint32_t** indices, uint32_t* vertexCount, uint32_t* indexCount) {
-  if (model->triangleVertexCount == 0) {
-    countVertices(model, model->rootNode, vertexCount, indexCount);
-  }
-
-  if (vertices && !model->triangleVertices) {
-    uint32_t* tempIndices;
-    uint32_t baseIndex = 0;
-    model->triangleVertices = lovrMalloc(model->triangleVertexCount * 3 * sizeof(float));
-    model->triangleIndices = lovrMalloc(model->triangleIndexCount * sizeof(uint32_t));
-    *vertices = model->triangleVertices;
-    tempIndices = model->triangleIndices;
-    collectVertices(model, model->rootNode, vertices, &tempIndices, &baseIndex, (float[16]) MAT4_IDENTITY);
-  }
-
-  if (vertexCount) *vertexCount = model->triangleVertexCount;
-  if (indexCount) *indexCount = model->triangleIndexCount;
-
-  if (vertices) *vertices = model->triangleVertices;
-  if (indices) *indices = model->triangleIndices;
-}
-
-uint32_t lovrModelDataNextNodeWithMesh(ModelData* model, uint32_t node) {
-  while (++node < model->nodeCount) {
-    if (model->nodes[node].mesh != ~0u) {
+uint32_t lovrModelMetadataNextNodeWithMesh(ModelMetadata* meta, uint32_t node) {
+  while (++node < meta->nodeCount) {
+    if (meta->nodes[node].mesh != ~0u) {
       return node;
     }
   }

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -103,7 +103,7 @@ void lovrModelDataAllocate(ModelData* model) {
   model->indices = meta->indexCount > 0 ? lovrMalloc(meta->indexCount * meta->indexSize) : NULL;
   model->skinData = meta->skinnedVertexCount > 0 ? lovrMalloc(meta->skinnedVertexCount * sizeof(SkinData)) : NULL;
   model->blendData = meta->blendedVertexCount > 0 ? lovrMalloc(meta->blendedVertexCount * sizeof(BlendData)) : NULL;
-  model->images = meta->imageCount > 0 ? lovrMalloc(meta->imageCount * sizeof(Image*)) : NULL;
+  model->images = meta->imageCount > 0 ? lovrCalloc(meta->imageCount * sizeof(Image*)) : NULL;
 
   for (uint32_t i = 0; i < meta->meshCount; i++) {
     meta->meshes[i].vertexOffset = ~0u;

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -6,17 +6,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-static size_t typeSizes[] = {
-  [I8] = 1,
-  [U8] = 1,
-  [I16] = 2,
-  [U16] = 2,
-  [I32] = 4,
-  [U32] = 4,
-  [F32] = 4,
-  [SN10x3] = 4
-};
-
 static void* nullIO(const char* path, size_t* count) {
   return NULL;
 }
@@ -34,19 +23,11 @@ ModelData* lovrModelDataCreate(Blob* source, ModelDataIO* io) {
     return NULL;
   }
 
-  if (!lovrModelDataFinalize(model)) {
-    lovrModelDataDestroy(model);
-    return NULL;
-  }
-
   return model;
 }
 
 void lovrModelDataDestroy(void* ref) {
   ModelData* model = ref;
-  for (uint32_t i = 0; model->blobs && i < model->blobCount; i++) {
-    lovrRelease(model->blobs[i], lovrBlobDestroy);
-  }
   for (uint32_t i = 0; model->images && i < model->imageCount; i++) {
     lovrRelease(model->images[i], lovrImageDestroy);
   }
@@ -54,8 +35,12 @@ void lovrModelDataDestroy(void* ref) {
   map_free(model->animationMap);
   map_free(model->materialMap);
   map_free(model->nodeMap);
+  lovrFree(model->triangleVertices);
+  lovrFree(model->triangleIndices);
   lovrFree(model->vertices);
   lovrFree(model->indices);
+  lovrFree(model->skinData);
+  lovrFree(model->blendData);
   lovrFree(model->metadata);
   lovrFree(model->data);
   lovrFree(model);
@@ -64,224 +49,110 @@ void lovrModelDataDestroy(void* ref) {
 // Batches allocations for all the ModelData arrays
 void lovrModelDataAllocate(ModelData* model) {
   size_t totalSize = 0;
-  size_t sizes[19];
+  size_t sizes[16];
   size_t alignment = 8;
-  totalSize += sizes[0] = ALIGN(model->blobCount * sizeof(Blob*), alignment);
-  totalSize += sizes[1] = ALIGN(model->bufferCount * sizeof(ModelBuffer), alignment);
-  totalSize += sizes[2] = ALIGN(model->imageCount * sizeof(Image*), alignment);
-  totalSize += sizes[3] = ALIGN(model->attributeCount * sizeof(ModelAttribute), alignment);
-  totalSize += sizes[4] = ALIGN(model->primitiveCount * sizeof(ModelPrimitive), alignment);
-  totalSize += sizes[5] = ALIGN(model->materialCount * sizeof(ModelMaterial), alignment);
-  totalSize += sizes[6] = ALIGN(model->blendShapeCount * sizeof(ModelBlendShape), alignment);
-  totalSize += sizes[7] = ALIGN(model->animationCount * sizeof(ModelAnimation), alignment);
-  totalSize += sizes[8] = ALIGN(model->skinCount * sizeof(ModelSkin), alignment);
-  totalSize += sizes[9] = ALIGN(model->nodeCount * sizeof(ModelNode), alignment);
-  totalSize += sizes[10] = ALIGN(model->channelCount * sizeof(ModelAnimationChannel), alignment);
-  totalSize += sizes[11] = ALIGN(model->blendDataCount * sizeof(ModelBlendData), alignment);
-  totalSize += sizes[12] = ALIGN(model->jointCount * sizeof(uint32_t), alignment);
-  totalSize += sizes[13] = ALIGN(model->charCount * sizeof(char), alignment);
+  totalSize += sizes[0] = ALIGN(model->imageCount * sizeof(Image*), alignment);
+  totalSize += sizes[1] = ALIGN(model->meshCount * sizeof(ModelMesh), alignment);
+  totalSize += sizes[2] = ALIGN(model->materialCount * sizeof(ModelMaterial), alignment);
+  totalSize += sizes[3] = ALIGN(model->blendShapeCount * sizeof(ModelBlendShape), alignment);
+  totalSize += sizes[4] = ALIGN(model->animationCount * sizeof(ModelAnimation), alignment);
+  totalSize += sizes[5] = ALIGN(model->skinCount * sizeof(ModelSkin), alignment);
+  totalSize += sizes[6] = ALIGN(model->nodeCount * sizeof(ModelNode), alignment);
+  totalSize += sizes[7] = ALIGN(model->primitiveCount * sizeof(ModelPrimitive), alignment);
+  totalSize += sizes[8] = ALIGN(model->channelCount * sizeof(ModelAnimationChannel), alignment);
+  totalSize += sizes[9] = ALIGN(model->jointCount * 16 * sizeof(float), alignment);
+  totalSize += sizes[10] = ALIGN(model->jointCount * sizeof(uint32_t), alignment);
+  totalSize += sizes[11] = ALIGN(model->charCount * sizeof(char), alignment);
+  totalSize += sizes[12] = ALIGN(sizeof(map_t), alignment);
+  totalSize += sizes[13] = ALIGN(sizeof(map_t), alignment);
   totalSize += sizes[14] = ALIGN(sizeof(map_t), alignment);
   totalSize += sizes[15] = ALIGN(sizeof(map_t), alignment);
-  totalSize += sizes[16] = ALIGN(sizeof(map_t), alignment);
-  totalSize += sizes[17] = ALIGN(sizeof(map_t), alignment);
 
   size_t offset = 0;
   char* p = model->data = lovrCalloc(totalSize);
-  model->blobs = (Blob**) (p + offset), offset += sizes[0];
-  model->buffers = (ModelBuffer*) (p + offset), offset += sizes[1];
-  model->images = (Image**) (p + offset), offset += sizes[2];
-  model->attributes = (ModelAttribute*) (p + offset), offset += sizes[3];
-  model->primitives = (ModelPrimitive*) (p + offset), offset += sizes[4];
-  model->materials = (ModelMaterial*) (p + offset), offset += sizes[5];
-  model->blendShapes = (ModelBlendShape*) (p + offset), offset += sizes[6];
-  model->animations = (ModelAnimation*) (p + offset), offset += sizes[7];
-  model->skins = (ModelSkin*) (p + offset), offset += sizes[8];
-  model->nodes = (ModelNode*) (p + offset), offset += sizes[9];
-  model->channels = (ModelAnimationChannel*) (p + offset), offset += sizes[10];
-  model->blendData = (ModelBlendData*) (p + offset), offset += sizes[11];
-  model->joints = (uint32_t*) (p + offset), offset += sizes[12];
-  model->chars = (char*) (p + offset), offset += sizes[13];
-  model->blendShapeMap = (map_t*) (p + offset), offset += sizes[14];
-  model->animationMap = (map_t*) (p + offset), offset += sizes[15];
-  model->materialMap = (map_t*) (p + offset), offset += sizes[16];
-  model->nodeMap = (map_t*) (p + offset), offset += sizes[17];
+  model->images = (Image**) (p + offset), offset += sizes[0];
+  model->meshes = (ModelMesh*) (p + offset), offset += sizes[1];
+  model->materials = (ModelMaterial*) (p + offset), offset += sizes[2];
+  model->blendShapes = (ModelBlendShape*) (p + offset), offset += sizes[3];
+  model->animations = (ModelAnimation*) (p + offset), offset += sizes[4];
+  model->skins = (ModelSkin*) (p + offset), offset += sizes[5];
+  model->nodes = (ModelNode*) (p + offset), offset += sizes[6];
+  model->primitives = (ModelPrimitive*) (p + offset), offset += sizes[7];
+  model->channels = (ModelAnimationChannel*) (p + offset), offset += sizes[8];
+  model->inverseBindMatrices = (float*) (p + offset), offset += sizes[9];
+  model->joints = (uint32_t*) (p + offset), offset += sizes[10];
+  model->chars = (char*) (p + offset), offset += sizes[11];
+  model->blendShapeMap = (map_t*) (p + offset), offset += sizes[12];
+  model->animationMap = (map_t*) (p + offset), offset += sizes[13];
+  model->materialMap = (map_t*) (p + offset), offset += sizes[14];
+  model->nodeMap = (map_t*) (p + offset), offset += sizes[15];
+
+  model->vertices = model->vertexCount > 0 ? lovrMalloc(model->vertexCount * sizeof(ModelVertex)) : NULL;
+  model->indices = model->indexCount > 0 ? lovrMalloc(model->indexCount * model->indexSize) : NULL;
+  model->skinData = model->skinnedVertexCount > 0 ? lovrMalloc(model->skinnedVertexCount * sizeof(SkinData)) : NULL;
+  model->blendData = model->blendedVertexCount > 0 ? lovrMalloc(model->blendedVertexCount * sizeof(BlendData)) : NULL;
 
   map_init(model->blendShapeMap, model->blendShapeCount);
   map_init(model->animationMap, model->animationCount);
   map_init(model->materialMap, model->materialCount);
   map_init(model->nodeMap, model->nodeCount);
-}
 
-bool lovrModelDataFinalize(ModelData* model) {
   for (uint32_t i = 0; i < model->primitiveCount; i++) {
-    model->primitives[i].skin = ~0u;
+    model->primitives[i].mode = DRAW_TRIANGLE_LIST;
+    model->primitives[i].material = ~0u;
+  }
+
+  for (uint32_t i = 0; i < model->materialCount; i++) {
+    model->materials[i] = (ModelMaterial) {
+      .color = { 1.f, 1.f, 1.f, 1.f },
+      .glow = { 0.f, 0.f, 0.f, 1.f },
+      .uvShift = { 0.f, 0.f },
+      .uvScale = { 1.f, 1.f },
+      .metalness = 1.f,
+      .roughness = 1.f,
+      .clearcoat = 0.f,
+      .clearcoatRoughness = 0.f,
+      .occlusionStrength = 1.f,
+      .normalScale = 1.f,
+      .alphaCutoff = 0.f,
+      .texture = ~0u,
+      .glowTexture = ~0u,
+      .metalnessTexture = ~0u,
+      .roughnessTexture = ~0u,
+      .clearcoatTexture = ~0u,
+      .occlusionTexture = ~0u,
+      .normalTexture = ~0u
+    };
   }
 
   for (uint32_t i = 0; i < model->nodeCount; i++) {
-    ModelNode* node = &model->nodes[i];
-
-    if (node->primitiveCount > 0) {
-      for (uint32_t j = 0; j < model->nodeCount; j++) {
-        if (i == j || model->nodes[j].primitiveCount == 0 || node->primitiveIndex != model->nodes[j].primitiveIndex) continue;
-        lovrCheck(node->skin == model->nodes[j].skin, "Model has a mesh used with multiple different skins, which is not supported");
-      }
-    }
-
-    for (uint32_t j = node->primitiveIndex; j < node->primitiveIndex + node->primitiveCount; j++) {
-      model->primitives[j].skin = node->skin;
-    }
+    vec3_set(model->nodes[i].transform.translation, 0.f, 0.f, 0.f);
+    quat_identity(model->nodes[i].transform.rotation);
+    vec3_set(model->nodes[i].transform.scale, 1.f, 1.f, 1.f);
+    model->nodes[i].hasMatrix = false;
+    model->nodes[i].child = ~0u;
+    model->nodes[i].sibling = ~0u;
+    model->nodes[i].parent = ~0u;
+    model->nodes[i].mesh = ~0u;
+    model->nodes[i].skin = ~0u;
   }
-
-  size_t maxIndexSize = 0;
-
-  for (uint32_t i = 0; i < model->primitiveCount; i++) {
-    ModelPrimitive* primitive = &model->primitives[i];
-    uint32_t vertexCount = primitive->attributes[ATTR_POSITION]->count;
-
-    if (primitive->skin != ~0u) {
-      model->skins[primitive->skin].vertexCount += vertexCount;
-      model->skins[primitive->skin].blendedVertexCount += primitive->blendShapeCount > 0 ? vertexCount : 0;
-      model->skinnedVertexCount += vertexCount;
-    }
-
-    model->blendShapeVertexCount += vertexCount * primitive->blendShapeCount;
-    model->dynamicVertexCount += primitive->skin != ~0u || !!primitive->blendShapes ? vertexCount : 0;
-    model->vertexCount += vertexCount;
-
-    model->indexCount += primitive->indices ? primitive->indices->count : 0;
-    if (primitive->indices) {
-      size_t indexSize = typeSizes[primitive->indices->type];
-      maxIndexSize = MAX(maxIndexSize, indexSize);
-      primitive->indices->stride = indexSize;
-    }
-
-    for (uint32_t j = 0; j < MAX_DEFAULT_ATTRIBUTES; j++) {
-      ModelAttribute* attribute = primitive->attributes[j];
-      if (!attribute) continue;
-      attribute->stride = model->buffers[attribute->buffer].stride;
-      if (attribute->stride == 0) attribute->stride = typeSizes[attribute->type] * attribute->components;
-    }
-
-    for (uint32_t j = 0; j < primitive->blendShapeCount; j++) {
-      ModelBlendData* blendData = &primitive->blendShapes[j];
-      ModelAttribute* attributes[] = { blendData->positions, blendData->normals, blendData->tangents };
-      for (uint32_t k = 0; k < COUNTOF(attributes); k++) {
-        if (!attributes[k]) continue;
-        ModelAttribute* attribute = attributes[k];
-        attribute->stride = model->buffers[attribute->buffer].stride;
-        if (attribute->stride == 0) attribute->stride = typeSizes[attribute->type] * attribute->components;
-      }
-    }
-  }
-
-  model->indexType = maxIndexSize >= 4 ? U32 : U16;
-
-  return true;
 }
 
-void lovrModelDataCopyAttribute(ModelData* data, ModelAttribute* attribute, char* dst, AttributeType type, uint32_t components, bool normalized, uint32_t count, size_t stride, uint8_t clear) {
-  char* src = attribute ? data->buffers[attribute->buffer].data + attribute->offset : NULL;
-  size_t size = components * typeSizes[type];
-
-  if (!attribute) {
-    for (uint32_t i = 0; i < count; i++, dst += stride) {
-      memset(dst, clear, size);
+bool lovrModelDataFinalize(ModelData* model) {
+  for (uint32_t i = 0; i < model->meshCount; i++) {
+    uint32_t skin = ~0u;
+    for (uint32_t j = 0; j < model->nodeCount; j++) {
+      if (model->nodes[j].mesh == i) {
+        if (skin == ~0u) {
+          skin = model->nodes[j].skin;
+        } else {
+          lovrAssert(model->nodes[j].skin == skin, "Model has mesh used with multiple different skins, which is not currently supported");
+        }
+      }
     }
-  } else if (attribute->type == type && attribute->components == components && attribute->normalized == normalized && attribute->stride == stride && stride == size) {
-    memcpy(dst, src, count * stride);
-  } else if (attribute->type == type && attribute->components >= components) {
-    for (uint32_t i = 0; i < count; i++, src += attribute->stride, dst += stride) {
-      memcpy(dst, src, size);
-    }
-  } else if (type == F32) {
-    if (attribute->type == U8 && attribute->normalized) {
-      for (uint32_t i = 0; i < count; i++, src += attribute->stride, dst += stride) {
-        for (uint32_t j = 0; j < components; j++) {
-          ((float*) dst)[j] = ((uint8_t*) src)[j] / 255.f;
-        }
-      }
-    } else if (attribute->type == U16 && attribute->normalized) {
-      for (uint32_t i = 0; i < count; i++, src += attribute->stride, dst += stride) {
-        for (uint32_t j = 0; j < components; j++) {
-          ((float*) dst)[j] = ((uint16_t*) src)[j] / 65535.f;
-        }
-      }
-    } else {
-      lovrUnreachable();
-    }
-  } else if (type == U8) {
-    if (attribute->type == U16 && attribute->normalized && normalized) {
-      for (uint32_t i = 0; i < count; i++, src += attribute->stride, dst += stride) {
-        for (uint32_t j = 0; j < components; j++) {
-          ((uint8_t*) dst)[j] = ((uint16_t*) src)[j] >> 8;
-        }
-        if (components == 4 && attribute->components == 3) {
-          ((uint8_t*) dst)[3] = 255;
-        }
-      }
-    } else if (attribute->type == U16 && !attribute->normalized && !normalized) {
-      for (uint32_t i = 0; i < count; i++, src += attribute->stride, dst += stride) {
-        for (uint32_t j = 0; j < components; j++) {
-          ((uint8_t*) dst)[j] = (uint8_t) ((uint16_t*) src)[j];
-        }
-      }
-    } else if (attribute->type == I16 && !attribute->normalized && !normalized) {
-      for (uint32_t i = 0; i < count; i++, src += attribute->stride, dst += stride) {
-        for (uint32_t j = 0; j < components; j++) {
-          ((uint8_t*) dst)[j] = (uint8_t) ((int16_t*) src)[j];
-        }
-      }
-    } else if (attribute->type == F32 && normalized) {
-      for (uint32_t i = 0; i < count; i++, src += attribute->stride, dst += stride) {
-        for (uint32_t j = 0; j < components; j++) {
-          ((uint8_t*) dst)[j] = ((float*) src)[j] * 255.f + .5f;
-        }
-        if (components == 4 && attribute->components == 3) {
-          ((uint8_t*) dst)[3] = 255;
-        }
-      }
-    } else {
-      lovrUnreachable();
-    }
-  } else if (type == U16 && components == 1 && !normalized && !attribute->normalized) {
-    if (attribute->type == U8) {
-      for (uint32_t i = 0; i < count; i++, src += attribute->stride, dst += stride) {
-        *((uint16_t*) dst) = *(uint8_t*) src;
-      }
-    } else {
-      lovrUnreachable();
-    }
-  } else if (type == U32 && components == 1 && !normalized && !attribute->normalized) {
-    if (attribute->type == U8) {
-      for (uint32_t i = 0; i < count; i++, src += attribute->stride, dst += stride) {
-        *((uint32_t*) dst) = *(uint8_t*) src;
-      }
-    } else if (attribute->type == U16) {
-      for (uint32_t i = 0; i < count; i++, src += attribute->stride, dst += stride) {
-        *((uint32_t*) dst) = *(uint16_t*) src;
-      }
-    } else {
-      lovrUnreachable();
-    }
-  } else if (type == SN10x3) {
-    if (attribute->type == F32) {
-      for (uint32_t i = 0; i < count; i++, src += attribute->stride, dst += stride) {
-        float x = ((float*) src)[0];
-        float y = ((float*) src)[1];
-        float z = ((float*) src)[2];
-        float w = attribute->components == 4 ? ((float*) src)[3] : 0.f;
-        *(uint32_t*) dst =
-          ((((uint32_t) (int32_t) (x * 511.f)) & 0x3ff) <<  0) |
-          ((((uint32_t) (int32_t) (y * 511.f)) & 0x3ff) << 10) |
-          ((((uint32_t) (int32_t) (z * 511.f)) & 0x3ff) << 20) |
-          ((((uint32_t) (int32_t) (w * 2.f)) & 0x003) << 30);
-      }
-    } else {
-      lovrUnreachable();
-    }
-  } else {
-    lovrUnreachable();
   }
+
+  return true;
 }
 
 static void boundingBoxHelper(ModelData* model, uint32_t nodeIndex, float* parentTransform) {
@@ -296,45 +167,48 @@ static void boundingBoxHelper(ModelData* model, uint32_t nodeIndex, float* paren
     float* T = node->transform.translation;
     float* R = node->transform.rotation;
     float* S = node->transform.scale;
-    mat4_translate(m, T[0], T[1], T[2]);
-    mat4_rotateQuat(m, R);
+    mat4_fromPose(m, T, R);
     mat4_scale(m, S[0], S[1], S[2]);
   }
 
-  for (uint32_t i = 0; i < node->primitiveCount; i++) {
-    ModelAttribute* position = model->primitives[node->primitiveIndex + i].attributes[ATTR_POSITION];
+  if (node->mesh != ~0u) {
+    ModelMesh* mesh = &model->meshes[node->mesh];
 
-    if (!position || !position->hasMin || !position->hasMax) {
-      continue;
+    for (uint32_t i = 0; i < mesh->primitiveCount; i++) {
+      ModelPrimitive* primitive = &mesh->primitives[i];
+
+      float xmin = primitive->bounds[0], xmax = primitive->bounds[1];
+      float ymin = primitive->bounds[2], ymax = primitive->bounds[3];
+      float zmin = primitive->bounds[4], zmax = primitive->bounds[5];
+
+      float xa[3] = { xmin * m[0], xmin * m[1], xmin * m[2] };
+      float xb[3] = { xmax * m[0], xmax * m[1], xmax * m[2] };
+
+      float ya[3] = { ymin * m[4], ymin * m[5], ymin * m[6] };
+      float yb[3] = { ymax * m[4], ymax * m[5], ymax * m[6] };
+
+      float za[3] = { zmin * m[8], zmin * m[9], zmin * m[10] };
+      float zb[3] = { zmax * m[8], zmax * m[9], zmax * m[10] };
+
+      float min[3] = {
+        MIN(xa[0], xb[0]) + MIN(ya[0], yb[0]) + MIN(za[0], zb[0]) + m[12],
+        MIN(xa[1], xb[1]) + MIN(ya[1], yb[1]) + MIN(za[1], zb[1]) + m[13],
+        MIN(xa[2], xb[2]) + MIN(ya[2], yb[2]) + MIN(za[2], zb[2]) + m[14]
+      };
+
+      float max[3] = {
+        MAX(xa[0], xb[0]) + MAX(ya[0], yb[0]) + MAX(za[0], zb[0]) + m[12],
+        MAX(xa[1], xb[1]) + MAX(ya[1], yb[1]) + MAX(za[1], zb[1]) + m[13],
+        MAX(xa[2], xb[2]) + MAX(ya[2], yb[2]) + MAX(za[2], zb[2]) + m[14]
+      };
+
+      model->boundingBox[0] = MIN(model->boundingBox[0], min[0]);
+      model->boundingBox[1] = MAX(model->boundingBox[1], max[0]);
+      model->boundingBox[2] = MIN(model->boundingBox[2], min[1]);
+      model->boundingBox[3] = MAX(model->boundingBox[3], max[1]);
+      model->boundingBox[4] = MIN(model->boundingBox[4], min[2]);
+      model->boundingBox[5] = MAX(model->boundingBox[5], max[2]);
     }
-
-    float xa[3] = { position->min[0] * m[0], position->min[0] * m[1], position->min[0] * m[2] };
-    float xb[3] = { position->max[0] * m[0], position->max[0] * m[1], position->max[0] * m[2] };
-
-    float ya[3] = { position->min[1] * m[4], position->min[1] * m[5], position->min[1] * m[6] };
-    float yb[3] = { position->max[1] * m[4], position->max[1] * m[5], position->max[1] * m[6] };
-
-    float za[3] = { position->min[2] * m[8], position->min[2] * m[9], position->min[2] * m[10] };
-    float zb[3] = { position->max[2] * m[8], position->max[2] * m[9], position->max[2] * m[10] };
-
-    float min[3] = {
-      MIN(xa[0], xb[0]) + MIN(ya[0], yb[0]) + MIN(za[0], zb[0]) + m[12],
-      MIN(xa[1], xb[1]) + MIN(ya[1], yb[1]) + MIN(za[1], zb[1]) + m[13],
-      MIN(xa[2], xb[2]) + MIN(ya[2], yb[2]) + MIN(za[2], zb[2]) + m[14]
-    };
-
-    float max[3] = {
-      MAX(xa[0], xb[0]) + MAX(ya[0], yb[0]) + MAX(za[0], zb[0]) + m[12],
-      MAX(xa[1], xb[1]) + MAX(ya[1], yb[1]) + MAX(za[1], zb[1]) + m[13],
-      MAX(xa[2], xb[2]) + MAX(ya[2], yb[2]) + MAX(za[2], zb[2]) + m[14]
-    };
-
-    model->boundingBox[0] = MIN(model->boundingBox[0], min[0]);
-    model->boundingBox[1] = MAX(model->boundingBox[1], max[0]);
-    model->boundingBox[2] = MIN(model->boundingBox[2], min[1]);
-    model->boundingBox[3] = MAX(model->boundingBox[3], max[1]);
-    model->boundingBox[4] = MIN(model->boundingBox[4], min[2]);
-    model->boundingBox[5] = MAX(model->boundingBox[5], max[2]);
   }
 
   for (uint32_t i = node->child; i != ~0u; i = model->nodes[i].sibling) {
@@ -367,30 +241,31 @@ static void boundingSphereHelper(ModelData* model, uint32_t nodeIndex, uint32_t*
     mat4_scale(m, S[0], S[1], S[2]);
   }
 
-  for (uint32_t i = 0; i < node->primitiveCount; i++) {
-    ModelAttribute* position = model->primitives[node->primitiveIndex + i].attributes[ATTR_POSITION];
+  if (node->mesh != ~0u) {
+    ModelMesh* mesh = &model->meshes[node->mesh];
 
-    if (!position || !position->hasMin || !position->hasMax) {
-      continue;
-    }
+    for (uint32_t i = 0; i < mesh->primitiveCount; i++) {
+      ModelPrimitive* primitive = &mesh->primitives[i];
 
-    float* min = position->min;
-    float* max = position->max;
+      float xmin = primitive->bounds[0], xmax = primitive->bounds[1];
+      float ymin = primitive->bounds[2], ymax = primitive->bounds[3];
+      float zmin = primitive->bounds[4], zmax = primitive->bounds[5];
 
-    float corners[8][3] = {
-      { min[0], min[1], min[2] },
-      { min[0], min[1], max[2] },
-      { min[0], max[1], min[2] },
-      { min[0], max[1], max[2] },
-      { max[0], min[1], min[2] },
-      { max[0], min[1], max[2] },
-      { max[0], max[1], min[2] },
-      { max[0], max[1], max[2] }
-    };
+      float corners[8][3] = {
+        { xmin, ymin, zmin },
+        { xmin, ymin, zmax },
+        { xmin, ymax, zmin },
+        { xmin, ymax, zmax },
+        { xmax, ymin, zmin },
+        { xmax, ymin, zmax },
+        { xmax, ymax, zmin },
+        { xmax, ymax, zmax }
+      };
 
-    for (uint32_t j = 0; j < 8; j++) {
-      mat4_mulPoint(m, corners[j]);
-      vec3_init(points + 3 * (*pointIndex)++, corners[j]);
+      for (uint32_t j = 0; j < 8; j++) {
+        mat4_mulPoint(m, corners[j]);
+        vec3_init(points + 3 * (*pointIndex)++, corners[j]);
+      }
     }
   }
 
@@ -404,7 +279,9 @@ void lovrModelDataGetBoundingSphere(ModelData* model, float sphere[4]) {
     uint32_t totalPrimitiveCount = 0;
 
     for (uint32_t i = 0; i < model->nodeCount; i++) {
-      totalPrimitiveCount += model->nodes[i].primitiveCount;
+      if (model->nodes[i].mesh != ~0u) {
+        totalPrimitiveCount += model->meshes[model->nodes[i].mesh].primitiveCount;
+      }
     }
 
     uint32_t pointCount = totalPrimitiveCount * 8;
@@ -472,23 +349,18 @@ void lovrModelDataGetBoundingSphere(ModelData* model, float sphere[4]) {
 static void countVertices(ModelData* model, uint32_t nodeIndex, uint32_t* vertexCount, uint32_t* indexCount) {
   ModelNode* node = &model->nodes[nodeIndex];
 
-  for (uint32_t i = 0; i < node->primitiveCount; i++) {
-    ModelPrimitive* primitive = &model->primitives[node->primitiveIndex + i];
-    ModelAttribute* positions = primitive->attributes[ATTR_POSITION];
-    if (!positions) continue;
+  if (node->mesh != ~0u) {
+    ModelMesh* mesh = &model->meshes[node->mesh];
+    for (uint32_t i = 0; i < mesh->primitiveCount; i++) {
+      ModelPrimitive* primitive = &mesh->primitives[i];
 
-    // If 2 meshes in the node use the same vertex buffer, don't count the vertices twice
-    for (uint32_t j = 0; j < i; j++) {
-      if (model->primitives[node->primitiveIndex + j].attributes[ATTR_POSITION] == positions) {
-        positions = NULL;
-        break;
+      if (primitive->mode != DRAW_TRIANGLE_LIST) {
+        continue;
       }
-    }
 
-    ModelAttribute* indices = primitive->indices;
-    uint32_t count = positions ? positions->count : 0;
-    *vertexCount += count;
-    *indexCount += indices ? indices->count : count;
+      model->triangleVertexCount += primitive->vertexCount;
+      model->triangleIndexCount += primitive->indexCount > 0 ? primitive->count : primitive->vertexCount;
+    }
   }
 
   for (uint32_t i = node->child; i != ~0u; i = model->nodes[i].sibling) {
@@ -515,68 +387,52 @@ static void collectVertices(ModelData* model, uint32_t nodeIndex, float** vertic
 
   uint32_t nodeBase = *baseIndex;
 
-  for (uint32_t i = 0; i < node->primitiveCount; i++) {
-    ModelPrimitive* primitive = &model->primitives[node->primitiveIndex + i];
-    ModelAttribute* positions = primitive->attributes[ATTR_POSITION];
-    ModelAttribute* index = primitive->indices;
-    if (!positions) continue;
+  if (node->mesh != ~0u) {
+    ModelMesh* mesh = &model->meshes[node->mesh];
+    ModelVertex* vertex = mesh->vertices;
+    void* index = mesh->indices;
 
-    uint32_t base = nodeBase;
+    for (uint32_t i = 0; i < mesh->primitiveCount; i++) {
+      ModelPrimitive* primitive = &mesh->primitives[i];
 
-    // If 2 meshes in the node use the same vertex buffer, don't add the vertices twice
-    for (uint32_t j = 0; j < i; j++) {
-      if (model->primitives[node->primitiveIndex + j].attributes[ATTR_POSITION] == positions) {
-        break;
-      } else {
-        base += model->primitives[node->primitiveIndex + j].attributes[ATTR_POSITION]->count;
-      }
-    }
-
-    if (base == *baseIndex) {
-      char* data = (char*) model->buffers[positions->buffer].data + positions->offset;
-      size_t stride = positions->stride == 0 ? 3 * sizeof(float) : positions->stride;
-
-      for (uint32_t j = 0; j < positions->count; j++) {
-        float v[3];
-        memcpy(v, data, 3 * sizeof(float));
-        mat4_mulPoint(m, v);
-        vec3_init(*vertices, v);
-        *vertices += 3;
-        data += stride;
+      if (primitive->mode != DRAW_TRIANGLE_LIST) {
+        continue;
       }
 
-      *baseIndex += positions->count;
-    }
+      uint32_t base = nodeBase;
 
-    if (indices && index) {
-      char* data = (char*) model->buffers[index->buffer].data + index->offset;
-      size_t stride = index->stride == 0 ? typeSizes[index->type] : index->stride;
+      if (base == *baseIndex) {
+        for (uint32_t j = 0; j < primitive->vertexCount; j++) {
+          float v[3] = { vertex->position.x, vertex->position.y, vertex->position.z };
+          vec3_init(*vertices, mat4_mulPoint(m, v));
+          *vertices += 3;
+          vertex++;
+        }
 
-      if (index->type == U32) {
-        for (uint32_t j = 0; j < index->count; j++) {
-          **indices = *(uint32_t*) data + base;
-          *indices += 1;
-          data += stride;
-        }
-      } else if (index->type == U16) {
-        for (uint32_t j = 0; j < index->count; j++) {
-          **indices = (uint32_t) *(uint16_t*) data + base;
-          *indices += 1;
-          data += stride;
-        }
-      } else if (index->type == U8) {
-        for (uint32_t j = 0; j < index->count; j++) {
-          **indices = (uint32_t) *(uint8_t*) data + base;
-          *indices += 1;
-          data += stride;
+        *baseIndex += primitive->vertexCount;
+      }
+
+      if (primitive->indexCount > 0) {
+        if (model->indexSize == 4) {
+          for (uint32_t j = 0; j < primitive->indexCount; j++) {
+            **indices = *(uint32_t*) index + base;
+            *indices += 1;
+            index = (char*) index + 4;
+          }
+        } else if (model->indexSize == 2) {
+          for (uint32_t j = 0; j < primitive->indexCount; j++) {
+            **indices = (uint32_t) *(uint16_t*) index + base;
+            *indices += 1;
+            index = (char*) index + 2;
+          }
+        } else {
+          lovrUnreachable();
         }
       } else {
-        lovrUnreachable();
-      }
-    } else {
-      for (uint32_t j = 0; j < positions->count; j++) {
-        **indices = j + base;
-        *indices += 1;
+        for (uint32_t j = 0; j < primitive->vertexCount; j++) {
+          **indices = j + base;
+          *indices += 1;
+        }
       }
     }
   }
@@ -587,23 +443,23 @@ static void collectVertices(ModelData* model, uint32_t nodeIndex, float** vertic
 }
 
 void lovrModelDataGetTriangles(ModelData* model, float** vertices, uint32_t** indices, uint32_t* vertexCount, uint32_t* indexCount) {
-  if (model->totalVertexCount == 0) {
-    countVertices(model, model->rootNode, &model->totalVertexCount, &model->totalIndexCount);
+  if (model->triangleVertexCount == 0) {
+    countVertices(model, model->rootNode, vertexCount, indexCount);
   }
 
   if (vertices && !model->vertices) {
     uint32_t* tempIndices;
     uint32_t baseIndex = 0;
-    model->vertices = lovrMalloc(model->totalVertexCount * 3 * sizeof(float));
-    model->indices = lovrMalloc(model->totalIndexCount * sizeof(uint32_t));
-    *vertices = model->vertices;
-    tempIndices = model->indices;
+    model->vertices = lovrMalloc(model->triangleVertexCount * 3 * sizeof(float));
+    model->indices = lovrMalloc(model->triangleIndexCount * sizeof(uint32_t));
+    *vertices = model->triangleVertices;
+    tempIndices = model->triangleIndices;
     collectVertices(model, model->rootNode, vertices, &tempIndices, &baseIndex, (float[16]) MAT4_IDENTITY);
   }
 
-  if (vertexCount) *vertexCount = model->totalVertexCount;
-  if (indexCount) *indexCount = model->totalIndexCount;
+  if (vertexCount) *vertexCount = model->triangleVertexCount;
+  if (indexCount) *indexCount = model->triangleIndexCount;
 
-  if (vertices) *vertices = model->vertices;
-  if (indices) *indices = model->indices;
+  if (vertices) *vertices = model->triangleVertices;
+  if (indices) *indices = model->triangleIndices;
 }

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -308,6 +308,26 @@ void lovrModelDataGetTriangles(ModelData* model, float** vertices, uint32_t** in
   if (indices) *indices = model->triangleIndices;
 }
 
+uint32_t lovrModelMetadataGetTotalVertexCount(ModelMetadata* meta) {
+  uint32_t count = 0;
+  for (uint32_t i = 0; i < meta->nodeCount; i++) {
+    if (meta->nodes[i].mesh != ~0u) {
+      count += meta->meshes[meta->nodes[i].mesh].vertexCount;
+    }
+  }
+  return count;
+}
+
+uint32_t lovrModelMetadataGetTotalIndexCount(ModelMetadata* meta) {
+  uint32_t count = 0;
+  for (uint32_t i = 0; i < meta->nodeCount; i++) {
+    if (meta->nodes[i].mesh != ~0u) {
+      count += meta->meshes[meta->nodes[i].mesh].indexCount;
+    }
+  }
+  return count;
+}
+
 static void boundingBoxHelper(ModelMetadata* meta, uint32_t nodeIndex, float* parentTransform) {
   ModelNode* node = &meta->nodes[nodeIndex];
 

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -24,6 +24,8 @@ ModelData* lovrModelDataCreate(Blob* source, ModelDataIO* io) {
     return NULL;
   }
 
+  lovrModelDataFinalize(model);
+
   return model;
 }
 

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -200,27 +200,6 @@ bool lovrModelDataFinalize(ModelData* model) {
   return true;
 }
 
-static void countVertices(ModelData* model, uint32_t nodeIndex, uint32_t* vertexCount, uint32_t* indexCount) {
-  ModelNode* node = &model->meta.nodes[nodeIndex];
-
-  if (node->mesh != ~0u) {
-    ModelMesh* mesh = &model->meta.meshes[node->mesh];
-    ModelPart* part = mesh->parts;
-
-    model->triangleVertexCount += mesh->vertexCount;
-
-    for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
-      if (part->mode == DRAW_TRIANGLE_LIST) {
-        model->triangleIndexCount += part->count;
-      }
-    }
-  }
-
-  for (uint32_t i = node->child; i != ~0u; i = model->meta.nodes[i].sibling) {
-    countVertices(model, i, vertexCount, indexCount);
-  }
-}
-
 static void collectVertices(ModelData* model, uint32_t nodeIndex, float** vertices, uint32_t** indices, uint32_t* baseIndex, float* parentTransform) {
   ModelNode* node = &model->meta.nodes[nodeIndex];
 
@@ -249,31 +228,33 @@ static void collectVertices(ModelData* model, uint32_t nodeIndex, float** vertic
       *vertices += 3;
     }
 
-    for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
-      if (part->mode != DRAW_TRIANGLE_LIST) {
-        continue;
-      }
+    if (*indices) {
+      for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
+        if (part->mode != DRAW_TRIANGLE_LIST) {
+          continue;
+        }
 
-      if (mesh->indexCount > 0) {
-        if (model->meta.indexSize == 4) {
-          uint32_t* indexData = (uint32_t*) model->indices + part->start;
-          for (uint32_t j = 0; j < part->count; j++) {
-            **indices = indexData[j] + *baseIndex;
-            *indices += 1;
-          }
-        } else if (model->meta.indexSize == 2) {
-          uint16_t* indexData = (uint16_t*) model->indices + part->start;
-          for (uint32_t j = 0; j < part->count; j++) {
-            **indices = (uint32_t) indexData[j] + *baseIndex;
-            *indices += 1;
+        if (mesh->indexCount > 0) {
+          if (model->meta.indexSize == 4) {
+            uint32_t* indexData = (uint32_t*) model->indices + part->start;
+            for (uint32_t j = 0; j < part->count; j++) {
+              **indices = indexData[j] + *baseIndex;
+              *indices += 1;
+            }
+          } else if (model->meta.indexSize == 2) {
+            uint16_t* indexData = (uint16_t*) model->indices + part->start;
+            for (uint32_t j = 0; j < part->count; j++) {
+              **indices = (uint32_t) indexData[j] + *baseIndex;
+              *indices += 1;
+            }
+          } else {
+            lovrUnreachable();
           }
         } else {
-          lovrUnreachable();
-        }
-      } else {
-        for (uint32_t j = 0; j < part->count; j++) {
-          **indices = *baseIndex + j;
-          *indices += 1;
+          for (uint32_t j = 0; j < part->count; j++) {
+            **indices = *baseIndex + j;
+            *indices += 1;
+          }
         }
       }
     }
@@ -287,45 +268,32 @@ static void collectVertices(ModelData* model, uint32_t nodeIndex, float** vertic
 }
 
 void lovrModelDataGetTriangles(ModelData* model, float** vertices, uint32_t** indices, uint32_t* vertexCount, uint32_t* indexCount) {
-  if (model->triangleVertexCount == 0) {
-    countVertices(model, model->meta.rootNode, vertexCount, indexCount);
-  }
+  ModelMetadata* meta = &model->meta;
 
-  if (vertices && !model->triangleVertices) {
-    uint32_t* tempIndices;
-    uint32_t baseIndex = 0;
-    model->triangleVertices = lovrMalloc(model->triangleVertexCount * 3 * sizeof(float));
-    model->triangleIndices = lovrMalloc(model->triangleIndexCount * sizeof(uint32_t));
-    *vertices = model->triangleVertices;
-    tempIndices = model->triangleIndices;
-    collectVertices(model, model->meta.rootNode, vertices, &tempIndices, &baseIndex, (float[16]) MAT4_IDENTITY);
-  }
+  *vertexCount = 0;
+  *indexCount = 0;
 
-  if (vertexCount) *vertexCount = model->triangleVertexCount;
-  if (indexCount) *indexCount = model->triangleIndexCount;
-
-  if (vertices) *vertices = model->triangleVertices;
-  if (indices) *indices = model->triangleIndices;
-}
-
-uint32_t lovrModelMetadataGetTotalVertexCount(ModelMetadata* meta) {
-  uint32_t count = 0;
   for (uint32_t i = 0; i < meta->nodeCount; i++) {
     if (meta->nodes[i].mesh != ~0u) {
-      count += meta->meshes[meta->nodes[i].mesh].vertexCount;
-    }
-  }
-  return count;
-}
+      ModelMesh* mesh = &meta->meshes[meta->nodes[i].mesh];
+      *vertexCount += mesh->vertexCount;
 
-uint32_t lovrModelMetadataGetTotalIndexCount(ModelMetadata* meta) {
-  uint32_t count = 0;
-  for (uint32_t i = 0; i < meta->nodeCount; i++) {
-    if (meta->nodes[i].mesh != ~0u) {
-      count += meta->meshes[meta->nodes[i].mesh].indexCount;
+      for (uint32_t j = 0; j < mesh->partCount; j++) {
+        if (mesh->parts[j].mode == DRAW_TRIANGLE_LIST) {
+          *indexCount += mesh->parts[j].count;
+        }
+      }
     }
   }
-  return count;
+
+  float* positions = lovrMalloc(*vertexCount * 3 * sizeof(float));
+  uint32_t* indexData = indices ? lovrMalloc(*indexCount * sizeof(uint32_t)) : NULL;
+
+  *vertices = positions;
+  if (indices) *indices = indexData;
+
+  uint32_t baseIndex = 0;
+  collectVertices(model, model->meta.rootNode, &positions, &indexData, &baseIndex, (float[16]) MAT4_IDENTITY);
 }
 
 static void boundingBoxHelper(ModelMetadata* meta, uint32_t nodeIndex, float* parentTransform) {

--- a/src/modules/data/modelData.c
+++ b/src/modules/data/modelData.c
@@ -487,3 +487,13 @@ void lovrModelDataGetTriangles(ModelData* model, float** vertices, uint32_t** in
   if (vertices) *vertices = model->triangleVertices;
   if (indices) *indices = model->triangleIndices;
 }
+
+uint32_t lovrModelDataNextNodeWithMesh(ModelData* model, uint32_t node) {
+  while (++node < model->nodeCount) {
+    if (model->nodes[node].mesh != ~0u) {
+      return node;
+    }
+  }
+
+  return ~0u;
+}

--- a/src/modules/data/modelData.h
+++ b/src/modules/data/modelData.h
@@ -37,31 +37,29 @@ typedef enum {
 } ModelDrawMode;
 
 typedef struct {
-  ModelDrawMode mode;
-  uint32_t material;
   uint32_t start;
   uint32_t count;
-  uint32_t vertexCount;
-  uint32_t indexCount;
+  uint32_t baseVertex;
+  uint32_t material;
+  ModelDrawMode mode;
   float bounds[6];
-} ModelPrimitive;
+} ModelPart;
 
 typedef struct {
   const char* name;
-  uint32_t mesh;
   float weight;
 } ModelBlendShape;
 
 typedef struct {
-  uint32_t primitiveCount;
+  ModelPart* parts;
+  uint32_t partCount;
+  uint32_t vertexOffset;
   uint32_t vertexCount;
+  uint32_t indexOffset;
   uint32_t indexCount;
+  uint32_t skinDataOffset;
+  uint32_t blendDataOffset;
   uint32_t blendShapeCount;
-  ModelPrimitive* primitives;
-  ModelVertex* vertices;
-  void* indices;
-  SkinData* skinData;
-  BlendData* blendData;
   ModelBlendShape* blendShapes;
 } ModelMesh;
 
@@ -153,7 +151,6 @@ typedef struct ModelData {
   uint32_t meshCount;
   uint32_t imageCount;
   uint32_t materialCount;
-  uint32_t blendShapeCount;
   uint32_t animationCount;
   uint32_t skinCount;
   uint32_t nodeCount;
@@ -161,18 +158,19 @@ typedef struct ModelData {
   ModelMesh* meshes;
   struct Image** images;
   ModelMaterial* materials;
-  ModelBlendShape* blendShapes;
   ModelAnimation* animations;
   ModelSkin* skins;
   ModelNode* nodes;
 
-  uint32_t primitiveCount;
+  uint32_t partCount;
+  uint32_t blendShapeCount;
   uint32_t channelCount;
   uint32_t keyframeDataCount;
   uint32_t jointCount;
   uint32_t charCount;
 
-  ModelPrimitive* primitives;
+  ModelPart* parts;
+  ModelBlendShape* blendShapes;
   ModelAnimationChannel* channels;
   float* keyframeData;
   float* inverseBindMatrices;

--- a/src/modules/data/modelData.h
+++ b/src/modules/data/modelData.h
@@ -119,8 +119,8 @@ typedef struct {
 
 typedef struct {
   uint32_t* joints;
-  uint32_t jointCount;
   float* inverseBindMatrices;
+  uint32_t jointCount;
 } ModelSkin;
 
 typedef struct {
@@ -143,6 +143,7 @@ typedef struct {
 
 typedef struct ModelData {
   uint32_t ref;
+  uint32_t rootNode;
   uint64_t id;
   void* data;
 
@@ -164,15 +165,16 @@ typedef struct ModelData {
   ModelAnimation* animations;
   ModelSkin* skins;
   ModelNode* nodes;
-  uint32_t rootNode;
 
   uint32_t primitiveCount;
   uint32_t channelCount;
+  uint32_t keyframeDataCount;
   uint32_t jointCount;
   uint32_t charCount;
 
   ModelPrimitive* primitives;
   ModelAnimationChannel* channels;
+  float* keyframeData;
   float* inverseBindMatrices;
   uint32_t* joints;
   char* chars;

--- a/src/modules/data/modelData.h
+++ b/src/modules/data/modelData.h
@@ -217,6 +217,8 @@ void lovrModelDataAllocate(ModelData* model);
 bool lovrModelDataFinalize(ModelData* model);
 void lovrModelDataGetTriangles(ModelData* data, float** vertices, uint32_t** indices, uint32_t* vertexCount, uint32_t* indexCount);
 
+uint32_t lovrModelMetadataGetTotalVertexCount(ModelMetadata* meta);
+uint32_t lovrModelMetadataGetTotalIndexCount(ModelMetadata* meta);
 void lovrModelMetadataGetBoundingBox(ModelMetadata* meta, float box[6]);
 void lovrModelMetadataGetMeshBoundingBox(ModelMetadata* meta, uint32_t index, float box[6]);
 uint32_t lovrModelMetadataNextNodeWithMesh(ModelMetadata* meta, uint32_t node);

--- a/src/modules/data/modelData.h
+++ b/src/modules/data/modelData.h
@@ -8,57 +8,23 @@ struct Blob;
 struct Image;
 
 typedef struct {
-  uint32_t blob;
-  size_t offset;
-  size_t size;
-  size_t stride;
-  char* data;
-} ModelBuffer;
-
-typedef enum {
-  ATTR_POSITION,
-  ATTR_NORMAL,
-  ATTR_UV,
-  ATTR_COLOR,
-  ATTR_TANGENT,
-  ATTR_JOINTS,
-  ATTR_WEIGHTS,
-  MAX_DEFAULT_ATTRIBUTES
-} DefaultAttribute;
-
-typedef enum { I8, U8, I16, U16, I32, U32, F32, SN10x3 } AttributeType;
-
-typedef union {
-  void* raw;
-  int8_t* i8;
-  uint8_t* u8;
-  int16_t* i16;
-  uint16_t* u16;
-  int32_t* i32;
-  uint32_t* u32;
-  float* f32;
-} AttributeData;
+  struct { float x, y, z; } position;
+  uint32_t normal;
+  struct { float u, v; } uv;
+  struct { uint8_t r, g, b, a; } color;
+  uint32_t tangent;
+} ModelVertex;
 
 typedef struct {
-  uint32_t offset;
-  uint32_t buffer;
-  size_t stride;
-  uint32_t count;
-  AttributeType type;
-  unsigned components : 3;
-  unsigned normalized : 1;
-  unsigned matrix : 1;
-  unsigned hasMin : 1;
-  unsigned hasMax : 1;
-  float min[4];
-  float max[4];
-} ModelAttribute;
+  uint8_t joints[4];
+  uint8_t weights[4];
+} SkinData;
 
 typedef struct {
-  ModelAttribute* positions;
-  ModelAttribute* normals;
-  ModelAttribute* tangents;
-} ModelBlendData;
+  float x, y, z;
+  float nx, ny, nz;
+  float tx, ty, tz;
+} BlendData;
 
 typedef enum {
   DRAW_POINT_LIST,
@@ -71,14 +37,33 @@ typedef enum {
 } ModelDrawMode;
 
 typedef struct {
-  ModelAttribute* attributes[MAX_DEFAULT_ATTRIBUTES];
-  ModelAttribute* indices;
-  ModelBlendData* blendShapes;
-  uint32_t blendShapeCount;
   ModelDrawMode mode;
   uint32_t material;
-  uint32_t skin;
+  uint32_t start;
+  uint32_t count;
+  uint32_t vertexCount;
+  uint32_t indexCount;
+  float bounds[6];
 } ModelPrimitive;
+
+typedef struct {
+  const char* name;
+  uint32_t mesh;
+  float weight;
+} ModelBlendShape;
+
+typedef struct {
+  uint32_t primitiveCount;
+  uint32_t vertexCount;
+  uint32_t indexCount;
+  uint32_t blendShapeCount;
+  ModelPrimitive* primitives;
+  ModelVertex* vertices;
+  void* indices;
+  SkinData* skinData;
+  BlendData* blendData;
+  ModelBlendShape* blendShapes;
+} ModelMesh;
 
 typedef struct {
   float color[4];
@@ -102,12 +87,6 @@ typedef struct {
   uint32_t normalTexture;
   const char* name;
 } ModelMaterial;
-
-typedef struct {
-  const char* name;
-  uint32_t node;
-  float weight;
-} ModelBlendShape;
 
 typedef enum {
   PROP_TRANSLATION,
@@ -141,8 +120,6 @@ typedef struct {
 typedef struct {
   uint32_t* joints;
   uint32_t jointCount;
-  uint32_t vertexCount;
-  uint32_t blendedVertexCount;
   float* inverseBindMatrices;
 } ModelSkin;
 
@@ -159,10 +136,7 @@ typedef struct {
   uint32_t child;
   uint32_t sibling;
   uint32_t parent;
-  uint32_t primitiveIndex;
-  uint32_t primitiveCount;
-  uint32_t blendShapeIndex;
-  uint32_t blendShapeCount;
+  uint32_t mesh;
   uint32_t skin;
   bool hasMatrix;
 } ModelNode;
@@ -175,11 +149,16 @@ typedef struct ModelData {
   void* metadata;
   size_t metadataSize;
 
-  struct Blob** blobs;
+  uint32_t meshCount;
+  uint32_t imageCount;
+  uint32_t materialCount;
+  uint32_t blendShapeCount;
+  uint32_t animationCount;
+  uint32_t skinCount;
+  uint32_t nodeCount;
+
+  ModelMesh* meshes;
   struct Image** images;
-  ModelBuffer* buffers;
-  ModelAttribute* attributes;
-  ModelPrimitive* primitives;
   ModelMaterial* materials;
   ModelBlendShape* blendShapes;
   ModelAnimation* animations;
@@ -187,42 +166,37 @@ typedef struct ModelData {
   ModelNode* nodes;
   uint32_t rootNode;
 
-  uint32_t blobCount;
-  uint32_t imageCount;
-  uint32_t bufferCount;
-  uint32_t attributeCount;
   uint32_t primitiveCount;
-  uint32_t materialCount;
-  uint32_t blendShapeCount;
-  uint32_t animationCount;
-  uint32_t skinCount;
-  uint32_t nodeCount;
-
-  ModelAnimationChannel* channels;
-  ModelBlendData* blendData;
-  uint32_t* joints;
-  char* chars;
   uint32_t channelCount;
-  uint32_t blendDataCount;
   uint32_t jointCount;
   uint32_t charCount;
 
-  // Computed properties (loaders don't need to fill these out)
+  ModelPrimitive* primitives;
+  ModelAnimationChannel* channels;
+  float* inverseBindMatrices;
+  uint32_t* joints;
+  char* chars;
 
   uint32_t vertexCount;
-  uint32_t skinnedVertexCount;
-  uint32_t blendShapeVertexCount;
-  uint32_t dynamicVertexCount;
   uint32_t indexCount;
-  AttributeType indexType;
+  uint32_t skinnedVertexCount;
+  uint32_t blendedVertexCount;
+  uint32_t animatedVertexCount;
+  uint32_t indexSize;
+
+  ModelVertex* vertices;
+  void* indices;
+  SkinData* skinData;
+  BlendData* blendData;
+
+  // Computed properties (loaders don't need to fill these out)
 
   float boundingBox[6];
   float boundingSphere[4];
-
-  float* vertices;
-  uint32_t* indices;
-  uint32_t totalVertexCount;
-  uint32_t totalIndexCount;
+  float* triangleVertices;
+  uint32_t* triangleIndices;
+  uint32_t triangleVertexCount;
+  uint32_t triangleIndexCount;
 
   // Lookups
 
@@ -241,7 +215,6 @@ bool lovrModelDataInitStl(ModelData** model, struct Blob* blob, ModelDataIO* io)
 void lovrModelDataDestroy(void* ref);
 void lovrModelDataAllocate(ModelData* model);
 bool lovrModelDataFinalize(ModelData* model);
-void lovrModelDataCopyAttribute(ModelData* data, ModelAttribute* attribute, char* dst, AttributeType type, uint32_t components, bool normalized, uint32_t count, size_t stride, uint8_t clear);
 void lovrModelDataGetBoundingBox(ModelData* data, float box[6]);
 void lovrModelDataGetBoundingSphere(ModelData* data, float sphere[4]);
 void lovrModelDataGetTriangles(ModelData* data, float** vertices, uint32_t** indices, uint32_t* vertexCount, uint32_t* indexCount);

--- a/src/modules/data/modelData.h
+++ b/src/modules/data/modelData.h
@@ -216,5 +216,7 @@ void lovrModelDataDestroy(void* ref);
 void lovrModelDataAllocate(ModelData* model);
 bool lovrModelDataFinalize(ModelData* model);
 void lovrModelDataGetBoundingBox(ModelData* data, float box[6]);
+void lovrModelDataGetMeshBoundingBox(ModelData* model, uint32_t index, float box[6]);
 void lovrModelDataGetBoundingSphere(ModelData* data, float sphere[4]);
+void lovrModelDataGetMeshBoundingSphere(ModelData* model, uint32_t index, uint32_t part, float sphere[4]);
 void lovrModelDataGetTriangles(ModelData* data, float** vertices, uint32_t** indices, uint32_t* vertexCount, uint32_t* indexCount);

--- a/src/modules/data/modelData.h
+++ b/src/modules/data/modelData.h
@@ -220,3 +220,4 @@ void lovrModelDataGetMeshBoundingBox(ModelData* model, uint32_t index, float box
 void lovrModelDataGetBoundingSphere(ModelData* data, float sphere[4]);
 void lovrModelDataGetMeshBoundingSphere(ModelData* model, uint32_t index, uint32_t part, float sphere[4]);
 void lovrModelDataGetTriangles(ModelData* data, float** vertices, uint32_t** indices, uint32_t* vertexCount, uint32_t* indexCount);
+uint32_t lovrModelDataNextNodeWithMesh(ModelData* data, uint32_t node);

--- a/src/modules/data/modelData.h
+++ b/src/modules/data/modelData.h
@@ -193,17 +193,11 @@ typedef struct ModelMetadata {
 typedef struct ModelData {
   uint32_t ref;
   ModelMetadata meta;
-
   ModelVertex* vertices;
   void* indices;
   SkinData* skinData;
   BlendData* blendData;
   struct Image** images;
-
-  uint32_t triangleVertexCount;
-  uint32_t triangleIndexCount;
-  float* triangleVertices;
-  uint32_t* triangleIndices;
 } ModelData;
 
 typedef void* ModelDataIO(const char* filename, size_t* bytesRead);
@@ -215,10 +209,8 @@ bool lovrModelDataInitStl(ModelData** model, struct Blob* blob, ModelDataIO* io)
 void lovrModelDataDestroy(void* ref);
 void lovrModelDataAllocate(ModelData* model);
 bool lovrModelDataFinalize(ModelData* model);
-void lovrModelDataGetTriangles(ModelData* data, float** vertices, uint32_t** indices, uint32_t* vertexCount, uint32_t* indexCount);
+void lovrModelDataGetTriangles(ModelData* model, float** vertices, uint32_t** indices, uint32_t* vertexCount, uint32_t* indexCount);
 
-uint32_t lovrModelMetadataGetTotalVertexCount(ModelMetadata* meta);
-uint32_t lovrModelMetadataGetTotalIndexCount(ModelMetadata* meta);
 void lovrModelMetadataGetBoundingBox(ModelMetadata* meta, float box[6]);
 void lovrModelMetadataGetMeshBoundingBox(ModelMetadata* meta, uint32_t index, float box[6]);
 uint32_t lovrModelMetadataNextNodeWithMesh(ModelMetadata* meta, uint32_t node);

--- a/src/modules/data/modelData.h
+++ b/src/modules/data/modelData.h
@@ -139,24 +139,21 @@ typedef struct {
   bool hasMatrix;
 } ModelNode;
 
-typedef struct ModelData {
-  uint32_t ref;
-  uint32_t rootNode;
-  uint64_t id;
-  void* data;
+typedef struct ModelMetadata {
+  struct Blob* blob;
 
-  void* metadata;
-  size_t metadataSize;
+  uint64_t id;
+  char* comment;
+  size_t commentLength;
 
   uint32_t meshCount;
-  uint32_t imageCount;
   uint32_t materialCount;
   uint32_t animationCount;
   uint32_t skinCount;
   uint32_t nodeCount;
+  uint32_t rootNode;
 
   ModelMesh* meshes;
-  struct Image** images;
   ModelMaterial* materials;
   ModelAnimation* animations;
   ModelSkin* skins;
@@ -183,27 +180,30 @@ typedef struct ModelData {
   uint32_t blendedVertexCount;
   uint32_t animatedVertexCount;
   uint32_t indexSize;
+  uint32_t imageCount;
+
+  uint32_t* blendShapeLookup;
+  uint32_t* animationLookup;
+  uint32_t* materialLookup;
+  uint32_t* nodeLookup;
+
+  float bounds[6];
+} ModelMetadata;
+
+typedef struct ModelData {
+  uint32_t ref;
+  ModelMetadata meta;
 
   ModelVertex* vertices;
   void* indices;
   SkinData* skinData;
   BlendData* blendData;
+  struct Image** images;
 
-  // Computed properties (loaders don't need to fill these out)
-
-  float boundingBox[6];
-  float boundingSphere[4];
-  float* triangleVertices;
-  uint32_t* triangleIndices;
   uint32_t triangleVertexCount;
   uint32_t triangleIndexCount;
-
-  // Lookups
-
-  void* blendShapeMap;
-  void* animationMap;
-  void* materialMap;
-  void* nodeMap;
+  float* triangleVertices;
+  uint32_t* triangleIndices;
 } ModelData;
 
 typedef void* ModelDataIO(const char* filename, size_t* bytesRead);
@@ -215,9 +215,8 @@ bool lovrModelDataInitStl(ModelData** model, struct Blob* blob, ModelDataIO* io)
 void lovrModelDataDestroy(void* ref);
 void lovrModelDataAllocate(ModelData* model);
 bool lovrModelDataFinalize(ModelData* model);
-void lovrModelDataGetBoundingBox(ModelData* data, float box[6]);
-void lovrModelDataGetMeshBoundingBox(ModelData* model, uint32_t index, float box[6]);
-void lovrModelDataGetBoundingSphere(ModelData* data, float sphere[4]);
-void lovrModelDataGetMeshBoundingSphere(ModelData* model, uint32_t index, uint32_t part, float sphere[4]);
 void lovrModelDataGetTriangles(ModelData* data, float** vertices, uint32_t** indices, uint32_t* vertexCount, uint32_t* indexCount);
-uint32_t lovrModelDataNextNodeWithMesh(ModelData* data, uint32_t node);
+
+void lovrModelMetadataGetBoundingBox(ModelMetadata* meta, float box[6]);
+void lovrModelMetadataGetMeshBoundingBox(ModelMetadata* meta, uint32_t index, float box[6]);
+uint32_t lovrModelMetadataNextNodeWithMesh(ModelMetadata* meta, uint32_t node);

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -676,13 +676,13 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   if (info.meshes) {
     jsmntok_t* token = info.meshes;
     for (int i = (token++)->size; i > 0 ; i--) {
+      uint32_t blendShapeCount = 0;
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "primitives")) {
           model->primitiveCount += token->size;
           for (int p = (token++)->size; p > 0; p--) {
             uint32_t vertexCount = 0;
-            uint32_t blendShapeCount = 0;
             bool hasJoints = false;
             for (int k2 = (token++)->size; k2 > 0; k2--) {
               gltfString key = NOM_STR(json, token);
@@ -697,7 +697,8 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 uint32_t index = NOM_U32(json, token);
                 model->indexCount += accessors[index].count;
                 model->indexSize = MAX(model->indexSize, typeSizes[accessors[index].type]);
-              } else if (p == 0 && STR_EQ(key, "targets")) {
+              } else if (STR_EQ(key, "targets")) {
+                lovrAssertGoto(fail, blendShapeCount == 0 || blendShapeCount == token->size, "Model has inconsistent blend shape counts");
                 blendShapeCount = token->size;
                 token = NOM(token);
               } else {
@@ -708,12 +709,13 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
             model->skinnedVertexCount += hasJoints ? vertexCount : 0;
             model->blendedVertexCount += vertexCount * blendShapeCount;
             model->animatedVertexCount += (hasJoints || blendShapeCount > 0) ? vertexCount : 0;
-            model->blendShapeCount += blendShapeCount;
           }
         } else if (STR_EQ(key, "extras")) {
           for (int k2 = (token++)->size; k2 > 0; k2--) {
             gltfString key = NOM_STR(json, token);
             if (STR_EQ(key, "targetNames")) {
+              lovrAssertGoto(fail, blendShapeCount == 0 || blendShapeCount == token->size, "Model has inconsistent blend shape counts");
+              blendShapeCount = token->size;
               for (int j = (token++)->size; j > 0; j--) {
                 model->charCount += token->end - token->start + 1;
                 token++;
@@ -726,6 +728,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           token = NOM(token);
         }
       }
+      model->blendShapeCount += blendShapeCount;
     }
   }
 
@@ -973,9 +976,6 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     ModelBlendShape* blendShapes = model->blendShapes;
     for (int i = (token++)->size; i > 0; i--, mesh++) {
       mesh->primitives = primitive;
-      mesh->vertices = vertices;
-      mesh->indices = indexData;
-      mesh->blendData = blendData;
       mesh->blendShapes = blendShapes;
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
@@ -989,9 +989,6 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
             gltfAccessor* indices = NULL;
             gltfAccessor* joints = NULL;
             gltfAccessor* weights = NULL;
-            gltfAccessor* blendPositions = NULL;
-            gltfAccessor* blendNormals = NULL;
-            gltfAccessor* blendTangents = NULL;
 
             for (int k2 = (token++)->size; k2 > 0; k2--) {
               gltfString key = NOM_STR(json, token);
@@ -1021,14 +1018,25 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               } else if (STR_EQ(key, "indices")) {
                 indices = &accessors[NOM_U32(json, token)];
               } else if (STR_EQ(key, "targets")) {
-                mesh->blendShapeCount = token->size;
+                if (mesh->blendShapeCount == 0) mesh->blendShapeCount = token->size;
                 for (int t = (token++)->size; t > 0; t--) {
+                  gltfAccessor* blendPositions = NULL;
+                  gltfAccessor* blendNormals = NULL;
+                  gltfAccessor* blendTangents = NULL;
                   for (int a = (token++)->size; a > 0; a--) {
                     gltfString name = NOM_STR(json, token);
                     uint32_t accessor = NOM_U32(json, token);
                     if (STR_EQ(name, "POSITION")) blendPositions = &accessors[accessor];
                     else if (STR_EQ(name, "NORMAL")) blendNormals = &accessors[accessor];
                     else if (STR_EQ(name, "TANGENT")) blendTangents = &accessors[accessor];
+                  }
+                  if (blendPositions) {
+                    uint32_t count = blendPositions->count;
+                    if (!mesh->blendData) mesh->blendData = blendData;
+                    copyAttribute(blendData, blendPositions, F32, 3, false, 0, sizeof(BlendData), count, 0);
+                    copyAttribute(blendData, blendNormals, F32, 3, false, 12, sizeof(BlendData), count, 0);
+                    copyAttribute(blendData, blendTangents, F32, 3, false, 24, sizeof(BlendData), count, 0);
+                    blendData += blendPositions->count;
                   }
                 }
               } else if (STR_EQ(key, "material")) {
@@ -1053,6 +1061,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 primitive->count = vertexCount;
               }
 
+              if (!mesh->vertices) mesh->vertices = vertices;
               copyAttribute(vertices, positions, F32, 3, false, 0, sizeof(ModelVertex), vertexCount, 0);
               copyAttribute(vertices, normals, SN10x3, 1, false, 12, sizeof(ModelVertex), vertexCount, 0);
               copyAttribute(vertices, uvs, F32, 2, false, 16, sizeof(ModelVertex), vertexCount, 0);
@@ -1061,29 +1070,19 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               vertices += vertexCount;
 
               if (indices) {
+                if (!mesh->indices) mesh->indices = indexData;
                 int type = model->indexSize == 4 ? U32 : U16;
                 copyAttribute(indexData, indices, type, 1, false, 0, model->indexSize, indices->count, 0);
                 indexData = (char*) indexData + (indices->count * model->indexSize);
               }
 
               if (joints && weights) {
-                mesh->skinData = mesh->skinData ? mesh->skinData : skinData;
+                if (!mesh->skinData) mesh->skinData = skinData;
                 copyAttribute(skinData, joints, U8, 4, false, 0, sizeof(SkinData), vertexCount, 0);
                 copyAttribute(skinData, weights, U8, 4, true, 4, sizeof(SkinData), vertexCount, 0);
                 skinData += vertexCount;
               }
 
-              if (blendPositions) {
-                for (uint32_t b = 0; b < mesh->blendShapeCount; b++) {
-                  copyAttribute(blendData, blendPositions, F32, 3, false, 0, sizeof(BlendData), vertexCount, 0);
-                  copyAttribute(blendData, blendNormals, F32, 3, false, 12, sizeof(BlendData), vertexCount, 0);
-                  copyAttribute(blendData, blendTangents, F32, 3, false, 24, sizeof(BlendData), vertexCount, 0);
-                  blendData += vertexCount;
-                }
-              }
-
-              primitive->vertexCount = vertexCount;
-              primitive->indexCount = indices ? indices->count : 0;
               primitive->bounds[0] = (positions->min[0] + positions->max[0]) / 2.f;
               primitive->bounds[1] = (positions->min[1] + positions->max[1]) / 2.f;
               primitive->bounds[2] = (positions->min[2] + positions->max[2]) / 2.f;
@@ -1091,13 +1090,14 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               primitive->bounds[4] = (positions->max[1] - positions->min[1]) / 2.f;
               primitive->bounds[5] = (positions->max[2] - positions->min[2]) / 2.f;
 
-              mesh->vertexCount += vertexCount;
-              mesh->indexCount += indices ? indices->count : 0;
+              primitive->vertexCount = vertexCount;
+              primitive->indexCount = indices ? indices->count : 0;
+              mesh->vertexCount += primitive->vertexCount;
+              mesh->indexCount += primitive->indexCount;
               mesh->primitiveCount++;
             }
           }
         } else if (STR_EQ(key, "weights")) {
-          lovrAssertGoto(fail, (uint32_t) token->size == mesh->blendShapeCount, "Inconsistent blend shape counts");
           for (int w = (token++)->size, index = 0; w > 0; w--, index++) {
             mesh->blendShapes[index].weight = NOM_FLOAT(json, token);
           }
@@ -1105,7 +1105,6 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           for (int k2 = (token++)->size; k2 > 0; k2--) {
             gltfString key = NOM_STR(json, token);
             if (STR_EQ(key, "targetNames")) {
-              lovrAssertGoto(fail, (uint32_t) token->size == mesh->blendShapeCount, "Inconsistent blend shape counts");
               for (int k3 = (token++)->size, index = 0; k3 > 0; k3--, index++) {
                 gltfString name = NOM_STR(json, token);
                 uint64_t hash = hash64(name.data, name.length);
@@ -1123,8 +1122,15 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
         } else {
           token = NOM(token);
         }
+      }
 
+      if (mesh->blendShapeCount > 0) {
+        for (uint32_t i = 0; i < mesh->blendShapeCount; i++) {
+          mesh->blendShapes[i].mesh = mesh - model->meshes;
+        }
         blendShapes += mesh->blendShapeCount;
+      } else {
+        mesh->blendShapes = NULL;
       }
     }
   }

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -2,6 +2,7 @@
 #include "data/blob.h"
 #include "data/image.h"
 #include "util.h"
+#include "core/job.h"
 #include "lib/jsmn/jsmn.h"
 #include <stdlib.h>
 #include <string.h>
@@ -80,6 +81,16 @@ typedef struct {
   uint32_t node;
   uint32_t nodeCount;
 } gltfScene;
+
+typedef struct {
+  job* handle;
+  Image* result;
+  gltfImage* image;
+  gltfBufferView* buffers;
+  ModelDataIO* io;
+  char* basePath;
+  char* error;
+} ImageJob;
 
 static uint32_t nomU32(const char* s) {
   uint32_t n = 0;
@@ -184,42 +195,82 @@ static jsmntok_t* nomTexture(const char* json, jsmntok_t* token, uint32_t* image
   return token;
 }
 
-static bool loadImage(ModelData* model, gltfBufferView* buffers, gltfImage* images, uint32_t index, ModelDataIO* io, char* filename, size_t maxLength) {
-  if (model->images[index]) {
-    return true; // Already loaded
-  }
+static void loadImage(void* arg) {
+  ImageJob* ctx = arg;
+  Blob* blob;
 
-  gltfImage* image = &images[index];
-  if (image->bufferView != ~0u) {
-    gltfBufferView* buffer = &buffers[image->bufferView];
-    Blob* blob = lovrBlobCreate(buffer->data, buffer->size, NULL);
-    model->images[index] = lovrImageCreateFromFile(blob);
+  if (ctx->image->bufferView != ~0u) {
+    gltfBufferView* buffer = &ctx->buffers[ctx->image->bufferView];
+    blob = lovrBlobCreate(buffer->data, buffer->size, NULL);
+    ctx->result = lovrImageCreateFromFile(blob);
     blob->data = NULL; // XXX Blob data ownership
     lovrRelease(blob, lovrBlobDestroy);
-  } else if (image->uri.data) {
-    void* data;
-    Blob* blob;
-    size_t size;
-    if (image->uri.length >= 5 && !strncmp("data:", image->uri.data, 5)) {
-      data = decodeBase64(image->uri.data, image->uri.length, &size);
-      lovrAssert(data, "Could not decode base64 image");
+  } else if (ctx->image->uri.data) {
+    if (ctx->image->uri.length >= 5 && !strncmp("data:", ctx->image->uri.data, 5)) {
+      size_t size;
+      void* data = decodeBase64(ctx->image->uri.data, ctx->image->uri.length, &size);
+      if (!data) {
+        ctx->error = lovrStrdup("Could not decode base64 image");
+        return;
+      }
       blob = lovrBlobCreate(data, size, NULL);
     } else {
-      char* path = image->uri.data;
-      size_t length = image->uri.length;
-      lovrAssert(length < maxLength, "Image filename is too long");
-      lovrAssert(path[0] != '/', "Absolute paths in models are not supported");
-      if (path[0] && path[1] && !memcmp(path, "./", 2)) path += 2;
-      strncat(filename, path, length);
-      data = io(filename, &size);
-      lovrAssert(data && size > 0, "Unable to read image from '%s'", filename);
+      char* path = ctx->image->uri.data;
+      size_t length = ctx->image->uri.length;
+
+      if (path[0] == '/') {
+        ctx->error = lovrStrdup("Absolute paths in models are not supported");
+        return;
+      }
+
+      // Remove ./ prefix
+      if (path[0] && path[1] && !memcmp(path, "./", 2)) {
+        path += 2;
+        length -= 2;
+      }
+
+      // basePath/path
+      size_t baseLength = strlen(ctx->basePath);
+      size_t totalLength = baseLength + 1 + length + 1;
+      char* fullpath = lovrMalloc(totalLength);
+
+      memcpy(fullpath, ctx->basePath, baseLength);
+      fullpath[baseLength] = '/';
+
+      memcpy(fullpath + baseLength + 1, path, length);
+      fullpath[baseLength + 1 + length] = '\0';
+
+      size_t size;
+      void* data = ctx->io(fullpath, &size);
+
+      if (!data || size <= 0) {
+        const char* message = "Unable to read image from ";
+        size_t messageLength = strlen(message);
+        ctx->error = lovrMalloc(messageLength + length + 1);
+        memcpy(ctx->error, message, messageLength);
+        memcpy(ctx->error + messageLength, path, length);
+        ctx->error[messageLength + length + 1] = '\0';
+        return;
+      }
+
       blob = lovrBlobCreate(data, size, NULL);
     }
-    model->images[index] = lovrImageCreateFromFile(blob);
+
+    ctx->result = lovrImageCreateFromFile(blob);
     lovrRelease(blob, lovrBlobDestroy);
   }
+}
 
-  return !!model->images[index];
+static void startImageJob(ModelData* model, ImageJob* jobs, uint32_t index, gltfBufferView* buffers, gltfImage* images, ModelDataIO* io, char* basePath) {
+  if (jobs[index].handle) {
+    return;
+  }
+
+  jobs[index].image = &images[index];
+  jobs[index].buffers = buffers;
+  jobs[index].basePath = basePath;
+  jobs[index].io = io;
+  jobs[index].handle = job_start(loadImage, &jobs[index]);
 }
 
 static size_t typeSizes[] = {
@@ -750,6 +801,8 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   // their data into this memory.
   lovrModelDataAllocate(model);
 
+  ImageJob* imageJobs = lovrCalloc(model->imageCount * sizeof(ImageJob));
+
   // Blobs
   if (info.buffers) {
     jsmntok_t* token = info.buffers;
@@ -917,7 +970,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               material->color[3] = NOM_FLOAT(json, token);
             } else if (STR_EQ(key, "baseColorTexture")) {
               token = nomTexture(json, token, &material->texture, textures, material);
-              if (!loadImage(model, buffers, images, material->texture, io, filename, maxPathLength)) goto fail;
+              startImageJob(model, imageJobs, material->texture, buffers, images, io, filename);
               *root = '\0';
             } else if (STR_EQ(key, "metallicFactor")) {
               material->metalness = NOM_FLOAT(json, token);
@@ -925,7 +978,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               material->roughness = NOM_FLOAT(json, token);
             } else if (STR_EQ(key, "metallicRoughnessTexture")) {
               token = nomTexture(json, token, &material->metalnessTexture, textures, NULL);
-              if (!loadImage(model, buffers, images, material->metalnessTexture, io, filename, maxPathLength)) goto fail;
+              startImageJob(model, imageJobs, material->metalnessTexture, buffers, images, io, filename);
               material->roughnessTexture = material->metalnessTexture;
               *root = '\0';
             } else {
@@ -934,15 +987,15 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           }
         } else if (STR_EQ(key, "normalTexture")) {
           token = nomTexture(json, token, &material->normalTexture, textures, NULL);
-          if (!loadImage(model, buffers, images, material->normalTexture, io, filename, maxPathLength)) goto fail;
+          startImageJob(model, imageJobs, material->normalTexture, buffers, images, io, filename);
           *root = '\0';
         } else if (STR_EQ(key, "occlusionTexture")) {
           token = nomTexture(json, token, &material->occlusionTexture, textures, NULL);
-          if (!loadImage(model, buffers, images, material->occlusionTexture, io, filename, maxPathLength)) goto fail;
+          startImageJob(model, imageJobs, material->occlusionTexture, buffers, images, io, filename);
           *root = '\0';
         } else if (STR_EQ(key, "emissiveTexture")) {
           token = nomTexture(json, token, &material->glowTexture, textures, NULL);
-          if (!loadImage(model, buffers, images, material->glowTexture, io, filename, maxPathLength)) goto fail;
+          startImageJob(model, imageJobs, material->glowTexture, buffers, images, io, filename);
           *root = '\0';
         } else if (STR_EQ(key, "emissiveFactor")) {
           token++; // Enter array
@@ -1290,6 +1343,25 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     model->rootNode = scenes[rootScene].node;
   }
 
+  for (uint32_t i = 0; i < model->imageCount; i++) {
+    ImageJob* task = &imageJobs[i];
+
+    if (task->handle) {
+      job_wait(task->handle);
+      task->handle = NULL;
+
+      if (task->error) {
+        lovrSetError(task->error);
+        lovrFree(task->error);
+        goto fail;
+      } else {
+        model->images[i] = task->result;
+      }
+    }
+  }
+
+  lovrFree(imageJobs);
+
   for (int i = 0; i < info.buffers->size; i++) {
     lovrRelease(blobs[i], lovrBlobDestroy);
   }
@@ -1306,6 +1378,18 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   return true;
 
 fail:
+  for (uint32_t i = 0; i < model->imageCount; i++) {
+    ImageJob* task = &imageJobs[i];
+
+    if (task->handle) {
+      job_wait(task->handle);
+      lovrRelease(task->result, lovrImageDestroy);
+      lovrFree(task->error);
+    }
+  }
+
+  lovrFree(imageJobs);
+
   for (int i = 0; i < info.buffers->size; i++) {
     lovrRelease(blobs[i], lovrBlobDestroy);
   }

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -730,12 +730,15 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     jsmntok_t* token = info.meshes;
     for (int i = (token++)->size, group = 0; i > 0; i--, group++) {
       uint32_t blendShapeCount = 0;
+      uint32_t maxUnindexedVertexCount = 0;
+      bool indexed = false;
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "primitives")) {
           meta->partCount += token->size;
           for (int p = (token++)->size; p > 0; p--) {
             uint32_t vertexCount = 0;
+            uint32_t indexCount = 0;
             bool hasJoints = false;
             for (int k2 = (token++)->size; k2 > 0; k2--) {
               gltfString key = NOM_STR(json, token);
@@ -748,8 +751,9 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 }
               } else if (STR_EQ(key, "indices")) {
                 uint32_t index = NOM_U32(json, token);
-                meta->indexCount += accessors[index].count;
+                indexCount = accessors[index].count;
                 meta->indexSize = MAX(meta->indexSize, typeSizes[accessors[index].type]);
+                indexed = true;
               } else if (STR_EQ(key, "targets")) {
                 lovrAssertGoto(fail, blendShapeCount == 0 || blendShapeCount == token->size, "Model has inconsistent blend shape counts");
                 blendShapeCount = token->size;
@@ -759,9 +763,11 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               }
             }
             meta->vertexCount += vertexCount;
+            meta->indexCount += indexCount;
             meta->skinnedVertexCount += hasJoints ? vertexCount : 0;
             meta->blendedVertexCount += vertexCount * blendShapeCount;
             meta->animatedVertexCount += (hasJoints || blendShapeCount > 0) ? vertexCount : 0;
+            if (indexCount == 0) maxUnindexedVertexCount = MAX(maxUnindexedVertexCount, vertexCount);
           }
         } else if (STR_EQ(key, "extras")) {
           for (int k2 = (token++)->size; k2 > 0; k2--) {
@@ -782,6 +788,11 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
         }
       }
       meta->blendShapeCount += blendShapeCount;
+      // If any primitives are indexed, we generate indices for any non-indexed primitives in the
+      // mesh.  If any of those dummy indices have a value > 65536, we need to upgrade to 32-bit indices.
+      if (indexed && maxUnindexedVertexCount > UINT16_MAX) {
+        meta->indexSize = 4;
+      }
     }
   }
 
@@ -1105,12 +1116,15 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
             }
 
             if (positions) {
+              if (mesh->vertexOffset == ~0u) mesh->vertexOffset = vertexOffset;
+              if (indices && mesh->indexOffset == ~0u) mesh->indexOffset = indexOffset;
+
               if (indices || mesh->indexCount > 0) {
-                part->start = indexOffset;
-                part->count = indices->count;
-                part->baseVertex = vertexOffset;
+                part->start = indexOffset - mesh->indexOffset;
+                part->count = indices ? indices->count : positions->count;
+                part->baseVertex = vertexOffset - mesh->vertexOffset;
               } else {
-                part->start = vertexOffset;
+                part->start = vertexOffset - mesh->vertexOffset;
                 part->count = positions->count;
               }
 
@@ -1121,13 +1135,12 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               copyAttribute(vertices, uvs, F32, 2, false, 16, sizeof(ModelVertex), vertexCount, 0);
               copyAttribute(vertices, colors, U8, 4, true, 24, sizeof(ModelVertex), vertexCount, 0xff);
               copyAttribute(vertices, tangents, SN10x3, 1, false, 28, sizeof(ModelVertex), vertexCount, 0);
-              if (mesh->vertexOffset == ~0u) mesh->vertexOffset = vertexOffset;
               mesh->vertexCount += vertexCount;
               vertexOffset += vertexCount;
 
               // We keep meshes consistently indexed or non-indexed, so we have to generate indices if:
               // - This is the first indexed primitive, and we already wrote non-indexed primitives
-              // - This is a non-inxed primitive, and we've already written an indexed primitive
+              // - This is a non-indexed primitive, and we've already written an indexed primitive
               if ((indices && mesh->indexCount == 0) || (!indices && mesh->indexCount > 0)) {
                 uint32_t partIndex = indices ? 0 : part - mesh->parts;
                 uint32_t partCount = indices ? mesh->partCount : 1;
@@ -1137,14 +1150,14 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                   uint32_t count = mesh->parts[partIndex + p].count;
                   if (meta->indexSize == 4) {
                     for (uint32_t index = 0; index < count; index++) {
-                      ((uint32_t*) indexData)[index] = indexOffset + index;
+                      ((uint32_t*) indexData)[index] = index;
                     }
                   } else {
                     for (uint32_t index = 0; index < count; index++) {
-                      ((uint16_t*) indexData)[index] = indexOffset + index;
+                      ((uint16_t*) indexData)[index] = index;
                     }
                   }
-                  mesh->parts[partIndex + p].start = indexOffset;
+                  mesh->parts[partIndex + p].start = indexOffset - mesh->indexOffset;
                   mesh->indexCount += count;
                   indexOffset += count;
                 }
@@ -1155,7 +1168,6 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 int type = meta->indexSize == 4 ? U32 : U16;
                 void* indexData = (char*) model->indices + (indexOffset * meta->indexSize);
                 copyAttribute(indexData, indices, type, 1, false, 0, meta->indexSize, indexCount, 0);
-                if (mesh->indexOffset == ~0u) mesh->indexOffset = indexOffset;
                 mesh->indexCount += indexCount;
                 indexOffset += indexCount;
               }

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -675,12 +675,12 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   // Iterate over meshes and tally up vertex/index/blendshape counts (now that we have accessors)
   if (info.meshes) {
     jsmntok_t* token = info.meshes;
-    for (int i = (token++)->size; i > 0 ; i--) {
+    for (int i = (token++)->size, group = 0; i > 0; i--, group++) {
       uint32_t blendShapeCount = 0;
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "primitives")) {
-          model->primitiveCount += token->size;
+          model->partCount += token->size;
           for (int p = (token++)->size; p > 0; p--) {
             uint32_t vertexCount = 0;
             bool hasJoints = false;
@@ -968,19 +968,20 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   if (model->meshCount > 0) {
     jsmntok_t* token = info.meshes;
     ModelMesh* mesh = model->meshes;
-    ModelPrimitive* primitive = model->primitives;
-    ModelVertex* vertices = model->vertices;
-    void* indexData = model->indices;
-    SkinData* skinData = model->skinData;
-    BlendData* blendData = model->blendData;
+    ModelPart* part = model->parts;
+    uint32_t vertexOffset = 0;
+    uint32_t indexOffset = 0;
+    uint32_t skinDataOffset = 0;
+    uint32_t blendDataOffset = 0;
+    uint32_t blendShapeIndex = 0;
     ModelBlendShape* blendShapes = model->blendShapes;
-    for (int i = (token++)->size; i > 0; i--, mesh++) {
-      mesh->primitives = primitive;
+    for (int i = (token++)->size; i > 0; i--) {
+      mesh->parts = part;
       mesh->blendShapes = blendShapes;
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "primitives")) {
-          for (uint32_t j = (token++)->size; j > 0; j--, primitive++) {
+          for (uint32_t j = (token++)->size; j > 0; j--, mesh++) {
             gltfAccessor* positions = NULL;
             gltfAccessor* normals = NULL;
             gltfAccessor* uvs = NULL;
@@ -994,13 +995,13 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               gltfString key = NOM_STR(json, token);
               if (STR_EQ(key, "mode")) {
                 switch (NOM_U32(json, token)) {
-                  case 0: primitive->mode = DRAW_POINT_LIST; break;
-                  case 1: primitive->mode = DRAW_LINE_LIST; break;
-                  case 2: primitive->mode = DRAW_LINE_LOOP; break;
-                  case 3: primitive->mode = DRAW_LINE_STRIP; break;
-                  case 4: primitive->mode = DRAW_TRIANGLE_LIST; break;
-                  case 5: primitive->mode = DRAW_TRIANGLE_STRIP; break;
-                  case 6: primitive->mode = DRAW_TRIANGLE_FAN; break;
+                  case 0: part->mode = DRAW_POINT_LIST; break;
+                  case 1: part->mode = DRAW_LINE_LIST; break;
+                  case 2: part->mode = DRAW_LINE_LOOP; break;
+                  case 3: part->mode = DRAW_LINE_STRIP; break;
+                  case 4: part->mode = DRAW_TRIANGLE_LIST; break;
+                  case 5: part->mode = DRAW_TRIANGLE_STRIP; break;
+                  case 6: part->mode = DRAW_TRIANGLE_FAN; break;
                   default: lovrAssertGoto(fail, false, "Unknown primitive mode");
                 }
               } else if (STR_EQ(key, "attributes")) {
@@ -1019,87 +1020,112 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 indices = &accessors[NOM_U32(json, token)];
               } else if (STR_EQ(key, "targets")) {
                 if (mesh->blendShapeCount == 0) mesh->blendShapeCount = token->size;
+                mesh->blendDataOffset = blendDataOffset;
                 for (int t = (token++)->size; t > 0; t--) {
                   gltfAccessor* blendPositions = NULL;
                   gltfAccessor* blendNormals = NULL;
                   gltfAccessor* blendTangents = NULL;
+                  uint32_t count = 0;
+
                   for (int a = (token++)->size; a > 0; a--) {
                     gltfString name = NOM_STR(json, token);
                     uint32_t accessor = NOM_U32(json, token);
                     if (STR_EQ(name, "POSITION")) blendPositions = &accessors[accessor];
                     else if (STR_EQ(name, "NORMAL")) blendNormals = &accessors[accessor];
                     else if (STR_EQ(name, "TANGENT")) blendTangents = &accessors[accessor];
+                    count = accessors[accessor].count;
                   }
-                  if (blendPositions) {
-                    uint32_t count = blendPositions->count;
-                    if (!mesh->blendData) mesh->blendData = blendData;
-                    copyAttribute(blendData, blendPositions, F32, 3, false, 0, sizeof(BlendData), count, 0);
-                    copyAttribute(blendData, blendNormals, F32, 3, false, 12, sizeof(BlendData), count, 0);
-                    copyAttribute(blendData, blendTangents, F32, 3, false, 24, sizeof(BlendData), count, 0);
-                    blendData += blendPositions->count;
-                  }
+
+                  BlendData* blendData = model->blendData + blendDataOffset;
+                  copyAttribute(blendData, blendPositions, F32, 3, false, 0, sizeof(BlendData), count, 0);
+                  copyAttribute(blendData, blendNormals, F32, 3, false, 12, sizeof(BlendData), count, 0);
+                  copyAttribute(blendData, blendTangents, F32, 3, false, 24, sizeof(BlendData), count, 0);
+                  blendDataOffset += blendPositions->count;
                 }
               } else if (STR_EQ(key, "material")) {
-                primitive->material = NOM_U32(json, token);
+                part->material = NOM_U32(json, token);
               } else {
                 token = NOM(token);
               }
             }
 
             if (positions) {
-              uint32_t vertexCount = positions->count;
-
-              if (indices) {
-                if (model->indexSize == 4) {
-                  primitive->start = (uint32_t*) indexData - (uint32_t*) model->indices;
-                } else {
-                  primitive->start = (uint16_t*) indexData - (uint16_t*) model->indices;
-                }
-                primitive->count = indices->count;
+              if (indices || mesh->indexCount > 0) {
+                part->start = indexOffset;
+                part->count = indices->count;
+                part->baseVertex = vertexOffset;
               } else {
-                primitive->start = vertices - model->vertices;
-                primitive->count = vertexCount;
+                part->start = vertexOffset;
+                part->count = positions->count;
               }
 
-              if (!mesh->vertices) mesh->vertices = vertices;
+              uint32_t vertexCount = positions->count;
+              ModelVertex* vertices = model->vertices + vertexOffset;
               copyAttribute(vertices, positions, F32, 3, false, 0, sizeof(ModelVertex), vertexCount, 0);
               copyAttribute(vertices, normals, SN10x3, 1, false, 12, sizeof(ModelVertex), vertexCount, 0);
               copyAttribute(vertices, uvs, F32, 2, false, 16, sizeof(ModelVertex), vertexCount, 0);
               copyAttribute(vertices, colors, U8, 4, true, 24, sizeof(ModelVertex), vertexCount, 0xff);
               copyAttribute(vertices, tangents, SN10x3, 1, false, 28, sizeof(ModelVertex), vertexCount, 0);
-              vertices += vertexCount;
+              if (mesh->vertexOffset == ~0u) mesh->vertexOffset = vertexOffset;
+              mesh->vertexCount += vertexCount;
+              vertexOffset += vertexCount;
+
+              // We keep meshes consistently indexed or non-indexed, so we have to generate indices if:
+              // - This is the first indexed primitive, and we already wrote non-indexed primitives
+              // - This is a non-inxed primitive, and we've already written an indexed primitive
+              if ((indices && mesh->indexCount == 0) || (!indices && mesh->indexCount > 0)) {
+                uint32_t partIndex = indices ? 0 : part - mesh->parts;
+                uint32_t partCount = indices ? mesh->partCount : 1;
+                void* indexData = (char*) model->indices + (indexOffset * model->indexSize);
+
+                for (uint32_t p = 0; p < partCount; p++) {
+                  uint32_t count = mesh->parts[partIndex + p].count;
+                  if (model->indexSize == 4) {
+                    for (uint32_t index = 0; index < count; index++) {
+                      ((uint32_t*) indexData)[index] = indexOffset + index;
+                    }
+                  } else {
+                    for (uint32_t index = 0; index < count; index++) {
+                      ((uint16_t*) indexData)[index] = indexOffset + index;
+                    }
+                  }
+                  mesh->parts[partIndex + p].start = indexOffset;
+                  mesh->indexCount += count;
+                  indexOffset += count;
+                }
+              }
 
               if (indices) {
-                if (!mesh->indices) mesh->indices = indexData;
+                uint32_t indexCount = indices->count;
                 int type = model->indexSize == 4 ? U32 : U16;
-                copyAttribute(indexData, indices, type, 1, false, 0, model->indexSize, indices->count, 0);
-                indexData = (char*) indexData + (indices->count * model->indexSize);
+                void* indexData = (char*) model->indices + (indexOffset * model->indexSize);
+                copyAttribute(indexData, indices, type, 1, false, 0, model->indexSize, indexCount, 0);
+                if (mesh->indexOffset == ~0u) mesh->indexOffset = indexOffset;
+                mesh->indexCount += indexCount;
+                indexOffset += indexCount;
               }
 
               if (joints && weights) {
-                if (!mesh->skinData) mesh->skinData = skinData;
+                SkinData* skinData = model->skinData + skinDataOffset;
                 copyAttribute(skinData, joints, U8, 4, false, 0, sizeof(SkinData), vertexCount, 0);
                 copyAttribute(skinData, weights, U8, 4, true, 4, sizeof(SkinData), vertexCount, 0);
-                skinData += vertexCount;
+                if (mesh->skinDataOffset == ~0u) mesh->skinDataOffset = skinDataOffset;
+                skinDataOffset += vertexCount;
               }
 
-              primitive->bounds[0] = (positions->min[0] + positions->max[0]) / 2.f;
-              primitive->bounds[1] = (positions->min[1] + positions->max[1]) / 2.f;
-              primitive->bounds[2] = (positions->min[2] + positions->max[2]) / 2.f;
-              primitive->bounds[3] = (positions->max[0] - positions->min[0]) / 2.f;
-              primitive->bounds[4] = (positions->max[1] - positions->min[1]) / 2.f;
-              primitive->bounds[5] = (positions->max[2] - positions->min[2]) / 2.f;
-
-              primitive->vertexCount = vertexCount;
-              primitive->indexCount = indices ? indices->count : 0;
-              mesh->vertexCount += primitive->vertexCount;
-              mesh->indexCount += primitive->indexCount;
-              mesh->primitiveCount++;
+              part->bounds[0] = (positions->min[0] + positions->max[0]) / 2.f;
+              part->bounds[1] = (positions->min[1] + positions->max[1]) / 2.f;
+              part->bounds[2] = (positions->min[2] + positions->max[2]) / 2.f;
+              part->bounds[3] = (positions->max[0] - positions->min[0]) / 2.f;
+              part->bounds[4] = (positions->max[1] - positions->min[1]) / 2.f;
+              part->bounds[5] = (positions->max[2] - positions->min[2]) / 2.f;
+              mesh->partCount++;
+              part++;
             }
           }
         } else if (STR_EQ(key, "weights")) {
           for (int w = (token++)->size, index = 0; w > 0; w--, index++) {
-            mesh->blendShapes[index].weight = NOM_FLOAT(json, token);
+            model->blendShapes[index].weight = NOM_FLOAT(json, token);
           }
         } else if (STR_EQ(key, "extras")) {
           for (int k2 = (token++)->size; k2 > 0; k2--) {
@@ -1124,14 +1150,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
         }
       }
 
-      if (mesh->blendShapeCount > 0) {
-        for (uint32_t i = 0; i < mesh->blendShapeCount; i++) {
-          mesh->blendShapes[i].mesh = mesh - model->meshes;
-        }
-        blendShapes += mesh->blendShapeCount;
-      } else {
-        mesh->blendShapes = NULL;
-      }
+      blendShapes += mesh->blendShapeCount;
     }
   }
 
@@ -1295,6 +1314,7 @@ fail:
   lovrFree(blobs);
   lovrFree(buffers);
   lovrFree(accessors);
+  lovrFree(animationSamplers);
   lovrFree(images);
   lovrFree(textures);
   lovrFree(scenes);

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -242,6 +242,7 @@ static void loadImage(void* arg) {
 
       size_t size;
       void* data = ctx->io(fullpath, &size);
+      lovrFree(fullpath);
 
       if (!data || size <= 0) {
         const char* message = "Unable to read image from ";

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -443,6 +443,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   gltfImage* images = NULL;
   gltfTexture* textures = NULL;
   gltfScene* scenes = NULL;
+  int animationSamplerCount = 0;
   int rootScene = 0;
 
   for (jsmntok_t* token = tokens + 1; token < tokens + tokenCount;) {
@@ -498,21 +499,20 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     } else if (STR_EQ(key, "animations")){
       info.animations = token;
       model->animationCount = token->size;
-      size_t samplerCount = 0;
       jsmntok_t* t = token;
       for (int i = (t++)->size; i > 0; i--) {
         if (t->size > 0) {
           for (int k = (t++)->size; k > 0; k--) {
             gltfString key = NOM_STR(json, t);
             if (STR_EQ(key, "channels")) { model->channelCount += t->size; }
-            else if (STR_EQ(key, "samplers")) { samplerCount += t->size; }
+            else if (STR_EQ(key, "samplers")) { animationSamplerCount += t->size; }
             else if (STR_EQ(key, "name")) { model->charCount += t->end - t->start + 1; }
             t = NOM(t);
           }
         }
       }
 
-      animationSamplers = lovrMalloc(samplerCount * sizeof(gltfAnimationSampler));
+      animationSamplers = lovrMalloc(animationSamplerCount * sizeof(gltfAnimationSampler));
       gltfAnimationSampler* sampler = animationSamplers;
       for (int i = (token++)->size; i > 0; i--) {
         for (int k = (token++)->size; k > 0; k--) {
@@ -673,57 +673,68 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   }
 
   // Iterate over meshes and tally up vertex/index/blendshape counts (now that we have accessors)
-  jsmntok_t* token = info.meshes;
-  for (int i = (token++)->size; i > 0 ; i--) {
-    for (int k = (token++)->size; k > 0; k--) {
-      gltfString key = NOM_STR(json, token);
-      if (STR_EQ(key, "primitives")) {
-        model->primitiveCount += token->size;
-        for (int p = (token++)->size; p > 0; p--) {
-          uint32_t vertexCount = 0;
-          uint32_t blendShapeCount = 0;
-          bool hasJoints = false;
+  if (info.meshes) {
+    jsmntok_t* token = info.meshes;
+    for (int i = (token++)->size; i > 0 ; i--) {
+      for (int k = (token++)->size; k > 0; k--) {
+        gltfString key = NOM_STR(json, token);
+        if (STR_EQ(key, "primitives")) {
+          model->primitiveCount += token->size;
+          for (int p = (token++)->size; p > 0; p--) {
+            uint32_t vertexCount = 0;
+            uint32_t blendShapeCount = 0;
+            bool hasJoints = false;
+            for (int k2 = (token++)->size; k2 > 0; k2--) {
+              gltfString key = NOM_STR(json, token);
+              if (STR_EQ(key, "attributes")) {
+                for (int a = (token++)->size; a > 0; a--) {
+                  gltfString name = NOM_STR(json, token);
+                  uint32_t index = NOM_U32(json, token);
+                  if (STR_EQ(name, "POSITION")) vertexCount = accessors[index].count;
+                  else if (STR_EQ(name, "JOINTS_0")) hasJoints = true;
+                }
+              } else if (STR_EQ(key, "indices")) {
+                uint32_t index = NOM_U32(json, token);
+                model->indexCount += accessors[index].count;
+                model->indexSize = MAX(model->indexSize, typeSizes[accessors[index].type]);
+              } else if (p == 0 && STR_EQ(key, "targets")) {
+                blendShapeCount = token->size;
+                token = NOM(token);
+              } else {
+                token = NOM(token);
+              }
+            }
+            model->vertexCount += vertexCount;
+            model->skinnedVertexCount += hasJoints ? vertexCount : 0;
+            model->blendedVertexCount += vertexCount * blendShapeCount;
+            model->animatedVertexCount += (hasJoints || blendShapeCount > 0) ? vertexCount : 0;
+            model->blendShapeCount += blendShapeCount;
+          }
+        } else if (STR_EQ(key, "extras")) {
           for (int k2 = (token++)->size; k2 > 0; k2--) {
             gltfString key = NOM_STR(json, token);
-            if (STR_EQ(key, "attributes")) {
-              for (int a = (token++)->size; a > 0; a--) {
-                gltfString name = NOM_STR(json, token);
-                uint32_t index = NOM_U32(json, token);
-                if (STR_EQ(name, "POSITION")) vertexCount = accessors[index].count;
-                else if (STR_EQ(name, "JOINTS_0")) hasJoints = true;
+            if (STR_EQ(key, "targetNames")) {
+              for (int j = (token++)->size; j > 0; j--) {
+                model->charCount += token->end - token->start + 1;
+                token++;
               }
-            } else if (STR_EQ(key, "indices")) {
-              uint32_t index = NOM_U32(json, token);
-              model->indexCount += accessors[index].count;
-              model->indexSize = MAX(model->indexSize, typeSizes[accessors[index].type]);
-            } else if (p == 0 && STR_EQ(key, "targets")) {
-              model->blendShapeCount += token->size;
-              token = NOM(token);
             } else {
               token = NOM(token);
             }
           }
-          model->vertexCount += vertexCount;
-          model->skinnedVertexCount += hasJoints ? vertexCount : 0;
-          model->blendedVertexCount += vertexCount * blendShapeCount;
-          model->animatedVertexCount += (hasJoints || blendShapeCount > 0) ? vertexCount : 0;
+        } else {
+          token = NOM(token);
         }
-      } else if (STR_EQ(key, "extras")) {
-        for (int k2 = (token++)->size; k2 > 0; k2--) {
-          gltfString key = NOM_STR(json, token);
-          if (STR_EQ(key, "targetNames")) {
-            for (int j = (token++)->size; j > 0; j--) {
-              model->charCount += token->end - token->start + 1;
-              token++;
-            }
-          } else {
-            token = NOM(token);
-          }
-        }
-      } else {
-        token = NOM(token);
       }
     }
+  }
+
+  // Count keyframes
+  for (uint32_t i = 0; i < animationSamplerCount; i++) {
+    gltfAccessor* times = &accessors[animationSamplers[i].input];
+    gltfAccessor* values = &accessors[animationSamplers[i].output];
+    model->keyframeDataCount += times->count;
+    model->keyframeDataCount += values->count * values->components;
   }
 
   // We only support a single root node, so if there is more than one root node in the scene then
@@ -817,6 +828,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     int channelIndex = 0;
     int baseSampler = 0;
     jsmntok_t* token = info.animations;
+    float* keyframeData = model->keyframeData;
     ModelAnimation* animation = model->animations;
     for (int i = (token++)->size; i > 0; i--, animation++) {
       int samplerCount = 0;
@@ -828,17 +840,25 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           channelIndex += animation->channelCount;
           for (uint32_t j = 0; j < animation->channelCount; j++) {
             ModelAnimationChannel* channel = &animation->channels[j];
-            //ModelAttribute* times = NULL;
-            //ModelAttribute* data = NULL;
 
             for (int k2 = (token++)->size; k2 > 0; k2--) {
               gltfString key = NOM_STR(json, token);
               if (STR_EQ(key, "sampler")) {
                 gltfAnimationSampler* sampler = animationSamplers + baseSampler + NOM_U32(json, token);
-                //times = &model->attributes[sampler->input];
-                //data = &model->attributes[sampler->output];
-                //channel->smoothing = sampler->smoothing;
-                //channel->keyframeCount = times->count;
+
+                gltfAccessor* times = &accessors[sampler->input];
+                channel->times = keyframeData;
+                copyAttribute(keyframeData, times, F32, 1, false, 0, 4, times->count, 0);
+                animation->duration = MAX(animation->duration, channel->times[times->count - 1]);
+                keyframeData += times->count;
+
+                gltfAccessor* values = &accessors[sampler->output];
+                channel->data = keyframeData;
+                copyAttribute(keyframeData, values, F32, values->components, false, 0, values->components * 4, values->count, 0);
+                keyframeData += values->count * values->components;
+
+                channel->smoothing = sampler->smoothing;
+                channel->keyframeCount = times->count;
               } else if (STR_EQ(key, "target")) {
                 for (int k3 = (token++)->size; k3 > 0; k3--) {
                   gltfString key = NOM_STR(json, token);
@@ -858,23 +878,6 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 token = NOM(token);
               }
             }
-
-            /*
-            lovrAssertGoto(fail, times, "Missing keyframe times");
-            lovrAssertGoto(fail, data, "Missing keyframe data");
-
-            ModelBuffer* buffer;
-            buffer = &model->buffers[times->buffer];
-            lovrAssertGoto(fail, times->type == F32 && (buffer->stride == 0 || buffer->stride == sizeof(float)), "Keyframe times must be tightly-packed floats");
-            channel->times = (float*) (buffer->data + times->offset);
-
-            buffer = &model->buffers[data->buffer];
-            uint8_t components = data->components;
-            lovrAssertGoto(fail, data->type == F32 && (buffer->stride == 0 || buffer->stride == sizeof(float) * components), "Keyframe data must be tightly-packed floats");
-            channel->data = (float*) (buffer->data + data->offset);
-
-            animation->duration = MAX(animation->duration, channel->times[channel->keyframeCount - 1]);
-            */
           }
         } else if (STR_EQ(key, "samplers")) {
           samplerCount = token->size;
@@ -967,12 +970,13 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     void* indexData = model->indices;
     SkinData* skinData = model->skinData;
     BlendData* blendData = model->blendData;
-    uint32_t blendShapeIndex = 0;
+    ModelBlendShape* blendShapes = model->blendShapes;
     for (int i = (token++)->size; i > 0; i--, mesh++) {
-      uint32_t drawStart = 0;
       mesh->primitives = primitive;
-      mesh->blendShapes = mesh->blendShapeCount > 0 ? model->blendShapes + blendShapeIndex : NULL;
-      blendShapeIndex += model->blendShapeCount;
+      mesh->vertices = vertices;
+      mesh->indices = indexData;
+      mesh->blendData = blendData;
+      mesh->blendShapes = blendShapes;
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "primitives")) {
@@ -1037,7 +1041,18 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
             if (positions) {
               uint32_t vertexCount = positions->count;
 
-              mesh->vertices = vertices;
+              if (indices) {
+                if (model->indexSize == 4) {
+                  primitive->start = (uint32_t*) indexData - (uint32_t*) model->indices;
+                } else {
+                  primitive->start = (uint16_t*) indexData - (uint16_t*) model->indices;
+                }
+                primitive->count = indices->count;
+              } else {
+                primitive->start = vertices - model->vertices;
+                primitive->count = vertexCount;
+              }
+
               copyAttribute(vertices, positions, F32, 3, false, 0, sizeof(ModelVertex), vertexCount, 0);
               copyAttribute(vertices, normals, SN10x3, 1, false, 12, sizeof(ModelVertex), vertexCount, 0);
               copyAttribute(vertices, uvs, F32, 2, false, 16, sizeof(ModelVertex), vertexCount, 0);
@@ -1046,21 +1061,19 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               vertices += vertexCount;
 
               if (indices) {
-                mesh->indices = indexData;
                 int type = model->indexSize == 4 ? U32 : U16;
                 copyAttribute(indexData, indices, type, 1, false, 0, model->indexSize, indices->count, 0);
                 indexData = (char*) indexData + (indices->count * model->indexSize);
               }
 
               if (joints && weights) {
-                mesh->skinData = skinData;
+                mesh->skinData = mesh->skinData ? mesh->skinData : skinData;
                 copyAttribute(skinData, joints, U8, 4, false, 0, sizeof(SkinData), vertexCount, 0);
                 copyAttribute(skinData, weights, U8, 4, true, 4, sizeof(SkinData), vertexCount, 0);
                 skinData += vertexCount;
               }
 
-              if (mesh->blendShapeCount > 0) {
-                mesh->blendData = blendData;
+              if (blendPositions) {
                 for (uint32_t b = 0; b < mesh->blendShapeCount; b++) {
                   copyAttribute(blendData, blendPositions, F32, 3, false, 0, sizeof(BlendData), vertexCount, 0);
                   copyAttribute(blendData, blendNormals, F32, 3, false, 12, sizeof(BlendData), vertexCount, 0);
@@ -1069,8 +1082,6 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 }
               }
 
-              primitive->start = drawStart;
-              primitive->count = indices ? indices->count : vertexCount;
               primitive->vertexCount = vertexCount;
               primitive->indexCount = indices ? indices->count : 0;
               primitive->bounds[0] = (positions->min[0] + positions->max[0]) / 2.f;
@@ -1079,7 +1090,9 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               primitive->bounds[3] = (positions->max[0] - positions->min[0]) / 2.f;
               primitive->bounds[4] = (positions->max[1] - positions->min[1]) / 2.f;
               primitive->bounds[5] = (positions->max[2] - positions->min[2]) / 2.f;
-              drawStart += primitive->count;
+
+              mesh->vertexCount += vertexCount;
+              mesh->indexCount += indices ? indices->count : 0;
               mesh->primitiveCount++;
             }
           }
@@ -1097,7 +1110,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 gltfString name = NOM_STR(json, token);
                 uint64_t hash = hash64(name.data, name.length);
                 if (map_get(model->blendShapeMap, hash) == MAP_NIL) {
-                  map_set(model->blendShapeMap, hash, blendShapeIndex + index);
+                  map_set(model->blendShapeMap, hash, mesh->blendShapes - model->blendShapes + index);
                 }
                 memcpy(model->chars, name.data, name.length);
                 mesh->blendShapes[index].name = model->chars;
@@ -1110,6 +1123,8 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
         } else {
           token = NOM(token);
         }
+
+        blendShapes += mesh->blendShapeCount;
       }
     }
   }
@@ -1194,7 +1209,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
         if (STR_EQ(key, "inverseBindMatrices")) {
           gltfAccessor* accessor = &accessors[NOM_U32(json, token)];
           skin->inverseBindMatrices = inverseBindMatrices;
-          memcpy(skin->inverseBindMatrices, accessor, accessor->count * 16 * sizeof(float));
+          memcpy(skin->inverseBindMatrices, accessor->data, accessor->count * 16 * sizeof(float));
           inverseBindMatrices += accessor->count * 16;
         } else if (STR_EQ(key, "joints")) {
           skin->joints = &model->joints[jointIndex];

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -285,11 +285,11 @@ static size_t typeSizes[] = {
   [SN10x3] = 4
 };
 
-void copyAttribute(void* dst, gltfAccessor* accessor, ComponentType type, uint32_t components, bool normalized, size_t offset, size_t stride, uint32_t count, uint8_t clear) {
+void copyAttribute(void* destination, gltfAccessor* accessor, ComponentType type, uint32_t components, bool normalized, size_t offset, size_t stride, uint32_t count, uint8_t clear) {
   char* src = accessor ? accessor->data : NULL;
   size_t size = components * typeSizes[type];
   size_t srcStride = accessor && accessor->stride ? accessor->stride : size;
-  dst = (char*) dst + offset;
+  char* dst = (char*) destination + offset;
 
   if (!src) {
     if (stride == size) {

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -1113,12 +1113,12 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 skinDataOffset += vertexCount;
               }
 
-              part->bounds[0] = (positions->min[0] + positions->max[0]) / 2.f;
-              part->bounds[1] = (positions->min[1] + positions->max[1]) / 2.f;
-              part->bounds[2] = (positions->min[2] + positions->max[2]) / 2.f;
-              part->bounds[3] = (positions->max[0] - positions->min[0]) / 2.f;
-              part->bounds[4] = (positions->max[1] - positions->min[1]) / 2.f;
-              part->bounds[5] = (positions->max[2] - positions->min[2]) / 2.f;
+              part->bounds[0] = positions->min[0];
+              part->bounds[1] = positions->max[0];
+              part->bounds[2] = positions->min[1];
+              part->bounds[3] = positions->max[1];
+              part->bounds[4] = positions->min[2];
+              part->bounds[5] = positions->max[2];
               mesh->partCount++;
               part++;
             }

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -975,13 +975,13 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     uint32_t blendDataOffset = 0;
     uint32_t blendShapeIndex = 0;
     ModelBlendShape* blendShapes = model->blendShapes;
-    for (int i = (token++)->size; i > 0; i--) {
+    for (int i = (token++)->size; i > 0; i--, mesh++) {
       mesh->parts = part;
       mesh->blendShapes = blendShapes;
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "primitives")) {
-          for (uint32_t j = (token++)->size; j > 0; j--, mesh++) {
+          for (uint32_t j = (token++)->size; j > 0; j--, part++) {
             gltfAccessor* positions = NULL;
             gltfAccessor* normals = NULL;
             gltfAccessor* uvs = NULL;
@@ -1120,7 +1120,6 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               part->bounds[4] = positions->min[2];
               part->bounds[5] = positions->max[2];
               mesh->partCount++;
-              part++;
             }
           }
         } else if (STR_EQ(key, "weights")) {

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -35,18 +35,37 @@ typedef struct {
   uint32_t type;
 } gltfChunkHeader;
 
+typedef enum { I8, U8, I16, U16, I32, U32, F32, SN10x3 } ComponentType;
+
+typedef struct {
+  uint32_t blob;
+  size_t offset;
+  size_t size;
+  size_t stride;
+  char* data;
+} gltfBufferView;
+
+typedef struct {
+  char* data;
+  size_t stride;
+  uint32_t bufferView;
+  uint32_t offset;
+  uint32_t count;
+  ComponentType type;
+  uint32_t components;
+  bool normalized;
+  bool matrix;
+  bool hasMin;
+  bool hasMax;
+  float min[4];
+  float max[4];
+} gltfAccessor;
+
 typedef struct {
   uint32_t input;
   uint32_t output;
   SmoothMode smoothing;
 } gltfAnimationSampler;
-
-typedef struct {
-  uint32_t primitiveIndex;
-  uint32_t primitiveCount;
-  uint32_t blendShapeIndex;
-  uint32_t blendShapeCount;
-} gltfMesh;
 
 typedef struct {
   uint32_t bufferView;
@@ -165,14 +184,14 @@ static jsmntok_t* nomTexture(const char* json, jsmntok_t* token, uint32_t* image
   return token;
 }
 
-static bool loadImage(ModelData* model, gltfImage* images, uint32_t index, ModelDataIO* io, char* filename, size_t maxLength) {
+static bool loadImage(ModelData* model, gltfBufferView* buffers, gltfImage* images, uint32_t index, ModelDataIO* io, char* filename, size_t maxLength) {
   if (model->images[index]) {
     return true; // Already loaded
   }
 
   gltfImage* image = &images[index];
   if (image->bufferView != ~0u) {
-    ModelBuffer* buffer = &model->buffers[image->bufferView];
+    gltfBufferView* buffer = &buffers[image->bufferView];
     Blob* blob = lovrBlobCreate(buffer->data, buffer->size, NULL);
     model->images[index] = lovrImageCreateFromFile(blob);
     blob->data = NULL; // XXX Blob data ownership
@@ -201,6 +220,128 @@ static bool loadImage(ModelData* model, gltfImage* images, uint32_t index, Model
   }
 
   return !!model->images[index];
+}
+
+static size_t typeSizes[] = {
+  [I8] = 1,
+  [U8] = 1,
+  [I16] = 2,
+  [U16] = 2,
+  [I32] = 4,
+  [U32] = 4,
+  [F32] = 4,
+  [SN10x3] = 4
+};
+
+void copyAttribute(void* dst, gltfAccessor* accessor, ComponentType type, uint32_t components, bool normalized, size_t offset, size_t stride, uint32_t count, uint8_t clear) {
+  char* src = accessor ? accessor->data : NULL;
+  size_t size = components * typeSizes[type];
+  size_t srcStride = accessor && accessor->stride ? accessor->stride : size;
+  dst = (char*) dst + offset;
+
+  if (!src) {
+    if (stride == size) {
+      memset(dst, clear, count * size);
+    } else {
+      for (uint32_t i = 0; i < count; i++, dst += stride) {
+        memset(dst, clear, size);
+      }
+    }
+  } else if (accessor->type == type && accessor->components == components && accessor->normalized == normalized && srcStride == stride && stride == size) {
+    memcpy(dst, src, count * stride);
+  } else if (accessor->type == type && accessor->components >= components) {
+    for (uint32_t i = 0; i < count; i++, src += srcStride, dst += stride) {
+      memcpy(dst, src, size);
+    }
+  } else if (type == F32) {
+    if (accessor->type == U8 && accessor->normalized) {
+      for (uint32_t i = 0; i < count; i++, src += srcStride, dst += stride) {
+        for (uint32_t j = 0; j < components; j++) {
+          ((float*) dst)[j] = ((uint8_t*) src)[j] / 255.f;
+        }
+      }
+    } else if (accessor->type == U16 && accessor->normalized) {
+      for (uint32_t i = 0; i < count; i++, src += srcStride, dst += stride) {
+        for (uint32_t j = 0; j < components; j++) {
+          ((float*) dst)[j] = ((uint16_t*) src)[j] / 65535.f;
+        }
+      }
+    } else {
+      lovrUnreachable();
+    }
+  } else if (type == U8) {
+    if (accessor->type == U16 && accessor->normalized && normalized) {
+      for (uint32_t i = 0; i < count; i++, src += srcStride, dst += stride) {
+        for (uint32_t j = 0; j < components; j++) {
+          ((uint8_t*) dst)[j] = ((uint16_t*) src)[j] >> 8;
+        }
+        if (components == 4 && accessor->components == 3) {
+          ((uint8_t*) dst)[3] = 255;
+        }
+      }
+    } else if (accessor->type == U16 && !accessor->normalized && !normalized) {
+      for (uint32_t i = 0; i < count; i++, src += srcStride, dst += stride) {
+        for (uint32_t j = 0; j < components; j++) {
+          ((uint8_t*) dst)[j] = (uint8_t) ((uint16_t*) src)[j];
+        }
+      }
+    } else if (accessor->type == I16 && !accessor->normalized && !normalized) {
+      for (uint32_t i = 0; i < count; i++, src += srcStride, dst += stride) {
+        for (uint32_t j = 0; j < components; j++) {
+          ((uint8_t*) dst)[j] = (uint8_t) ((int16_t*) src)[j];
+        }
+      }
+    } else if (accessor->type == F32 && normalized) {
+      for (uint32_t i = 0; i < count; i++, src += srcStride, dst += stride) {
+        for (uint32_t j = 0; j < components; j++) {
+          ((uint8_t*) dst)[j] = ((float*) src)[j] * 255.f + .5f;
+        }
+        if (components == 4 && accessor->components == 3) {
+          ((uint8_t*) dst)[3] = 255;
+        }
+      }
+    } else {
+      lovrUnreachable();
+    }
+  } else if (type == U16 && components == 1 && !normalized && !accessor->normalized) {
+    if (accessor->type == U8) {
+      for (uint32_t i = 0; i < count; i++, src += srcStride, dst += stride) {
+        *((uint16_t*) dst) = *(uint8_t*) src;
+      }
+    } else {
+      lovrUnreachable();
+    }
+  } else if (type == U32 && components == 1 && !normalized && !accessor->normalized) {
+    if (accessor->type == U8) {
+      for (uint32_t i = 0; i < count; i++, src += srcStride, dst += stride) {
+        *((uint32_t*) dst) = *(uint8_t*) src;
+      }
+    } else if (accessor->type == U16) {
+      for (uint32_t i = 0; i < count; i++, src += srcStride, dst += stride) {
+        *((uint32_t*) dst) = *(uint16_t*) src;
+      }
+    } else {
+      lovrUnreachable();
+    }
+  } else if (type == SN10x3) {
+    if (accessor->type == F32) {
+      for (uint32_t i = 0; i < count; i++, src += srcStride, dst += stride) {
+        float x = ((float*) src)[0];
+        float y = ((float*) src)[1];
+        float z = ((float*) src)[2];
+        float w = accessor->components == 4 ? ((float*) src)[3] : 0.f;
+        *(uint32_t*) dst =
+          ((((uint32_t) (int32_t) (x * 511.f)) & 0x3ff) <<  0) |
+          ((((uint32_t) (int32_t) (y * 511.f)) & 0x3ff) << 10) |
+          ((((uint32_t) (int32_t) (z * 511.f)) & 0x3ff) << 20) |
+          ((((uint32_t) (int32_t) (w * 2.f)) & 0x003) << 30);
+      }
+    } else {
+      lovrUnreachable();
+    }
+  } else {
+    lovrUnreachable();
+  }
 }
 
 bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
@@ -281,10 +422,10 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   // record the locations of tokens that we'll use later to fill in the memory once it's allocated.
 
   struct {
-    jsmntok_t* animations;
-    jsmntok_t* attributes;
     jsmntok_t* buffers;
     jsmntok_t* bufferViews;
+    jsmntok_t* accessors;
+    jsmntok_t* animations;
     jsmntok_t* materials;
     jsmntok_t* meshes;
     jsmntok_t* nodes;
@@ -295,8 +436,10 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
 
   memset(&info, 0, sizeof(info));
 
+  Blob** blobs = NULL;
+  gltfBufferView* buffers = NULL;
+  gltfAccessor* accessors = NULL;
   gltfAnimationSampler* animationSamplers = NULL;
-  gltfMesh* meshes = NULL;
   gltfImage* images = NULL;
   gltfTexture* textures = NULL;
   gltfScene* scenes = NULL;
@@ -306,9 +449,51 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     gltfString key = NOM_STR(json, token);
 
     if (STR_EQ(key, "accessors")) {
-      info.attributes = token;
-      model->attributeCount = token->size;
-      token = NOM(token);
+      info.accessors = token;
+      accessors = lovrCalloc(token->size * sizeof(gltfAccessor));
+      gltfAccessor* accessor = accessors;
+      for (int i = (token++)->size; i > 0; i--, accessor++) {
+        for (int k = (token++)->size; k > 0; k--) {
+          gltfString key = NOM_STR(json, token);
+          if (STR_EQ(key, "bufferView")) { accessor->bufferView = NOM_U32(json, token); }
+          else if (STR_EQ(key, "count")) { accessor->count = NOM_U32(json, token); }
+          else if (STR_EQ(key, "byteOffset")) { accessor->offset = NOM_U32(json, token); }
+          else if (STR_EQ(key, "normalized")) { accessor->normalized = NOM_BOOL(json, token); }
+          else if (STR_EQ(key, "componentType")) {
+            switch (NOM_U32(json, token)) {
+              case 5120: accessor->type = I8; break;
+              case 5121: accessor->type = U8; break;
+              case 5122: accessor->type = I16; break;
+              case 5123: accessor->type = U16; break;
+              case 5125: accessor->type = U32; break;
+              case 5126: accessor->type = F32; break;
+              default: break;
+            }
+          } else if (STR_EQ(key, "type")) {
+            gltfString type = NOM_STR(json, token);
+            if (STR_EQ(type, "SCALAR")) {
+              accessor->components = 1;
+            } else if (type.length == 4) {
+              accessor->components = type.data[3] - '0';
+              accessor->matrix = type.data[0] == 'M';
+            }
+          } else if (STR_EQ(key, "min") && token->size <= 4) {
+            int n = (token++)->size;
+            accessor->hasMin = true;
+            for (int j = 0; j < n && j < 4; j++) {
+              accessor->min[j] = NOM_FLOAT(json, token);
+            }
+          } else if (STR_EQ(key, "max") && token->size <= 4) {
+            int n = (token++)->size;
+            accessor->hasMax = true;
+            for (int j = 0; j < n && j < 4; j++) {
+              accessor->max[j] = NOM_FLOAT(json, token);
+            }
+          } else {
+            token = NOM(token);
+          }
+        }
+      }
 
     } else if (STR_EQ(key, "animations")){
       info.animations = token;
@@ -360,12 +545,12 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
 
     } else if (STR_EQ(key, "buffers")) {
       info.buffers = token;
-      model->blobCount = token->size;
+      blobs = lovrCalloc(token->size * sizeof(Blob*));
       token = NOM(token);
 
     } else if (STR_EQ(key, "bufferViews")) {
       info.bufferViews = token;
-      model->bufferCount = token->size;
+      buffers = lovrCalloc(token->size * sizeof(gltfBufferView));
       token = NOM(token);
 
     } else if (STR_EQ(key, "images")) {
@@ -432,51 +617,8 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
 
     } else if (STR_EQ(key, "meshes")) {
       info.meshes = token;
-      meshes = lovrMalloc(token->size * sizeof(gltfMesh));
-      gltfMesh* mesh = meshes;
-      model->primitiveCount = 0;
-      model->blendShapeCount = 0;
-      for (int i = (token++)->size; i > 0; i--, mesh++) {
-        mesh->primitiveCount = 0;
-        mesh->blendShapeCount = 0;
-        for (int k = (token++)->size; k > 0; k--) {
-          gltfString key = NOM_STR(json, token);
-          if (STR_EQ(key, "primitives")) {
-            mesh->primitiveIndex = model->primitiveCount;
-            mesh->primitiveCount = token->size;
-            model->primitiveCount += token->size;
-            // Gotta look at targets of a primitive to truly know blend shape situation :')
-            for (int p = (token++)->size; p > 0; p--) {
-              for (int k2 = (token++)->size; k2 > 0; k2--) {
-                gltfString key = NOM_STR(json, token);
-                if (STR_EQ(key, "targets")) {
-                  if (p == 1) {
-                    mesh->blendShapeIndex = model->blendShapeCount;
-                    mesh->blendShapeCount = token->size;
-                    model->blendShapeCount += token->size;
-                  }
-                  model->blendDataCount += token->size;
-                }
-                token = NOM(token);
-              }
-            }
-          } else if (STR_EQ(key, "extras")) {
-            for (int k2 = (token++)->size; k2 > 0; k2--) {
-              gltfString key = NOM_STR(json, token);
-              if (STR_EQ(key, "targetNames")) {
-                for (int j = (token++)->size; j > 0; j--) {
-                  model->charCount += token->end - token->start + 1;
-                  token++;
-                }
-              } else {
-                token = NOM(token);
-              }
-            }
-          } else {
-            token = NOM(token);
-          }
-        }
-      }
+      model->meshCount = token->size;
+      token = NOM(token);
 
     } else if (STR_EQ(key, "nodes")) {
       info.nodes = token;
@@ -517,13 +659,70 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
       for (int i = (token++)->size; i > 0; i--) {
         for (int k = (token++)->size; k > 0; k--) {
           gltfString key = NOM_STR(json, token);
-          if (STR_EQ(key, "joints")) { model->jointCount += token->size; }
+          if (STR_EQ(key, "joints")) {
+            model->jointCount += token->size;
+            lovrAssertGoto(fail, token->size < 256, "Currently the max number of joints per skin is 256");
+          }
           token = NOM(token);
         }
       }
 
     } else {
       token = NOM(token);
+    }
+  }
+
+  // Iterate over meshes and tally up vertex/index/blendshape counts (now that we have accessors)
+  jsmntok_t* token = info.meshes;
+  for (int i = (token++)->size; i > 0 ; i--) {
+    for (int k = (token++)->size; k > 0; k--) {
+      gltfString key = NOM_STR(json, token);
+      if (STR_EQ(key, "primitives")) {
+        model->primitiveCount += token->size;
+        for (int p = (token++)->size; p > 0; p--) {
+          uint32_t vertexCount = 0;
+          uint32_t blendShapeCount = 0;
+          bool hasJoints = false;
+          for (int k2 = (token++)->size; k2 > 0; k2--) {
+            gltfString key = NOM_STR(json, token);
+            if (STR_EQ(key, "attributes")) {
+              for (int a = (token++)->size; a > 0; a--) {
+                gltfString name = NOM_STR(json, token);
+                uint32_t index = NOM_U32(json, token);
+                if (STR_EQ(name, "POSITION")) vertexCount = accessors[index].count;
+                else if (STR_EQ(name, "JOINTS_0")) hasJoints = true;
+              }
+            } else if (STR_EQ(key, "indices")) {
+              uint32_t index = NOM_U32(json, token);
+              model->indexCount += accessors[index].count;
+              model->indexSize = MAX(model->indexSize, typeSizes[accessors[index].type]);
+            } else if (p == 0 && STR_EQ(key, "targets")) {
+              model->blendShapeCount += token->size;
+              token = NOM(token);
+            } else {
+              token = NOM(token);
+            }
+          }
+          model->vertexCount += vertexCount;
+          model->skinnedVertexCount += hasJoints ? vertexCount : 0;
+          model->blendedVertexCount += vertexCount * blendShapeCount;
+          model->animatedVertexCount += (hasJoints || blendShapeCount > 0) ? vertexCount : 0;
+        }
+      } else if (STR_EQ(key, "extras")) {
+        for (int k2 = (token++)->size; k2 > 0; k2--) {
+          gltfString key = NOM_STR(json, token);
+          if (STR_EQ(key, "targetNames")) {
+            for (int j = (token++)->size; j > 0; j--) {
+              model->charCount += token->end - token->start + 1;
+              token++;
+            }
+          } else {
+            token = NOM(token);
+          }
+        }
+      } else {
+        token = NOM(token);
+      }
     }
   }
 
@@ -538,9 +737,9 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   lovrModelDataAllocate(model);
 
   // Blobs
-  if (model->blobCount > 0) {
+  if (info.buffers) {
     jsmntok_t* token = info.buffers;
-    Blob** blob = model->blobs;
+    Blob** blob = blobs;
     for (int i = (token++)->size; i > 0; i--, blob++) {
       gltfString uri;
       memset(&uri, 0, sizeof(uri));
@@ -578,10 +777,10 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     }
   }
 
-  // Buffers
-  if (model->bufferCount > 0) {
+  // Buffer views
+  if (info.bufferViews) {
     jsmntok_t* token = info.bufferViews;
-    ModelBuffer* buffer = model->buffers;
+    gltfBufferView* buffer = buffers;
     for (int i = (token++)->size; i > 0; i--, buffer++) {
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
@@ -592,7 +791,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
         else { token = NOM(token); }
       }
 
-      Blob* blob = model->blobs[buffer->blob];
+      Blob* blob = blobs[buffer->blob];
 
       // If this is the glb binary data, increment the offset to account for the file header
       if (glb && blob == source) {
@@ -603,51 +802,13 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     }
   }
 
-  // Attributes
-  if (model->attributeCount > 0) {
-    jsmntok_t* token = info.attributes;
-    ModelAttribute* attribute = model->attributes;
-    for (int i = (token++)->size; i > 0; i--, attribute++) {
-      for (int k = (token++)->size; k > 0; k--) {
-        gltfString key = NOM_STR(json, token);
-        if (STR_EQ(key, "bufferView")) { attribute->buffer = NOM_U32(json, token); }
-        else if (STR_EQ(key, "count")) { attribute->count = NOM_U32(json, token); }
-        else if (STR_EQ(key, "byteOffset")) { attribute->offset = NOM_U32(json, token); }
-        else if (STR_EQ(key, "normalized")) { attribute->normalized = NOM_BOOL(json, token); }
-        else if (STR_EQ(key, "componentType")) {
-          switch (NOM_U32(json, token)) {
-            case 5120: attribute->type = I8; break;
-            case 5121: attribute->type = U8; break;
-            case 5122: attribute->type = I16; break;
-            case 5123: attribute->type = U16; break;
-            case 5125: attribute->type = U32; break;
-            case 5126: attribute->type = F32; break;
-            default: break;
-          }
-        } else if (STR_EQ(key, "type")) {
-          gltfString type = NOM_STR(json, token);
-          if (STR_EQ(type, "SCALAR")) {
-            attribute->components = 1;
-          } else if (type.length == 4) {
-            attribute->components = type.data[3] - '0';
-            attribute->matrix = type.data[0] == 'M';
-          }
-        } else if (STR_EQ(key, "min") && token->size <= 4) {
-          int count = (token++)->size;
-          attribute->hasMin = true;
-          for (int j = 0; j < count; j++) {
-            attribute->min[j] = NOM_FLOAT(json, token);
-          }
-        } else if (STR_EQ(key, "max") && token->size <= 4) {
-          int count = (token++)->size;
-          attribute->hasMax = true;
-          for (int j = 0; j < count; j++) {
-            attribute->max[j] = NOM_FLOAT(json, token);
-          }
-        } else {
-          token = NOM(token);
-        }
-      }
+  // Accessors
+  if (info.accessors) {
+    for (uint32_t i = 0; i < info.accessors->size; i++) {
+      gltfAccessor* accessor = &accessors[i];
+      gltfBufferView* buffer = &buffers[accessor->bufferView];
+      accessors[i].data = buffer->data + accessor->offset;
+      accessors[i].stride = buffer->stride ? buffer->stride : (typeSizes[accessor->type] * accessor->components);
     }
   }
 
@@ -667,17 +828,17 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           channelIndex += animation->channelCount;
           for (uint32_t j = 0; j < animation->channelCount; j++) {
             ModelAnimationChannel* channel = &animation->channels[j];
-            ModelAttribute* times = NULL;
-            ModelAttribute* data = NULL;
+            //ModelAttribute* times = NULL;
+            //ModelAttribute* data = NULL;
 
             for (int k2 = (token++)->size; k2 > 0; k2--) {
               gltfString key = NOM_STR(json, token);
               if (STR_EQ(key, "sampler")) {
                 gltfAnimationSampler* sampler = animationSamplers + baseSampler + NOM_U32(json, token);
-                times = &model->attributes[sampler->input];
-                data = &model->attributes[sampler->output];
-                channel->smoothing = sampler->smoothing;
-                channel->keyframeCount = times->count;
+                //times = &model->attributes[sampler->input];
+                //data = &model->attributes[sampler->output];
+                //channel->smoothing = sampler->smoothing;
+                //channel->keyframeCount = times->count;
               } else if (STR_EQ(key, "target")) {
                 for (int k3 = (token++)->size; k3 > 0; k3--) {
                   gltfString key = NOM_STR(json, token);
@@ -698,6 +859,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               }
             }
 
+            /*
             lovrAssertGoto(fail, times, "Missing keyframe times");
             lovrAssertGoto(fail, data, "Missing keyframe data");
 
@@ -712,6 +874,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
             channel->data = (float*) (buffer->data + data->offset);
 
             animation->duration = MAX(animation->duration, channel->times[channel->keyframeCount - 1]);
+            */
           }
         } else if (STR_EQ(key, "samplers")) {
           samplerCount = token->size;
@@ -735,27 +898,6 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     jsmntok_t* token = info.materials;
     ModelMaterial* material = model->materials;
     for (int i = (token++)->size; i > 0; i--, material++) {
-      memcpy(material->color, (float[4]) { 1.f, 1.f, 1.f, 1.f }, 16);
-      memcpy(material->glow, (float[4]) { 0.f, 0.f, 0.f, 1.f }, 16);
-      material->uvShift[0] = 0.f;
-      material->uvShift[1] = 0.f;
-      material->uvScale[0] = 1.f;
-      material->uvScale[1] = 1.f;
-      material->metalness = 1.f;
-      material->roughness = 1.f;
-      material->clearcoat = 0.f;
-      material->clearcoatRoughness = 0.f;
-      material->occlusionStrength = 1.f;
-      material->normalScale = 1.f;
-      material->alphaCutoff = 0.f;
-      material->texture = ~0u;
-      material->glowTexture = ~0u;
-      material->metalnessTexture = ~0u;
-      material->roughnessTexture = ~0u;
-      material->clearcoatTexture = ~0u;
-      material->occlusionTexture = ~0u;
-      material->normalTexture = ~0u;
-
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "pbrMetallicRoughness")) {
@@ -769,7 +911,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               material->color[3] = NOM_FLOAT(json, token);
             } else if (STR_EQ(key, "baseColorTexture")) {
               token = nomTexture(json, token, &material->texture, textures, material);
-              if (!loadImage(model, images, material->texture, io, filename, maxPathLength)) goto fail;
+              if (!loadImage(model, buffers, images, material->texture, io, filename, maxPathLength)) goto fail;
               *root = '\0';
             } else if (STR_EQ(key, "metallicFactor")) {
               material->metalness = NOM_FLOAT(json, token);
@@ -777,7 +919,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               material->roughness = NOM_FLOAT(json, token);
             } else if (STR_EQ(key, "metallicRoughnessTexture")) {
               token = nomTexture(json, token, &material->metalnessTexture, textures, NULL);
-              if (!loadImage(model, images, material->metalnessTexture, io, filename, maxPathLength)) goto fail;
+              if (!loadImage(model, buffers, images, material->metalnessTexture, io, filename, maxPathLength)) goto fail;
               material->roughnessTexture = material->metalnessTexture;
               *root = '\0';
             } else {
@@ -786,15 +928,15 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           }
         } else if (STR_EQ(key, "normalTexture")) {
           token = nomTexture(json, token, &material->normalTexture, textures, NULL);
-          if (!loadImage(model, images, material->normalTexture, io, filename, maxPathLength)) goto fail;
+          if (!loadImage(model, buffers, images, material->normalTexture, io, filename, maxPathLength)) goto fail;
           *root = '\0';
         } else if (STR_EQ(key, "occlusionTexture")) {
           token = nomTexture(json, token, &material->occlusionTexture, textures, NULL);
-          if (!loadImage(model, images, material->occlusionTexture, io, filename, maxPathLength)) goto fail;
+          if (!loadImage(model, buffers, images, material->occlusionTexture, io, filename, maxPathLength)) goto fail;
           *root = '\0';
         } else if (STR_EQ(key, "emissiveTexture")) {
           token = nomTexture(json, token, &material->glowTexture, textures, NULL);
-          if (!loadImage(model, images, material->glowTexture, io, filename, maxPathLength)) goto fail;
+          if (!loadImage(model, buffers, images, material->glowTexture, io, filename, maxPathLength)) goto fail;
           *root = '\0';
         } else if (STR_EQ(key, "emissiveFactor")) {
           token++; // Enter array
@@ -816,27 +958,40 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     }
   }
 
-  // Primitives
-  if (model->primitiveCount > 0) {
-    gltfMesh* mesh = meshes;
+  // Meshes
+  if (model->meshCount > 0) {
     jsmntok_t* token = info.meshes;
-    ModelBlendData* blendData = model->blendData;
+    ModelMesh* mesh = model->meshes;
     ModelPrimitive* primitive = model->primitives;
+    ModelVertex* vertices = model->vertices;
+    void* indexData = model->indices;
+    SkinData* skinData = model->skinData;
+    BlendData* blendData = model->blendData;
+    uint32_t blendShapeIndex = 0;
     for (int i = (token++)->size; i > 0; i--, mesh++) {
+      uint32_t drawStart = 0;
+      mesh->primitives = primitive;
+      mesh->blendShapes = mesh->blendShapeCount > 0 ? model->blendShapes + blendShapeIndex : NULL;
+      blendShapeIndex += model->blendShapeCount;
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "primitives")) {
           for (uint32_t j = (token++)->size; j > 0; j--, primitive++) {
-            primitive->mode = DRAW_TRIANGLE_LIST;
-            primitive->material = ~0u;
+            gltfAccessor* positions = NULL;
+            gltfAccessor* normals = NULL;
+            gltfAccessor* uvs = NULL;
+            gltfAccessor* colors = NULL;
+            gltfAccessor* tangents = NULL;
+            gltfAccessor* indices = NULL;
+            gltfAccessor* joints = NULL;
+            gltfAccessor* weights = NULL;
+            gltfAccessor* blendPositions = NULL;
+            gltfAccessor* blendNormals = NULL;
+            gltfAccessor* blendTangents = NULL;
 
             for (int k2 = (token++)->size; k2 > 0; k2--) {
               gltfString key = NOM_STR(json, token);
-              if (STR_EQ(key, "material")) {
-                primitive->material = NOM_U32(json, token);
-              } else if (STR_EQ(key, "indices")) {
-                primitive->indices = &model->attributes[NOM_U32(json, token)];
-              } else if (STR_EQ(key, "mode")) {
+              if (STR_EQ(key, "mode")) {
                 switch (NOM_U32(json, token)) {
                   case 0: primitive->mode = DRAW_POINT_LIST; break;
                   case 1: primitive->mode = DRAW_LINE_LIST; break;
@@ -849,54 +1004,103 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 }
               } else if (STR_EQ(key, "attributes")) {
                 for (int a = (token++)->size; a > 0; a--) {
-                  DefaultAttribute attributeType = ~0;
                   gltfString name = NOM_STR(json, token);
-                  uint32_t attributeIndex = NOM_U32(json, token);
-                  if (STR_EQ(name, "POSITION")) { attributeType = ATTR_POSITION; }
-                  else if (STR_EQ(name, "NORMAL")) { attributeType = ATTR_NORMAL; }
-                  else if (STR_EQ(name, "TEXCOORD_0")) { attributeType = ATTR_UV; }
-                  else if (STR_EQ(name, "COLOR_0")) { attributeType = ATTR_COLOR; }
-                  else if (STR_EQ(name, "TANGENT")) { attributeType = ATTR_TANGENT; }
-                  else if (STR_EQ(name, "JOINTS_0")) { attributeType = ATTR_JOINTS; }
-                  else if (STR_EQ(name, "WEIGHTS_0")) { attributeType = ATTR_WEIGHTS; }
-                  if (attributeType != (DefaultAttribute) ~0) {
-                    primitive->attributes[attributeType] = &model->attributes[attributeIndex];
-                  }
+                  uint32_t accessor = NOM_U32(json, token);
+                  if (STR_EQ(name, "POSITION")) positions = &accessors[accessor];
+                  else if (STR_EQ(name, "NORMAL")) normals = &accessors[accessor];
+                  else if (STR_EQ(name, "TEXCOORD_0")) uvs = &accessors[accessor];
+                  else if (STR_EQ(name, "COLOR_0")) colors = &accessors[accessor];
+                  else if (STR_EQ(name, "TANGENT")) tangents = &accessors[accessor];
+                  else if (STR_EQ(name, "JOINTS_0")) joints = &accessors[accessor];
+                  else if (STR_EQ(name, "WEIGHTS_0")) weights = &accessors[accessor];
                 }
+              } else if (STR_EQ(key, "indices")) {
+                indices = &accessors[NOM_U32(json, token)];
               } else if (STR_EQ(key, "targets")) {
-                primitive->blendShapes = blendData;
-                primitive->blendShapeCount = token->size;
-                for (int t = (token++)->size; t > 0; t--, blendData++) {
+                mesh->blendShapeCount = token->size;
+                for (int t = (token++)->size; t > 0; t--) {
                   for (int a = (token++)->size; a > 0; a--) {
                     gltfString name = NOM_STR(json, token);
-                    ModelAttribute* attribute = &model->attributes[NOM_U32(json, token)];
-                    if (STR_EQ(name, "POSITION")) { blendData->positions = attribute; }
-                    else if (STR_EQ(name, "NORMAL")) { blendData->normals = attribute; }
-                    else if (STR_EQ(name, "TANGENT")) { blendData->tangents = attribute; }
+                    uint32_t accessor = NOM_U32(json, token);
+                    if (STR_EQ(name, "POSITION")) blendPositions = &accessors[accessor];
+                    else if (STR_EQ(name, "NORMAL")) blendNormals = &accessors[accessor];
+                    else if (STR_EQ(name, "TANGENT")) blendTangents = &accessors[accessor];
                   }
                 }
+              } else if (STR_EQ(key, "material")) {
+                primitive->material = NOM_U32(json, token);
               } else {
                 token = NOM(token);
               }
             }
+
+            if (positions) {
+              uint32_t vertexCount = positions->count;
+
+              mesh->vertices = vertices;
+              copyAttribute(vertices, positions, F32, 3, false, 0, sizeof(ModelVertex), vertexCount, 0);
+              copyAttribute(vertices, normals, SN10x3, 1, false, 12, sizeof(ModelVertex), vertexCount, 0);
+              copyAttribute(vertices, uvs, F32, 2, false, 16, sizeof(ModelVertex), vertexCount, 0);
+              copyAttribute(vertices, colors, U8, 4, true, 24, sizeof(ModelVertex), vertexCount, 0xff);
+              copyAttribute(vertices, tangents, SN10x3, 1, false, 28, sizeof(ModelVertex), vertexCount, 0);
+              vertices += vertexCount;
+
+              if (indices) {
+                mesh->indices = indexData;
+                int type = model->indexSize == 4 ? U32 : U16;
+                copyAttribute(indexData, indices, type, 1, false, 0, model->indexSize, indices->count, 0);
+                indexData = (char*) indexData + (indices->count * model->indexSize);
+              }
+
+              if (joints && weights) {
+                mesh->skinData = skinData;
+                copyAttribute(skinData, joints, U8, 4, false, 0, sizeof(SkinData), vertexCount, 0);
+                copyAttribute(skinData, weights, U8, 4, true, 4, sizeof(SkinData), vertexCount, 0);
+                skinData += vertexCount;
+              }
+
+              if (mesh->blendShapeCount > 0) {
+                mesh->blendData = blendData;
+                for (uint32_t b = 0; b < mesh->blendShapeCount; b++) {
+                  copyAttribute(blendData, blendPositions, F32, 3, false, 0, sizeof(BlendData), vertexCount, 0);
+                  copyAttribute(blendData, blendNormals, F32, 3, false, 12, sizeof(BlendData), vertexCount, 0);
+                  copyAttribute(blendData, blendTangents, F32, 3, false, 24, sizeof(BlendData), vertexCount, 0);
+                  blendData += vertexCount;
+                }
+              }
+
+              primitive->start = drawStart;
+              primitive->count = indices ? indices->count : vertexCount;
+              primitive->vertexCount = vertexCount;
+              primitive->indexCount = indices ? indices->count : 0;
+              primitive->bounds[0] = (positions->min[0] + positions->max[0]) / 2.f;
+              primitive->bounds[1] = (positions->min[1] + positions->max[1]) / 2.f;
+              primitive->bounds[2] = (positions->min[2] + positions->max[2]) / 2.f;
+              primitive->bounds[3] = (positions->max[0] - positions->min[0]) / 2.f;
+              primitive->bounds[4] = (positions->max[1] - positions->min[1]) / 2.f;
+              primitive->bounds[5] = (positions->max[2] - positions->min[2]) / 2.f;
+              drawStart += primitive->count;
+              mesh->primitiveCount++;
+            }
           }
         } else if (STR_EQ(key, "weights")) {
           lovrAssertGoto(fail, (uint32_t) token->size == mesh->blendShapeCount, "Inconsistent blend shape counts");
-          for (int w = (token++)->size, index = mesh->blendShapeIndex; w > 0; w--, index++) {
-            model->blendShapes[index].weight = NOM_FLOAT(json, token);
+          for (int w = (token++)->size, index = 0; w > 0; w--, index++) {
+            mesh->blendShapes[index].weight = NOM_FLOAT(json, token);
           }
         } else if (STR_EQ(key, "extras")) {
           for (int k2 = (token++)->size; k2 > 0; k2--) {
             gltfString key = NOM_STR(json, token);
             if (STR_EQ(key, "targetNames")) {
               lovrAssertGoto(fail, (uint32_t) token->size == mesh->blendShapeCount, "Inconsistent blend shape counts");
-              for (int k3 = (token++)->size, index = mesh->blendShapeIndex; k3 > 0; k3--, index++) {
+              for (int k3 = (token++)->size, index = 0; k3 > 0; k3--, index++) {
                 gltfString name = NOM_STR(json, token);
                 uint64_t hash = hash64(name.data, name.length);
                 if (map_get(model->blendShapeMap, hash) == MAP_NIL) {
-                  map_set(model->blendShapeMap, hash, index);
+                  map_set(model->blendShapeMap, hash, blendShapeIndex + index);
                 }
                 memcpy(model->chars, name.data, name.length);
+                mesh->blendShapes[index].name = model->chars;
                 model->chars += name.length + 1;
               }
             } else {
@@ -912,51 +1116,27 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
 
   // Nodes
   if (model->nodeCount > 0) {
-    for (uint32_t i = 0; i < model->nodeCount; i++) {
-      ModelNode* node = &model->nodes[i];
-      node->child = ~0u;
-      node->sibling = ~0u;
-      node->parent = ~0u;
-    }
-
     jsmntok_t* token = info.nodes;
     ModelNode* node = model->nodes;
     for (int i = (token++)->size; i > 0; i--, node++) {
-      uint32_t nodeIndex = node - model->nodes;
-      float* translation = node->transform.translation;
-      float* rotation = node->transform.rotation;
-      float* scale = node->transform.scale;
-      memcpy(translation, (float[3]) { 0.f, 0.f, 0.f }, 3 * sizeof(float));
-      memcpy(rotation, (float[4]) { 0.f, 0.f, 0.f, 1.f }, 4 * sizeof(float));
-      memcpy(scale, (float[3]) { 1.f, 1.f, 1.f }, 3 * sizeof(float));
-      node->hasMatrix = false;
-      node->skin = ~0u;
-
       jsmntok_t* weights = NULL;
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "mesh")) {
-          gltfMesh* mesh = &meshes[NOM_U32(json, token)];
-          node->primitiveIndex = mesh->primitiveIndex;
-          node->primitiveCount = mesh->primitiveCount;
-          node->blendShapeIndex = mesh->blendShapeIndex;
-          node->blendShapeCount = mesh->blendShapeCount;
-          for (uint32_t i = 0, index = node->blendShapeIndex; i < node->blendShapeCount; i++, index++) {
-            model->blendShapes[index].node = nodeIndex;
-          }
-        } else if (STR_EQ(key, "weights")) {
-          weights = token; // Deferred due to order dependency
+          node->mesh = NOM_U32(json, token);
         } else if (STR_EQ(key, "skin")) {
           node->skin = NOM_U32(json, token);
+        } else if (STR_EQ(key, "weights")) {
+          weights = token; // Deferred due to order dependency
         } else if (STR_EQ(key, "children")) {
           uint32_t childCount = (token++)->size;
           node->child = NOM_U32(json, token);
-          model->nodes[node->child].parent = nodeIndex;
+          model->nodes[node->child].parent = node - model->nodes;
           uint32_t prevChild = node->child;
           for (uint32_t j = 1; j < childCount; j++) {
             uint32_t child = NOM_U32(json, token);
             model->nodes[prevChild].sibling = child;
-            model->nodes[child].parent = nodeIndex;
+            model->nodes[child].parent = node - model->nodes;
             prevChild = child;
           }
         } else if (STR_EQ(key, "matrix")) {
@@ -967,20 +1147,20 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           }
         } else if (STR_EQ(key, "translation")) {
           lovrAssertGoto(fail, (token++)->size == 3, "Node translation needs 3 elements");
-          translation[0] = NOM_FLOAT(json, token);
-          translation[1] = NOM_FLOAT(json, token);
-          translation[2] = NOM_FLOAT(json, token);
+          node->transform.translation[0] = NOM_FLOAT(json, token);
+          node->transform.translation[1] = NOM_FLOAT(json, token);
+          node->transform.translation[2] = NOM_FLOAT(json, token);
         } else if (STR_EQ(key, "rotation")) {
           lovrAssertGoto(fail, (token++)->size == 4, "Node rotation needs 4 elements");
-          rotation[0] = NOM_FLOAT(json, token);
-          rotation[1] = NOM_FLOAT(json, token);
-          rotation[2] = NOM_FLOAT(json, token);
-          rotation[3] = NOM_FLOAT(json, token);
+          node->transform.rotation[0] = NOM_FLOAT(json, token);
+          node->transform.rotation[1] = NOM_FLOAT(json, token);
+          node->transform.rotation[2] = NOM_FLOAT(json, token);
+          node->transform.rotation[3] = NOM_FLOAT(json, token);
         } else if (STR_EQ(key, "scale")) {
           lovrAssertGoto(fail, (token++)->size == 3, "Node scale needs 3 elements");
-          scale[0] = NOM_FLOAT(json, token);
-          scale[1] = NOM_FLOAT(json, token);
-          scale[2] = NOM_FLOAT(json, token);
+          node->transform.scale[0] = NOM_FLOAT(json, token);
+          node->transform.scale[1] = NOM_FLOAT(json, token);
+          node->transform.scale[2] = NOM_FLOAT(json, token);
         } else if (STR_EQ(key, "name")) {
           gltfString name = NOM_STR(json, token);
           map_set(model->nodeMap, hash64(name.data, name.length), node - model->nodes);
@@ -992,10 +1172,11 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
         }
       }
 
-      if (node->blendShapeCount > 0 && weights) {
-        lovrAssertGoto(fail, (uint32_t) weights->size == node->blendShapeCount, "Inconsistent blend shape counts");
-        for (int w = (weights++)->size, index = node->blendShapeIndex; w > 0; w--, index++) {
-          model->blendShapes[index].weight = NOM_FLOAT(json, token);
+      if (weights && node->mesh != ~0u) {
+        ModelMesh* mesh = &model->meshes[node->mesh];
+        lovrAssertGoto(fail, (uint32_t) weights->size == mesh->blendShapeCount, "Inconsistent blend shape counts");
+        for (int w = (weights++)->size, index = 0; w > 0; w--, index++) {
+          mesh->blendShapes[index].weight = NOM_FLOAT(json, token);
         }
       }
     }
@@ -1006,13 +1187,15 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     int jointIndex = 0;
     jsmntok_t* token = info.skins;
     ModelSkin* skin = model->skins;
+    float* inverseBindMatrices = model->inverseBindMatrices;
     for (int i = (token++)->size; i > 0; i--, skin++) {
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "inverseBindMatrices")) {
-          ModelAttribute* attribute = &model->attributes[NOM_U32(json, token)];
-          ModelBuffer* buffer = &model->buffers[attribute->buffer];
-          skin->inverseBindMatrices = (float*) ((uint8_t*) buffer->data + attribute->offset);
+          gltfAccessor* accessor = &accessors[NOM_U32(json, token)];
+          skin->inverseBindMatrices = inverseBindMatrices;
+          memcpy(skin->inverseBindMatrices, accessor, accessor->count * 16 * sizeof(float));
+          inverseBindMatrices += accessor->count * 16;
         } else if (STR_EQ(key, "joints")) {
           skin->joints = &model->joints[jointIndex];
           skin->jointCount = (token++)->size;
@@ -1068,8 +1251,14 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
     model->rootNode = scenes[rootScene].node;
   }
 
+  for (int i = 0; i < info.buffers->size; i++) {
+    lovrRelease(blobs[i], lovrBlobDestroy);
+  }
+
+  lovrFree(blobs);
+  lovrFree(buffers);
+  lovrFree(accessors);
   lovrFree(animationSamplers);
-  lovrFree(meshes);
   lovrFree(images);
   lovrFree(textures);
   lovrFree(scenes);
@@ -1078,8 +1267,13 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   return true;
 
 fail:
-  lovrFree(animationSamplers);
-  lovrFree(meshes);
+  for (int i = 0; i < info.buffers->size; i++) {
+    lovrRelease(blobs[i], lovrBlobDestroy);
+  }
+
+  lovrFree(blobs);
+  lovrFree(buffers);
+  lovrFree(accessors);
   lovrFree(images);
   lovrFree(textures);
   lovrFree(scenes);

--- a/src/modules/data/modelData_gltf.c
+++ b/src/modules/data/modelData_gltf.c
@@ -464,11 +464,8 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   }
 
   ModelData* model = lovrCalloc(sizeof(ModelData));
+  ModelMetadata* meta = &model->meta;
   model->ref = 1;
-
-  model->metadata = lovrMalloc(jsonLength);
-  memcpy(model->metadata, json, jsonLength);
-  model->metadataSize = jsonLength;
 
   // Prepass: Basically we iterate over the tokens once and figure out how much memory we need and
   // record the locations of tokens that we'll use later to fill in the memory once it's allocated.
@@ -493,10 +490,13 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   gltfAccessor* accessors = NULL;
   gltfAnimationSampler* animationSamplers = NULL;
   gltfImage* images = NULL;
+  ImageJob* imageJobs = NULL;
   gltfTexture* textures = NULL;
   gltfScene* scenes = NULL;
   int animationSamplerCount = 0;
   int rootScene = 0;
+
+  meta->commentLength = jsonLength;
 
   for (jsmntok_t* token = tokens + 1; token < tokens + tokenCount;) {
     gltfString key = NOM_STR(json, token);
@@ -550,15 +550,15 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
 
     } else if (STR_EQ(key, "animations")){
       info.animations = token;
-      model->animationCount = token->size;
+      meta->animationCount = token->size;
       jsmntok_t* t = token;
       for (int i = (t++)->size; i > 0; i--) {
         if (t->size > 0) {
           for (int k = (t++)->size; k > 0; k--) {
             gltfString key = NOM_STR(json, t);
-            if (STR_EQ(key, "channels")) { model->channelCount += t->size; }
+            if (STR_EQ(key, "channels")) { meta->channelCount += t->size; }
             else if (STR_EQ(key, "samplers")) { animationSamplerCount += t->size; }
-            else if (STR_EQ(key, "name")) { model->charCount += t->end - t->start + 1; }
+            else if (STR_EQ(key, "name")) { meta->charCount += t->end - t->start + 1; }
             t = NOM(t);
           }
         }
@@ -606,8 +606,9 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
       token = NOM(token);
 
     } else if (STR_EQ(key, "images")) {
-      model->imageCount = token->size;
-      images = lovrMalloc(model->imageCount * sizeof(gltfImage));
+      meta->imageCount = token->size;
+      images = lovrMalloc(meta->imageCount * sizeof(gltfImage));
+      imageJobs = lovrCalloc(meta->imageCount * sizeof(ImageJob));
       gltfImage* image = images;
       for (int i = (token++)->size; i > 0; i--, image++) {
         image->bufferView = ~0u;
@@ -658,28 +659,28 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
 
     } else if (STR_EQ(key, "materials")) {
       info.materials = token;
-      model->materialCount = token->size;
+      meta->materialCount = token->size;
       for (int i = (token++)->size; i > 0; i--) {
         for (int k = (token++)->size; k > 0; k--) {
           gltfString key = NOM_STR(json, token);
-          if (STR_EQ(key, "name")) { model->charCount += token->end - token->start + 1; }
+          if (STR_EQ(key, "name")) { meta->charCount += token->end - token->start + 1; }
           token = NOM(token);
         }
       }
 
     } else if (STR_EQ(key, "meshes")) {
       info.meshes = token;
-      model->meshCount = token->size;
+      meta->meshCount = token->size;
       token = NOM(token);
 
     } else if (STR_EQ(key, "nodes")) {
       info.nodes = token;
-      model->nodeCount = token->size;
+      meta->nodeCount = token->size;
       for (int i = (token++)->size; i > 0; i--) {
         if (token->size > 0) {
           for (int k = (token++)->size; k > 0; k--) {
             gltfString key = NOM_STR(json, token);
-            if (STR_EQ(key, "name")) { model->charCount += token->end - token->start + 1; }
+            if (STR_EQ(key, "name")) { meta->charCount += token->end - token->start + 1; }
             token = NOM(token);
           }
         }
@@ -707,12 +708,12 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
 
     } else if (STR_EQ(key, "skins")) {
       info.skins = token;
-      model->skinCount = token->size;
+      meta->skinCount = token->size;
       for (int i = (token++)->size; i > 0; i--) {
         for (int k = (token++)->size; k > 0; k--) {
           gltfString key = NOM_STR(json, token);
           if (STR_EQ(key, "joints")) {
-            model->jointCount += token->size;
+            meta->jointCount += token->size;
             lovrAssertGoto(fail, token->size < 256, "Currently the max number of joints per skin is 256");
           }
           token = NOM(token);
@@ -732,7 +733,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "primitives")) {
-          model->partCount += token->size;
+          meta->partCount += token->size;
           for (int p = (token++)->size; p > 0; p--) {
             uint32_t vertexCount = 0;
             bool hasJoints = false;
@@ -747,8 +748,8 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 }
               } else if (STR_EQ(key, "indices")) {
                 uint32_t index = NOM_U32(json, token);
-                model->indexCount += accessors[index].count;
-                model->indexSize = MAX(model->indexSize, typeSizes[accessors[index].type]);
+                meta->indexCount += accessors[index].count;
+                meta->indexSize = MAX(meta->indexSize, typeSizes[accessors[index].type]);
               } else if (STR_EQ(key, "targets")) {
                 lovrAssertGoto(fail, blendShapeCount == 0 || blendShapeCount == token->size, "Model has inconsistent blend shape counts");
                 blendShapeCount = token->size;
@@ -757,10 +758,10 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
                 token = NOM(token);
               }
             }
-            model->vertexCount += vertexCount;
-            model->skinnedVertexCount += hasJoints ? vertexCount : 0;
-            model->blendedVertexCount += vertexCount * blendShapeCount;
-            model->animatedVertexCount += (hasJoints || blendShapeCount > 0) ? vertexCount : 0;
+            meta->vertexCount += vertexCount;
+            meta->skinnedVertexCount += hasJoints ? vertexCount : 0;
+            meta->blendedVertexCount += vertexCount * blendShapeCount;
+            meta->animatedVertexCount += (hasJoints || blendShapeCount > 0) ? vertexCount : 0;
           }
         } else if (STR_EQ(key, "extras")) {
           for (int k2 = (token++)->size; k2 > 0; k2--) {
@@ -769,7 +770,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               lovrAssertGoto(fail, blendShapeCount == 0 || blendShapeCount == token->size, "Model has inconsistent blend shape counts");
               blendShapeCount = token->size;
               for (int j = (token++)->size; j > 0; j--) {
-                model->charCount += token->end - token->start + 1;
+                meta->charCount += token->end - token->start + 1;
                 token++;
               }
             } else {
@@ -780,7 +781,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           token = NOM(token);
         }
       }
-      model->blendShapeCount += blendShapeCount;
+      meta->blendShapeCount += blendShapeCount;
     }
   }
 
@@ -788,21 +789,21 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   for (uint32_t i = 0; i < animationSamplerCount; i++) {
     gltfAccessor* times = &accessors[animationSamplers[i].input];
     gltfAccessor* values = &accessors[animationSamplers[i].output];
-    model->keyframeDataCount += times->count;
-    model->keyframeDataCount += values->count * values->components;
+    meta->keyframeDataCount += times->count;
+    meta->keyframeDataCount += values->count * values->components;
   }
 
   // We only support a single root node, so if there is more than one root node in the scene then
   // we create a fake "super root" node and add all the scene's root nodes as its children.
   if (info.sceneCount > 0 && scenes[rootScene].nodeCount > 1) {
-    model->nodeCount++;
+    meta->nodeCount++;
   }
 
   // Allocate memory, then revisit all of the tokens that were recorded during the prepass and write
   // their data into this memory.
   lovrModelDataAllocate(model);
 
-  ImageJob* imageJobs = lovrCalloc(model->imageCount * sizeof(ImageJob));
+  memcpy(meta->comment, json, jsonLength);
 
   // Blobs
   if (info.buffers) {
@@ -881,19 +882,19 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   }
 
   // Animations
-  if (model->animationCount > 0) {
+  if (meta->animationCount > 0) {
     int channelIndex = 0;
     int baseSampler = 0;
     jsmntok_t* token = info.animations;
-    float* keyframeData = model->keyframeData;
-    ModelAnimation* animation = model->animations;
+    float* keyframeData = meta->keyframeData;
+    ModelAnimation* animation = meta->animations;
     for (int i = (token++)->size; i > 0; i--, animation++) {
       int samplerCount = 0;
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
         if (STR_EQ(key, "channels")) {
           animation->channelCount = (token++)->size;
-          animation->channels = model->channels + channelIndex;
+          animation->channels = meta->channels + channelIndex;
           channelIndex += animation->channelCount;
           for (uint32_t j = 0; j < animation->channelCount; j++) {
             ModelAnimationChannel* channel = &animation->channels[j];
@@ -941,10 +942,10 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           token = NOM(token);
         } else if (STR_EQ(key, "name")) {
           gltfString name = NOM_STR(json, token);
-          map_set(model->animationMap, hash64(name.data, name.length), animation - model->animations);
-          memcpy(model->chars, name.data, name.length);
-          animation->name = model->chars;
-          model->chars += name.length + 1;
+          meta->animationLookup[animation - meta->animations] = (uint32_t) hash64(name.data, name.length);
+          memcpy(meta->chars, name.data, name.length);
+          animation->name = meta->chars;
+          meta->chars += name.length + 1;
         } else {
           token = NOM(token);
         }
@@ -954,9 +955,9 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   }
 
   // Materials
-  if (model->materialCount > 0) {
+  if (meta->materialCount > 0) {
     jsmntok_t* token = info.materials;
-    ModelMaterial* material = model->materials;
+    ModelMaterial* material = meta->materials;
     for (int i = (token++)->size; i > 0; i--, material++) {
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
@@ -1007,10 +1008,10 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           material->alphaCutoff = NOM_FLOAT(json, token);
         } else if (STR_EQ(key, "name")) {
           gltfString name = NOM_STR(json, token);
-          map_set(model->materialMap, hash64(name.data, name.length), material - model->materials);
-          memcpy(model->chars, name.data, name.length);
-          material->name = model->chars;
-          model->chars += name.length + 1;
+          meta->materialLookup[material - meta->materials] = (uint32_t) hash64(name.data, name.length);
+          memcpy(meta->chars, name.data, name.length);
+          material->name = meta->chars;
+          meta->chars += name.length + 1;
         } else {
           token = NOM(token);
         }
@@ -1019,16 +1020,16 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   }
 
   // Meshes
-  if (model->meshCount > 0) {
+  if (meta->meshCount > 0) {
     jsmntok_t* token = info.meshes;
-    ModelMesh* mesh = model->meshes;
-    ModelPart* part = model->parts;
+    ModelMesh* mesh = meta->meshes;
+    ModelPart* part = meta->parts;
     uint32_t vertexOffset = 0;
     uint32_t indexOffset = 0;
     uint32_t skinDataOffset = 0;
     uint32_t blendDataOffset = 0;
     uint32_t blendShapeIndex = 0;
-    ModelBlendShape* blendShapes = model->blendShapes;
+    ModelBlendShape* blendShapes = meta->blendShapes;
     for (int i = (token++)->size; i > 0; i--, mesh++) {
       mesh->parts = part;
       mesh->blendShapes = blendShapes;
@@ -1130,11 +1131,11 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
               if ((indices && mesh->indexCount == 0) || (!indices && mesh->indexCount > 0)) {
                 uint32_t partIndex = indices ? 0 : part - mesh->parts;
                 uint32_t partCount = indices ? mesh->partCount : 1;
-                void* indexData = (char*) model->indices + (indexOffset * model->indexSize);
+                void* indexData = (char*) model->indices + (indexOffset * meta->indexSize);
 
                 for (uint32_t p = 0; p < partCount; p++) {
                   uint32_t count = mesh->parts[partIndex + p].count;
-                  if (model->indexSize == 4) {
+                  if (meta->indexSize == 4) {
                     for (uint32_t index = 0; index < count; index++) {
                       ((uint32_t*) indexData)[index] = indexOffset + index;
                     }
@@ -1151,9 +1152,9 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
 
               if (indices) {
                 uint32_t indexCount = indices->count;
-                int type = model->indexSize == 4 ? U32 : U16;
-                void* indexData = (char*) model->indices + (indexOffset * model->indexSize);
-                copyAttribute(indexData, indices, type, 1, false, 0, model->indexSize, indexCount, 0);
+                int type = meta->indexSize == 4 ? U32 : U16;
+                void* indexData = (char*) model->indices + (indexOffset * meta->indexSize);
+                copyAttribute(indexData, indices, type, 1, false, 0, meta->indexSize, indexCount, 0);
                 if (mesh->indexOffset == ~0u) mesh->indexOffset = indexOffset;
                 mesh->indexCount += indexCount;
                 indexOffset += indexCount;
@@ -1178,7 +1179,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           }
         } else if (STR_EQ(key, "weights")) {
           for (int w = (token++)->size, index = 0; w > 0; w--, index++) {
-            model->blendShapes[index].weight = NOM_FLOAT(json, token);
+            meta->blendShapes[index].weight = NOM_FLOAT(json, token);
           }
         } else if (STR_EQ(key, "extras")) {
           for (int k2 = (token++)->size; k2 > 0; k2--) {
@@ -1186,13 +1187,11 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
             if (STR_EQ(key, "targetNames")) {
               for (int k3 = (token++)->size, index = 0; k3 > 0; k3--, index++) {
                 gltfString name = NOM_STR(json, token);
-                uint64_t hash = hash64(name.data, name.length);
-                if (map_get(model->blendShapeMap, hash) == MAP_NIL) {
-                  map_set(model->blendShapeMap, hash, mesh->blendShapes - model->blendShapes + index);
-                }
-                memcpy(model->chars, name.data, name.length);
-                mesh->blendShapes[index].name = model->chars;
-                model->chars += name.length + 1;
+                uint32_t hash = (uint32_t) hash64(name.data, name.length);
+                meta->blendShapeLookup[mesh->blendShapes - meta->blendShapes + index] = hash;
+                memcpy(meta->chars, name.data, name.length);
+                mesh->blendShapes[index].name = meta->chars;
+                meta->chars += name.length + 1;
               }
             } else {
               token = NOM(token);
@@ -1208,9 +1207,9 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   }
 
   // Nodes
-  if (model->nodeCount > 0) {
+  if (meta->nodeCount > 0) {
     jsmntok_t* token = info.nodes;
-    ModelNode* node = model->nodes;
+    ModelNode* node = meta->nodes;
     for (int i = (token++)->size; i > 0; i--, node++) {
       jsmntok_t* weights = NULL;
       for (int k = (token++)->size; k > 0; k--) {
@@ -1224,12 +1223,12 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
         } else if (STR_EQ(key, "children")) {
           uint32_t childCount = (token++)->size;
           node->child = NOM_U32(json, token);
-          model->nodes[node->child].parent = node - model->nodes;
+          meta->nodes[node->child].parent = node - meta->nodes;
           uint32_t prevChild = node->child;
           for (uint32_t j = 1; j < childCount; j++) {
             uint32_t child = NOM_U32(json, token);
-            model->nodes[prevChild].sibling = child;
-            model->nodes[child].parent = node - model->nodes;
+            meta->nodes[prevChild].sibling = child;
+            meta->nodes[child].parent = node - meta->nodes;
             prevChild = child;
           }
         } else if (STR_EQ(key, "matrix")) {
@@ -1256,17 +1255,17 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           node->transform.scale[2] = NOM_FLOAT(json, token);
         } else if (STR_EQ(key, "name")) {
           gltfString name = NOM_STR(json, token);
-          map_set(model->nodeMap, hash64(name.data, name.length), node - model->nodes);
-          memcpy(model->chars, name.data, name.length);
-          node->name = model->chars;
-          model->chars += name.length + 1;
+          meta->nodeLookup[node - meta->nodes] = (uint32_t) hash64(name.data, name.length);
+          memcpy(meta->chars, name.data, name.length);
+          node->name = meta->chars;
+          meta->chars += name.length + 1;
         } else {
           token = NOM(token);
         }
       }
 
       if (weights && node->mesh != ~0u) {
-        ModelMesh* mesh = &model->meshes[node->mesh];
+        ModelMesh* mesh = &meta->meshes[node->mesh];
         lovrAssertGoto(fail, (uint32_t) weights->size == mesh->blendShapeCount, "Inconsistent blend shape counts");
         for (int w = (weights++)->size, index = 0; w > 0; w--, index++) {
           mesh->blendShapes[index].weight = NOM_FLOAT(json, token);
@@ -1276,11 +1275,11 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   }
 
   // Skins
-  if (model->skinCount > 0) {
+  if (meta->skinCount > 0) {
     int jointIndex = 0;
     jsmntok_t* token = info.skins;
-    ModelSkin* skin = model->skins;
-    float* inverseBindMatrices = model->inverseBindMatrices;
+    ModelSkin* skin = meta->skins;
+    float* inverseBindMatrices = meta->inverseBindMatrices;
     for (int i = (token++)->size; i > 0; i--, skin++) {
       for (int k = (token++)->size; k > 0; k--) {
         gltfString key = NOM_STR(json, token);
@@ -1290,10 +1289,10 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           memcpy(skin->inverseBindMatrices, accessor->data, accessor->count * 16 * sizeof(float));
           inverseBindMatrices += accessor->count * 16;
         } else if (STR_EQ(key, "joints")) {
-          skin->joints = &model->joints[jointIndex];
+          skin->joints = &meta->joints[jointIndex];
           skin->jointCount = (token++)->size;
           for (uint32_t j = 0; j < skin->jointCount; j++) {
-            model->joints[jointIndex++] = NOM_U32(json, token);
+            meta->joints[jointIndex++] = NOM_U32(json, token);
           }
         } else {
           token = NOM(token);
@@ -1304,10 +1303,10 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
 
   // Scenes
   if (info.sceneCount == 0) {
-    model->rootNode = 0;
+    meta->rootNode = 0;
   } else if (scenes[rootScene].nodeCount > 1) {
-    model->rootNode = model->nodeCount - 1;
-    ModelNode* root = &model->nodes[model->rootNode];
+    meta->rootNode = meta->nodeCount - 1;
+    ModelNode* root = &meta->nodes[meta->rootNode];
     root->skin = ~0u;
 
     float* matrix = root->transform.matrix;
@@ -1324,12 +1323,12 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
           if (STR_EQ(key, "nodes")) {
             uint32_t childCount = (token++)->size;
             root->child = NOM_U32(json, token);
-            model->nodes[root->child].parent = model->rootNode;
+            meta->nodes[root->child].parent = meta->rootNode;
             uint32_t prevChild = root->child;
             for (uint32_t j = 1; j < childCount; j++) {
               uint32_t child = NOM_U32(json, token);
-              model->nodes[prevChild].sibling = child;
-              model->nodes[child].parent = model->rootNode;
+              meta->nodes[prevChild].sibling = child;
+              meta->nodes[child].parent = meta->rootNode;
               prevChild = child;
             }
           } else {
@@ -1341,10 +1340,10 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
       }
     }
   } else {
-    model->rootNode = scenes[rootScene].node;
+    meta->rootNode = scenes[rootScene].node;
   }
 
-  for (uint32_t i = 0; i < model->imageCount; i++) {
+  for (uint32_t i = 0; i < meta->imageCount; i++) {
     ImageJob* task = &imageJobs[i];
 
     if (task->handle) {
@@ -1379,7 +1378,7 @@ bool lovrModelDataInitGltf(ModelData** result, Blob* source, ModelDataIO* io) {
   return true;
 
 fail:
-  for (uint32_t i = 0; i < model->imageCount; i++) {
+  for (uint32_t i = 0; i < meta->imageCount; i++) {
     ImageJob* task = &imageJobs[i];
 
     if (task->handle) {

--- a/src/modules/data/modelData_obj.c
+++ b/src/modules/data/modelData_obj.c
@@ -1,9 +1,9 @@
 #include "data/modelData.h"
 #include "data/blob.h"
 #include "data/image.h"
-#include "core/maf.h"
 #include "util.h"
 #include <stdlib.h>
+#include <string.h>
 #include <float.h>
 
 typedef struct {
@@ -324,37 +324,38 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
 
   model = lovrCalloc(sizeof(ModelData));
   model->ref = 1;
-  model->meshCount = 1;
-  model->vertexCount = vertices.length;
-  model->indexCount = indices.length;
-  model->indexSize = 4;
-  model->partCount = (uint32_t) groups.length;
-  model->nodeCount = 1;
-  model->imageCount = (uint32_t) images.length;
-  model->materialCount = (uint32_t) materials.length;
+
+  ModelMetadata* meta = &model->meta;
+  meta->meshCount = 1;
+  meta->vertexCount = vertices.length;
+  meta->indexCount = indices.length;
+  meta->indexSize = 4;
+  meta->partCount = (uint32_t) groups.length;
+  meta->nodeCount = 1;
+  meta->imageCount = (uint32_t) images.length;
+  meta->materialCount = (uint32_t) materials.length;
+
   lovrModelDataAllocate(model);
 
-  memcpy(model->vertices, vertices.data, model->vertexCount * sizeof(ModelVertex));
-  memcpy(model->indices, indices.data, model->indexCount * sizeof(uint32_t));
+  memcpy(model->vertices, vertices.data, meta->vertexCount * sizeof(ModelVertex));
+  memcpy(model->indices, indices.data, meta->indexCount * sizeof(uint32_t));
 
-  if (model->imageCount > 0) {
-    memcpy(model->images, images.data, model->imageCount * sizeof(Image*));
-    memcpy(model->materials, materials.data, model->materialCount * sizeof(ModelMaterial));
-    memcpy(((map_t*) model->materialMap)->hashes, materialMap.hashes, materialMap.size * sizeof(uint64_t));
-    memcpy(((map_t*) model->materialMap)->values, materialMap.values, materialMap.size * sizeof(uint64_t));
+  if (meta->imageCount > 0) {
+    memcpy(model->images, images.data, meta->imageCount * sizeof(Image*));
+    memcpy(meta->materials, materials.data, meta->materialCount * sizeof(ModelMaterial));
   }
 
   for (size_t i = 0; i < groups.length; i++) {
     objGroup* group = &groups.data[i];
 
-    model->parts[i] = (ModelPart) {
+    meta->parts[i] = (ModelPart) {
       .start = group->start,
       .count = group->count,
       .material = group->material,
       .mode = DRAW_TRIANGLE_LIST
     };
 
-    float* bounds = model->parts[i].bounds;
+    float* bounds = meta->parts[i].bounds;
 
     for (size_t j = group->start; j < group->start + group->count; j++) {
       ModelVertex* vertex = &vertices.data[indices.data[j]];
@@ -367,8 +368,8 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
     }
   }
 
-  model->meshes[0] = (ModelMesh) {
-    .parts = model->parts,
+  meta->meshes[0] = (ModelMesh) {
+    .parts = meta->parts,
     .partCount = groups.length,
     .vertexCount = vertices.length,
     .indexCount = indices.length,
@@ -376,7 +377,7 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
     .blendDataOffset = ~0u
   };
 
-  model->nodes[0].mesh = 0;
+  meta->nodes[0].mesh = 0;
 
 finish:
   arr_free(&groups);

--- a/src/modules/data/modelData_obj.c
+++ b/src/modules/data/modelData_obj.c
@@ -351,8 +351,7 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
       .start = group->start,
       .count = group->count,
       .material = group->material,
-      .mode = DRAW_TRIANGLE_LIST,
-      .bounds = { FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX }
+      .mode = DRAW_TRIANGLE_LIST
     };
 
     float* bounds = model->parts[i].bounds;
@@ -366,14 +365,6 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
       bounds[4] = MIN(bounds[4], vertex->position.z);
       bounds[5] = MAX(bounds[5], vertex->position.z);
     }
-
-    // Convert to center/half-extent representation
-    bounds[0] = (bounds[0] + bounds[3]) / 2.f;
-    bounds[1] = (bounds[1] + bounds[4]) / 2.f;
-    bounds[2] = (bounds[2] + bounds[5]) / 2.f;
-    bounds[3] = (bounds[3] - bounds[0]) / 2.f;
-    bounds[4] = (bounds[4] - bounds[1]) / 2.f;
-    bounds[5] = (bounds[5] - bounds[2]) / 2.f;
   }
 
   model->meshes[0] = (ModelMesh) {

--- a/src/modules/data/modelData_obj.c
+++ b/src/modules/data/modelData_obj.c
@@ -25,6 +25,13 @@ static uint32_t nomu32(char* s, char** end) {
   return n;
 }
 
+uint32_t packNormal(float* v) {
+  return
+    ((((uint32_t) (int32_t) (v[0] * 511.f)) & 0x3ff) <<  0) |
+    ((((uint32_t) (int32_t) (v[1] * 511.f)) & 0x3ff) << 10) |
+    ((((uint32_t) (int32_t) (v[2] * 511.f)) & 0x3ff) << 20);
+}
+
 static bool parseMtl(char* path, char* base, ModelDataIO* io, arr_image_t* images, arr_material_t* materials, map_t* names) {
   size_t size = 0;
   char* p = io(path, &size);
@@ -155,8 +162,8 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
   arr_group_t groups;
   arr_image_t images;
   arr_material_t materials;
-  arr_t(float) vertexBlob;
-  arr_t(int) indexBlob;
+  arr_t(ModelVertex) vertices;
+  arr_t(int) indices;
   map_t materialMap;
   map_t vertexMap;
   arr_t(float) positions;
@@ -167,8 +174,8 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
   arr_init(&images);
   arr_init(&materials);
   map_init(&materialMap, 0);
-  arr_init(&vertexBlob);
-  arr_init(&indexBlob);
+  arr_init(&vertices);
+  arr_init(&indices);
   map_init(&vertexMap, 0);
   arr_init(&positions);
   arr_init(&normals);
@@ -228,8 +235,8 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
 
         // Triangulate faces (triangle fan)
         if (i >= 3) {
-          arr_push(&indexBlob, indexBlob.data[indexBlob.length - (3 * (i - 2))]);
-          arr_push(&indexBlob, indexBlob.data[indexBlob.length - 2]);
+          arr_push(&indices, indices.data[indices.length - (3 * (i - 2))]);
+          arr_push(&indices, indices.data[indices.length - 2]);
           group->count += 2;
         }
 
@@ -237,7 +244,7 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
         uint64_t hash = hash64(s, t - s);
         uint64_t index = map_get(&vertexMap, hash);
         if (index != MAP_NIL) {
-          arr_push(&indexBlob, index);
+          arr_push(&indices, index);
           group->count++;
           s = t;
           continue;
@@ -262,11 +269,21 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
         }
 
         float empty[3] = { 0.f };
-        arr_push(&indexBlob, (int) vertexBlob.length / 8);
-        map_set(&vertexMap, hash, vertexBlob.length / 8);
-        arr_append(&vertexBlob, positions.data + 3 * (v - 1), 3);
-        arr_append(&vertexBlob, vn > 0 ? (normals.data + 3 * (vn - 1)) : empty, 3);
-        arr_append(&vertexBlob, vt > 0 ? (uvs.data + 2 * (vt - 1)) : empty, 2);
+        arr_push(&indices, (int) vertices.length);
+        map_set(&vertexMap, hash, vertices.length);
+
+        float* position = &positions.data[3 * (v - 1)];
+        float* normal = vn > 0 ? &normals.data[3 * (vn - 1)] : empty;
+        float* uv = vt > 0 ? &uvs.data[2 * (vt - 1)] : empty;
+
+        ModelVertex vertex = {
+          .position = { position[0], position[1], position[2] },
+          .normal = packNormal(normal),
+          .uv = { uv[0], uv[1] },
+          .color = { 0xff, 0xff, 0xff, 0xff }
+        };
+
+        arr_push(&vertices, vertex);
         group->count++;
 
         s = t;
@@ -301,123 +318,73 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
     data = newline + 1;
   }
 
-  if (vertexBlob.length == 0 || indexBlob.length == 0) {
+  if (vertices.length == 0 || indices.length == 0) {
     goto finish;
   }
 
   model = lovrCalloc(sizeof(ModelData));
   model->ref = 1;
-  model->blobCount = 2;
-  model->bufferCount = 2;
-  model->attributeCount = 3 + (uint32_t) groups.length;
+  model->meshCount = 1;
+  model->vertexCount = vertices.length;
+  model->indexCount = indices.length;
+  model->indexSize = 4;
   model->primitiveCount = (uint32_t) groups.length;
   model->nodeCount = 1;
   model->imageCount = (uint32_t) images.length;
   model->materialCount = (uint32_t) materials.length;
   lovrModelDataAllocate(model);
 
-  model->blobs[0] = lovrBlobCreate(vertexBlob.data, vertexBlob.length * sizeof(float), "obj vertex data");
-  model->blobs[1] = lovrBlobCreate(indexBlob.data, indexBlob.length * sizeof(int), "obj index data");
-
-  model->buffers[0] = (ModelBuffer) {
-    .blob = 0,
-    .data = model->blobs[0]->data,
-    .size = model->blobs[0]->size,
-    .stride = 8 * sizeof(float)
-  };
-
-  model->buffers[1] = (ModelBuffer) {
-    .blob = 1,
-    .data = model->blobs[1]->data,
-    .size = model->blobs[1]->size,
-    .stride = sizeof(int)
-  };
-
+  memcpy(model->vertices, vertices.data, model->vertexCount * sizeof(ModelVertex));
+  memcpy(model->indices, indices.data, model->indexCount * sizeof(uint32_t));
   memcpy(model->images, images.data, model->imageCount * sizeof(Image*));
   memcpy(model->materials, materials.data, model->materialCount * sizeof(ModelMaterial));
   memcpy(((map_t*) model->materialMap)->hashes, materialMap.hashes, materialMap.size * sizeof(uint64_t));
   memcpy(((map_t*) model->materialMap)->values, materialMap.values, materialMap.size * sizeof(uint64_t));
 
-  float min[4] = { FLT_MAX };
-  float max[4] = { FLT_MIN };
-
-  for (size_t i = 0; i < vertexBlob.length; i += 8) {
-    float* v = vertexBlob.data + i;
-    min[0] = MIN(min[0], v[0]);
-    max[0] = MAX(max[0], v[0]);
-    min[1] = MIN(min[1], v[1]);
-    max[1] = MAX(max[1], v[1]);
-    min[2] = MIN(min[2], v[2]);
-    max[2] = MAX(max[2], v[2]);
-  }
-
-  model->attributes[0] = (ModelAttribute) {
-    .buffer = 0,
-    .offset = 0,
-    .count = (uint32_t) vertexBlob.length / 8,
-    .type = F32,
-    .components = 3,
-    .hasMin = true,
-    .hasMax = true,
-    .min[0] = min[0],
-    .min[1] = min[1],
-    .min[2] = min[2],
-    .max[0] = max[0],
-    .max[1] = max[1],
-    .max[2] = max[2]
-  };
-
-  model->attributes[1] = (ModelAttribute) {
-    .buffer = 0,
-    .offset = 3 * sizeof(float),
-    .count = (uint32_t) vertexBlob.length / 8,
-    .type = F32,
-    .components = 3
-  };
-
-  model->attributes[2] = (ModelAttribute) {
-    .buffer = 0,
-    .offset = 6 * sizeof(float),
-    .count = (uint32_t) vertexBlob.length / 8,
-    .type = F32,
-    .components = 2
-  };
-
   for (size_t i = 0; i < groups.length; i++) {
     objGroup* group = &groups.data[i];
-    model->attributes[3 + i] = (ModelAttribute) {
-      .buffer = 1,
-      .offset = group->start * sizeof(int),
-      .count = group->count,
-      .type = U32,
-      .components = 1
-    };
-  }
 
-  for (size_t i = 0; i < groups.length; i++) {
-    objGroup* group = &groups.data[i];
     model->primitives[i] = (ModelPrimitive) {
       .mode = DRAW_TRIANGLE_LIST,
-      .attributes = {
-        [ATTR_POSITION] = &model->attributes[0],
-        [ATTR_NORMAL] = &model->attributes[1],
-        [ATTR_UV] = &model->attributes[2]
-      },
-      .indices = &model->attributes[3 + i],
-      .material = group->material
+      .start = group->start,
+      .count = group->count,
+      .vertexCount = model->vertexCount,
+      .indexCount = group->count,
+      .material = group->material,
+      .bounds = { FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX }
     };
+
+    float* bounds = model->primitives[i].bounds;
+
+    for (size_t j = group->start; j < group->start + group->count; j++) {
+      ModelVertex* vertex = &vertices.data[indices.data[j]];
+      bounds[0] = MIN(bounds[0], vertex->position.x);
+      bounds[1] = MAX(bounds[1], vertex->position.x);
+      bounds[2] = MIN(bounds[2], vertex->position.y);
+      bounds[3] = MAX(bounds[3], vertex->position.y);
+      bounds[4] = MIN(bounds[4], vertex->position.z);
+      bounds[5] = MAX(bounds[5], vertex->position.z);
+    }
+
+    // Convert to center/half-extent representation
+    bounds[0] = (bounds[0] + bounds[3]) / 2.f;
+    bounds[1] = (bounds[1] + bounds[4]) / 2.f;
+    bounds[2] = (bounds[2] + bounds[5]) / 2.f;
+    bounds[3] = (bounds[3] - bounds[0]) / 2.f;
+    bounds[4] = (bounds[4] - bounds[1]) / 2.f;
+    bounds[5] = (bounds[5] - bounds[2]) / 2.f;
   }
 
-  model->nodes[0] = (ModelNode) {
-    .transform.matrix = MAT4_IDENTITY,
-    .primitiveIndex = 0,
-    .primitiveCount = (uint32_t) groups.length,
-    .child = ~0u,
-    .sibling = ~0u,
-    .parent = ~0u,
-    .skin = ~0u,
-    .hasMatrix = true
+  model->meshes[0] = (ModelMesh) {
+    .primitiveCount = groups.length,
+    .vertexCount = vertices.length,
+    .indexCount = indices.length,
+    .primitives = model->primitives,
+    .vertices = model->vertices,
+    .indices = model->indices
   };
+
+  model->nodes[0].mesh = 0;
 
 finish:
   arr_free(&groups);

--- a/src/modules/data/modelData_obj.c
+++ b/src/modules/data/modelData_obj.c
@@ -328,7 +328,7 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
   model->vertexCount = vertices.length;
   model->indexCount = indices.length;
   model->indexSize = 4;
-  model->primitiveCount = (uint32_t) groups.length;
+  model->partCount = (uint32_t) groups.length;
   model->nodeCount = 1;
   model->imageCount = (uint32_t) images.length;
   model->materialCount = (uint32_t) materials.length;
@@ -336,25 +336,26 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
 
   memcpy(model->vertices, vertices.data, model->vertexCount * sizeof(ModelVertex));
   memcpy(model->indices, indices.data, model->indexCount * sizeof(uint32_t));
-  memcpy(model->images, images.data, model->imageCount * sizeof(Image*));
-  memcpy(model->materials, materials.data, model->materialCount * sizeof(ModelMaterial));
-  memcpy(((map_t*) model->materialMap)->hashes, materialMap.hashes, materialMap.size * sizeof(uint64_t));
-  memcpy(((map_t*) model->materialMap)->values, materialMap.values, materialMap.size * sizeof(uint64_t));
+
+  if (model->imageCount > 0) {
+    memcpy(model->images, images.data, model->imageCount * sizeof(Image*));
+    memcpy(model->materials, materials.data, model->materialCount * sizeof(ModelMaterial));
+    memcpy(((map_t*) model->materialMap)->hashes, materialMap.hashes, materialMap.size * sizeof(uint64_t));
+    memcpy(((map_t*) model->materialMap)->values, materialMap.values, materialMap.size * sizeof(uint64_t));
+  }
 
   for (size_t i = 0; i < groups.length; i++) {
     objGroup* group = &groups.data[i];
 
-    model->primitives[i] = (ModelPrimitive) {
-      .mode = DRAW_TRIANGLE_LIST,
+    model->parts[i] = (ModelPart) {
       .start = group->start,
       .count = group->count,
-      .vertexCount = model->vertexCount,
-      .indexCount = group->count,
       .material = group->material,
+      .mode = DRAW_TRIANGLE_LIST,
       .bounds = { FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX }
     };
 
-    float* bounds = model->primitives[i].bounds;
+    float* bounds = model->parts[i].bounds;
 
     for (size_t j = group->start; j < group->start + group->count; j++) {
       ModelVertex* vertex = &vertices.data[indices.data[j]];
@@ -376,12 +377,12 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
   }
 
   model->meshes[0] = (ModelMesh) {
-    .primitiveCount = groups.length,
+    .parts = model->parts,
+    .partCount = groups.length,
     .vertexCount = vertices.length,
     .indexCount = indices.length,
-    .primitives = model->primitives,
-    .vertices = model->vertices,
-    .indices = model->indices
+    .skinDataOffset = ~0u,
+    .blendDataOffset = ~0u
   };
 
   model->nodes[0].mesh = 0;
@@ -392,6 +393,8 @@ finish:
   arr_free(&materials);
   map_free(&materialMap);
   map_free(&vertexMap);
+  arr_free(&vertices);
+  arr_free(&indices);
   arr_free(&positions);
   arr_free(&normals);
   arr_free(&uvs);
@@ -404,6 +407,8 @@ fail:
   arr_free(&materials);
   map_free(&materialMap);
   map_free(&vertexMap);
+  arr_free(&vertices);
+  arr_free(&indices);
   arr_free(&positions);
   arr_free(&normals);
   arr_free(&uvs);

--- a/src/modules/data/modelData_stl.c
+++ b/src/modules/data/modelData_stl.c
@@ -17,20 +17,19 @@ static bool lovrModelDataInitStlBinary(ModelData** result, Blob* source, ModelDa
 
   ModelData* model = lovrCalloc(sizeof(ModelData));
   model->ref = 1;
-  model->meshCount = 1;
-  model->vertexCount = vertexCount;
-  model->meshCount = 1;
-  model->nodeCount = 1;
+  model->meta.meshCount = 1;
+  model->meta.vertexCount = vertexCount;
+  model->meta.meshCount = 1;
+  model->meta.nodeCount = 1;
 
   lovrModelDataAllocate(model);
 
-  model->meshes[0].vertexOffset = 0;
-  model->meshes[0].vertexCount = vertexCount;
-
-  model->nodes[0].mesh = 0;
+  model->meta.meshes[0].vertexOffset = 0;
+  model->meta.meshes[0].vertexCount = vertexCount;
+  model->meta.nodes[0].mesh = 0;
 
   ModelVertex* vertices = model->vertices;
-  float* bounds = model->parts[0].bounds;
+  float* bounds = model->meta.parts[0].bounds;
 
   for (uint32_t i = 0; i < triangleCount; i++) {
     float* f = (float*) data;

--- a/src/modules/data/modelData_stl.c
+++ b/src/modules/data/modelData_stl.c
@@ -58,14 +58,6 @@ static bool lovrModelDataInitStlBinary(ModelData** result, Blob* source, ModelDa
     data += 50;
   }
 
-  // Convert bounds to center/half-extent representation
-  bounds[0] = (bounds[0] + bounds[3]) / 2.f;
-  bounds[1] = (bounds[1] + bounds[4]) / 2.f;
-  bounds[2] = (bounds[2] + bounds[5]) / 2.f;
-  bounds[3] = (bounds[3] - bounds[0]) / 2.f;
-  bounds[4] = (bounds[4] - bounds[1]) / 2.f;
-  bounds[5] = (bounds[5] - bounds[2]) / 2.f;
-
   *result = model;
   return true;
 }

--- a/src/modules/data/modelData_stl.c
+++ b/src/modules/data/modelData_stl.c
@@ -1,8 +1,8 @@
 #include "data/modelData.h"
 #include "data/blob.h"
-#include "core/maf.h"
 #include "util.h"
 #include <string.h>
+#include <float.h>
 
 static bool lovrModelDataInitStlAscii(ModelData** result, Blob* source, ModelDataIO* io) {
   return lovrSetError("ASCII STL files are not supported yet");
@@ -19,30 +19,18 @@ static bool lovrModelDataInitStlBinary(ModelData** result, Blob* source, ModelDa
   model->ref = 1;
   model->meshCount = 1;
   model->vertexCount = vertexCount;
-  model->primitiveCount = 1;
+  model->meshCount = 1;
   model->nodeCount = 1;
 
   lovrModelDataAllocate(model);
 
-  model->primitives[0] = (ModelPrimitive) {
-    .mode = DRAW_TRIANGLE_LIST,
-    .count = vertexCount,
-    .vertexCount = vertexCount,
-    .material = ~0u,
-    .bounds = { FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX }
-  };
-
-  model->meshes[0] = (ModelMesh) {
-    .primitiveCount = 1,
-    .primitives = model->primitives,
-    .vertexCount = vertexCount,
-    .vertices = model->vertices
-  };
+  model->meshes[0].vertexOffset = 0;
+  model->meshes[0].vertexCount = vertexCount;
 
   model->nodes[0].mesh = 0;
 
   ModelVertex* vertices = model->vertices;
-  float* bounds = model->primitives->bounds;
+  float* bounds = model->parts[0].bounds;
 
   for (uint32_t i = 0; i < triangleCount; i++) {
     float* f = (float*) data;
@@ -67,16 +55,16 @@ static bool lovrModelDataInitStlBinary(ModelData** result, Blob* source, ModelDa
       bounds[5] = MAX(bounds[5], v[j][2]);
     }
 
-    // Convert to center/half-extent representation
-    bounds[0] = (bounds[0] + bounds[3]) / 2.f;
-    bounds[1] = (bounds[1] + bounds[4]) / 2.f;
-    bounds[2] = (bounds[2] + bounds[5]) / 2.f;
-    bounds[3] = (bounds[3] - bounds[0]) / 2.f;
-    bounds[4] = (bounds[4] - bounds[1]) / 2.f;
-    bounds[5] = (bounds[5] - bounds[2]) / 2.f;
-
     data += 50;
   }
+
+  // Convert bounds to center/half-extent representation
+  bounds[0] = (bounds[0] + bounds[3]) / 2.f;
+  bounds[1] = (bounds[1] + bounds[4]) / 2.f;
+  bounds[2] = (bounds[2] + bounds[5]) / 2.f;
+  bounds[3] = (bounds[3] - bounds[0]) / 2.f;
+  bounds[4] = (bounds[4] - bounds[1]) / 2.f;
+  bounds[5] = (bounds[5] - bounds[2]) / 2.f;
 
   *result = model;
   return true;

--- a/src/modules/data/modelData_stl.c
+++ b/src/modules/data/modelData_stl.c
@@ -2,7 +2,6 @@
 #include "data/blob.h"
 #include "core/maf.h"
 #include "util.h"
-#include <stdlib.h>
 #include <string.h>
 
 static bool lovrModelDataInitStlAscii(ModelData** result, Blob* source, ModelDataIO* io) {
@@ -15,50 +14,68 @@ static bool lovrModelDataInitStlBinary(ModelData** result, Blob* source, ModelDa
   char* data = (char*) source->data + 84;
 
   uint32_t vertexCount = triangleCount * 3;
-  size_t vertexBufferSize = vertexCount * 6 * sizeof(float);
-  float* vertices = lovrMalloc(vertexBufferSize);
 
   ModelData* model = lovrCalloc(sizeof(ModelData));
   model->ref = 1;
-  model->blobCount = 1;
-  model->bufferCount = 1;
-  model->attributeCount = 2;
+  model->meshCount = 1;
+  model->vertexCount = vertexCount;
   model->primitiveCount = 1;
   model->nodeCount = 1;
 
   lovrModelDataAllocate(model);
 
-  model->blobs[0] = lovrBlobCreate(vertices, vertexBufferSize, "stl vertex data");
-  model->buffers[0] = (ModelBuffer) { .data = (char*) vertices, .size = vertexBufferSize, .stride = 6 * sizeof(float) };
-  model->attributes[0] = (ModelAttribute) { .count = vertexCount, .components = 3, .type = F32, .offset = 0 * sizeof(float) };
-  model->attributes[1] = (ModelAttribute) { .count = vertexCount, .components = 3, .type = F32, .offset = 3 * sizeof(float) };
   model->primitives[0] = (ModelPrimitive) {
     .mode = DRAW_TRIANGLE_LIST,
+    .count = vertexCount,
+    .vertexCount = vertexCount,
     .material = ~0u,
-    .attributes = {
-      [ATTR_POSITION] = &model->attributes[0],
-      [ATTR_NORMAL] = &model->attributes[1]
-    }
-  };
-  model->nodes[0] = (ModelNode) {
-    .hasMatrix = true,
-    .transform.matrix = MAT4_IDENTITY,
-    .primitiveCount = 1,
-    .child = ~0u,
-    .sibling = ~0u,
-    .parent = ~0u,
-    .skin = ~0u
+    .bounds = { FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX, FLT_MAX, -FLT_MAX }
   };
 
+  model->meshes[0] = (ModelMesh) {
+    .primitiveCount = 1,
+    .primitives = model->primitives,
+    .vertexCount = vertexCount,
+    .vertices = model->vertices
+  };
+
+  model->nodes[0].mesh = 0;
+
+  ModelVertex* vertices = model->vertices;
+  float* bounds = model->primitives->bounds;
+
   for (uint32_t i = 0; i < triangleCount; i++) {
-    memcpy(vertices + 3, data, 12);
-    memcpy(vertices + 9, data, 12);
-    memcpy(vertices + 15, data, 12), data += 12;
-    memcpy(vertices + 0, data, 12), data += 12;
-    memcpy(vertices + 6, data, 12), data += 12;
-    memcpy(vertices + 12, data, 12), data += 12;
-    vertices += 18;
-    data += 2;
+    float* f = (float*) data;
+    float* v[3] = { f + 3, f + 6, f + 9 };
+
+    uint32_t normal =
+      ((((uint32_t) (int32_t) (f[0] * 511.f)) & 0x3ff) <<  0) |
+      ((((uint32_t) (int32_t) (f[1] * 511.f)) & 0x3ff) << 10) |
+      ((((uint32_t) (int32_t) (f[2] * 511.f)) & 0x3ff) << 20);
+
+    for (uint32_t j = 0; j < 3; j++) {
+      *vertices++ = (ModelVertex) {
+        .position = { v[j][0], v[j][1], v[j][2] },
+        .normal = normal,
+        .color = { 0xff, 0xff, 0xff, 0xff }
+      };
+      bounds[0] = MIN(bounds[0], v[j][0]);
+      bounds[1] = MAX(bounds[1], v[j][0]);
+      bounds[2] = MIN(bounds[2], v[j][1]);
+      bounds[3] = MAX(bounds[3], v[j][1]);
+      bounds[4] = MIN(bounds[4], v[j][2]);
+      bounds[5] = MAX(bounds[5], v[j][2]);
+    }
+
+    // Convert to center/half-extent representation
+    bounds[0] = (bounds[0] + bounds[3]) / 2.f;
+    bounds[1] = (bounds[1] + bounds[4]) / 2.f;
+    bounds[2] = (bounds[2] + bounds[5]) / 2.f;
+    bounds[3] = (bounds[3] - bounds[0]) / 2.f;
+    bounds[4] = (bounds[4] - bounds[1]) / 2.f;
+    bounds[5] = (bounds[5] - bounds[2]) / 2.f;
+
+    data += 50;
   }
 
   *result = model;

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4847,15 +4847,21 @@ void lovrMeshGetDrawRange(Mesh* mesh, uint32_t* start, uint32_t* count, uint32_t
   *offset = mesh->baseVertex;
 }
 
-bool lovrMeshSetDrawRange(Mesh* mesh, uint32_t start, uint32_t count, uint32_t offset) {
+bool lovrMeshSetDrawRange(Mesh* mesh, uint32_t start, uint32_t count) {
   uint32_t vertexCount = mesh->vertexBuffer->info.format->length;
   uint32_t extent = mesh->indexCount > 0 ? mesh->indexCount : vertexCount;
   lovrCheck(start < extent && count <= extent - start, "Invalid draw range [%d,%d]", start + 1, start + 1 + count);
-  lovrCheck(offset < vertexCount, "Mesh vertex offset must be less than the vertex count");
   mesh->drawStart = start;
   mesh->drawCount = count;
-  mesh->baseVertex = offset;
   return true;
+}
+
+uint32_t lovrMeshGetBaseVertex(Mesh* mesh) {
+  return mesh->baseVertex;
+}
+
+void lovrMeshSetBaseVertex(Mesh* mesh, uint32_t base) {
+  mesh->baseVertex = base;
 }
 
 Material* lovrMeshGetMaterial(Mesh* mesh) {

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -8154,7 +8154,7 @@ bool lovrPassDrawPart(Pass* pass, Model* model, uint32_t meshIndex, uint32_t par
       .index.buffer = mesh->indexCount > 0 ? model->indexBuffer : NULL,
       .start = (mesh->indexCount > 0 ? mesh->indexOffset : mesh->vertexOffset) + part->start,
       .count = part->count,
-      .baseVertex = mesh->indexOffset + part->baseVertex,
+      .baseVertex = mesh->vertexOffset + part->baseVertex,
       .instances = instances
     };
 

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -68,6 +68,7 @@ typedef struct {
 struct Buffer {
   uint32_t ref;
   uint32_t base;
+  Buffer* root;
   Sync* sync;
   gpu_buffer* gpu;
   bool supportsMesh;
@@ -2095,8 +2096,9 @@ Buffer* lovrBufferCreate(const BufferInfo* info, void** data) {
 
   Buffer* buffer = lovrCalloc(sizeof(Buffer) + gpu_sizeof_buffer() + charCount + fieldCount * sizeof(DataField));
   buffer->ref = 1;
-  buffer->gpu = (gpu_buffer*) (buffer + 1);
+  buffer->root = buffer;
   buffer->sync = lovrCalloc(sizeof(Sync));
+  buffer->gpu = (gpu_buffer*) (buffer + 1);
   buffer->info = *info;
   buffer->info.fieldCount = fieldCount;
   buffer->info.size = size;
@@ -2184,13 +2186,37 @@ Buffer* lovrBufferCreate(const BufferInfo* info, void** data) {
   return buffer;
 }
 
+Buffer* lovrBufferCreateView(Buffer* parent, uint32_t offset, uint32_t extent) {
+  lovrCheck(offset < parent->info.size, "Buffer view byte range exceeds the size of its parent");
+  lovrCheck(extent < parent->info.size - offset , "Buffer view byte range exceeds the size of its parent");
+  lovrCheck(offset % parent->info.format->stride == 0, "Buffer view offset must be a multiple of its stride");
+  lovrCheck(extent % parent->info.format->stride == 0, "Buffer view extent must be a multiple of its stride");
+
+  Buffer* buffer = lovrCalloc(sizeof(Buffer));
+  buffer->ref = 1;
+  buffer->base = parent->base + offset;
+  buffer->root = parent->root;
+  buffer->sync = parent->sync;
+  buffer->gpu = parent->gpu;
+  buffer->supportsMesh = parent->supportsMesh;
+  buffer->info = parent->info;
+  buffer->info.size = extent;
+  lovrRetain(buffer->root);
+
+  return buffer;
+}
+
 void lovrBufferDestroy(void* ref) {
   Buffer* buffer = ref;
-  if (buffer->sync->lastTransferRead == state.tick || buffer->sync->lastTransferWrite == state.tick) {
-    lovrGraphicsSubmit(NULL, 0);
+  if (buffer->root == buffer) {
+    if (buffer->sync->lastTransferRead == state.tick || buffer->sync->lastTransferWrite == state.tick) {
+      lovrGraphicsSubmit(NULL, 0);
+    }
+    gpu_buffer_destroy(buffer->gpu);
+    lovrFree(buffer->sync);
+  } else {
+    lovrRelease(buffer->root, lovrBufferDestroy);
   }
-  gpu_buffer_destroy(buffer->gpu);
-  lovrFree(buffer->sync);
   lovrFree(buffer);
 }
 
@@ -5325,24 +5351,20 @@ Mesh* lovrModelGetMesh(Model* model, uint32_t index) {
   }
 
   if (!model->meshes[index]) {
-    Mesh* mesh = lovrMeshCreate(&(MeshInfo) {
-      .vertexBuffer = model->vertexBuffer,
-      .storage = MESH_GPU
-    }, NULL);
+    ModelMesh* data = &meta->meshes[index];
+    uint32_t offset = data->vertexOffset * sizeof(ModelVertex);
+    uint32_t extent = data->vertexCount * sizeof(ModelVertex);
+    Buffer* vertexBuffer = offset ? lovrBufferCreateView(model->vertexBuffer, offset, extent) : model->vertexBuffer;
+    Mesh* mesh = lovrMeshCreate(&(MeshInfo) { .vertexBuffer = vertexBuffer, .storage = MESH_GPU }, NULL);
 
     if (!mesh) {
       return NULL;
     }
 
-    ModelMesh* data = &meta->meshes[index];
     ModelPart* part = &data->parts[0];
 
-    if (data->indexCount > 0) {
-      lovrMeshSetIndexBuffer(mesh, model->indexBuffer);
-      lovrMeshSetDrawRange(mesh, data->indexOffset, part->count, data->vertexOffset);
-    } else {
-      lovrMeshSetDrawRange(mesh, data->vertexOffset, part->count, 0);
-    }
+    lovrMeshSetIndexBuffer(mesh, model->indexBuffer);
+    lovrMeshSetDrawRange(mesh, part->start, part->count, part->baseVertex);
 
     switch (part->mode) {
       case DRAW_POINT_LIST: lovrMeshSetDrawMode(mesh, DRAW_POINTS); break;

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -274,13 +274,6 @@ typedef struct {
   float scale[3];
 } NodeTransform;
 
-typedef struct {
-  uint32_t index;
-  uint32_t count;
-  uint32_t vertexIndex;
-  uint32_t vertexCount;
-} BlendGroup;
-
 struct Model {
   uint32_t ref;
   Model* parent;
@@ -296,12 +289,9 @@ struct Model {
   Material** materials;
   NodeTransform* localTransforms;
   float* globalTransforms;
-  float* boundingBoxes;
+  float* blendShapeWeights;
   bool transformsDirty;
   bool blendShapesDirty;
-  float* blendShapeWeights;
-  BlendGroup* blendGroups;
-  uint32_t blendGroupCount;
   uint32_t lastVertexAnimation;
 };
 
@@ -353,14 +343,6 @@ typedef struct {
   struct { float x, y, z; } normal;
   struct { float u, v; } uv;
 } ShapeVertex;
-
-typedef struct {
-  struct { float x, y, z; } position;
-  uint32_t normal;
-  struct { float u, v; } uv;
-  struct { uint8_t r, g, b, a; } color;
-  uint32_t tangent;
-} ModelVertex;
 
 typedef struct {
   struct { float x, y, z; } position;
@@ -4897,12 +4879,6 @@ Model* lovrModelCreate(const ModelInfo* info) {
   model->info = *info;
   lovrRetain(info->data);
 
-  size_t stack = 0;
-
-  for (uint32_t i = 0; i < data->skinCount; i++) {
-    lovrCheckGoto(fail, data->skins[i].jointCount <= 256, "Currently, the max number of joints per skin is 256");
-  }
-
   // Materials and Textures
   if (info->materials) {
     model->textures = lovrCalloc(data->imageCount * sizeof(Texture*));
@@ -4956,222 +4932,116 @@ Model* lovrModelCreate(const ModelInfo* info) {
     }
   }
 
-  // Buffers
-  char* vertexData = NULL;
-  char* indexData = NULL;
-  char* blendData = NULL;
-  char* skinData = NULL;
-
-  BufferInfo vertexBufferInfo = {
-    .format = (DataField[]) {
-      { .length = data->vertexCount, .stride = sizeof(ModelVertex), .fieldCount = 5 },
-      { .name = "VertexPosition", .type = TYPE_F32x3, .offset = offsetof(ModelVertex, position) },
-      { .name = "VertexNormal", .type = TYPE_SN10x3, .offset = offsetof(ModelVertex, normal) },
-      { .name = "VertexUV", .type = TYPE_F32x2, .offset = offsetof(ModelVertex, uv) },
-      { .name = "VertexColor", .type = TYPE_UN8x4, .offset = offsetof(ModelVertex, color) },
-      { .name = "VertexTangent", .type = TYPE_SN10x3, .offset = offsetof(ModelVertex, tangent) }
-    }
-  };
-
+  // Vertices
   if (data->vertexCount > 0) {
-    model->vertexBuffer = lovrBufferCreate(&vertexBufferInfo, (void**) &vertexData);
-    lovrAssertGoto(fail, model->vertexBuffer, "Failed to create model vertex buffer: %s", lovrGetError());
-  }
-
-  if (data->blendShapeVertexCount > 0) {
-    model->blendBuffer = lovrBufferCreate(&(BufferInfo) {
+    BufferInfo bufferInfo = {
       .format = (DataField[]) {
-        { .length = data->blendShapeVertexCount, .stride = sizeof(BlendVertex), .fieldCount = 3 },
-        { .type = TYPE_F32x3, .offset = offsetof(BlendVertex, position) },
-        { .type = TYPE_F32x3, .offset = offsetof(BlendVertex, normal) },
-        { .type = TYPE_F32x3, .offset = offsetof(BlendVertex, tangent) }
+        { .length = data->vertexCount, .stride = sizeof(ModelVertex), .fieldCount = 5 },
+        { .name = "VertexPosition", .type = TYPE_F32x3, .offset = offsetof(ModelVertex, position) },
+        { .name = "VertexNormal", .type = TYPE_SN10x3, .offset = offsetof(ModelVertex, normal) },
+        { .name = "VertexUV", .type = TYPE_F32x2, .offset = offsetof(ModelVertex, uv) },
+        { .name = "VertexColor", .type = TYPE_UN8x4, .offset = offsetof(ModelVertex, color) },
+        { .name = "VertexTangent", .type = TYPE_SN10x3, .offset = offsetof(ModelVertex, tangent) }
       }
-    }, (void**) &blendData);
+    };
 
-    lovrAssertGoto(fail, model->blendBuffer, "Failed to create model blend shape buffer: %s", lovrGetError());
+    void* vertexData = NULL;
+    model->vertexBuffer = lovrBufferCreate(&bufferInfo, (void**) &vertexData);
+    lovrAssertGoto(fail, model->vertexBuffer, "Failed to create model vertex buffer: %s", lovrGetError());
+    memcpy(vertexData, data->vertices, data->vertexCount * sizeof(ModelVertex));
+
+    // Animated vertices are ones that are blended or skinned.  They need a copy of the original vertex
+    if (data->animatedVertexCount > 0) {
+      bufferInfo.format->length = data->animatedVertexCount;
+      model->rawVertexBuffer = lovrBufferCreate(&bufferInfo, &vertexData);
+      lovrAssertGoto(fail, model->rawVertexBuffer, "Failed to create model raw vertex buffer: %s", lovrGetError());
+
+      for (uint32_t i = 0; i < data->meshCount; i++) {
+        ModelMesh* mesh = &data->meshes[i];
+        if (!mesh->skinData && !mesh->blendData) continue;
+        memcpy(vertexData, mesh->vertices, mesh->vertexCount * sizeof(ModelVertex));
+        vertexData = (ModelVertex*) vertexData + mesh->vertexCount;
+      }
+    }
   }
 
+  // Indices
+  if (data->indexCount > 0) {
+    BufferInfo bufferInfo = {
+      .format = &(DataField) {
+        .length = data->indexCount,
+        .stride = data->indexSize,
+        .type = data->indexSize == 4 ? TYPE_INDEX32 : TYPE_INDEX16
+      }
+    };
+
+    void* indexData = NULL;
+    model->indexBuffer = lovrBufferCreate(&bufferInfo, &indexData);
+    lovrAssertGoto(fail, model->indexBuffer, "Failed to create model index buffer: %s", lovrGetError());
+    memcpy(indexData, data->indices, data->indexCount * data->indexSize);
+  }
+
+  // Joints
   if (data->skinnedVertexCount > 0) {
-    model->skinBuffer = lovrBufferCreate(&(BufferInfo) {
+    BufferInfo bufferInfo = {
       .format = (DataField[]) {
         { .length = data->skinnedVertexCount, .stride = 8, .fieldCount = 2 },
         { .type = TYPE_UN8x4, .offset = 0 },
         { .type = TYPE_U8x4, .offset = 4 }
       }
-    }, (void**) &skinData);
+    };
 
+    void* skinData = NULL;
+    model->skinBuffer = lovrBufferCreate(&bufferInfo, &skinData);
     lovrAssertGoto(fail, model->skinBuffer, "Failed to create model skinning buffer: %s", lovrGetError());
+    memcpy(skinData, data->skinData, data->vertexCount * 8);
   }
 
-  // Dynamic vertices are ones that are blended or skinned.  They need a copy of the original vertex
-  if (data->dynamicVertexCount > 0) {
-    vertexBufferInfo.format->length = data->dynamicVertexCount;
-    model->rawVertexBuffer = lovrBufferCreate(&vertexBufferInfo, NULL);
-    lovrAssertGoto(fail, model->rawVertexBuffer, "Failed to create model raw vertex buffer: %s", lovrGetError());
-
-    // The vertex buffer may already have a pending copy if its memory was not host-visible, need to
-    // wait for that to complete before copying to the raw vertex buffer
-    gpu_barrier barrier = syncTransfer(model->vertexBuffer->sync, GPU_PHASE_COPY, GPU_CACHE_TRANSFER_READ);
-    gpu_sync(state.stream, &barrier, 1);
-
-    Buffer* src = model->vertexBuffer;
-    Buffer* dst = model->rawVertexBuffer;
-    gpu_copy_buffers(state.stream, src->gpu, dst->gpu, 0, 0, data->dynamicVertexCount * sizeof(ModelVertex));
-
-    gpu_sync(state.stream, &(gpu_barrier) {
-      .prev = GPU_PHASE_COPY,
-      .next = GPU_PHASE_SHADER_COMPUTE,
-      .flush = GPU_CACHE_TRANSFER_WRITE,
-      .clear = GPU_CACHE_STORAGE_READ | GPU_CACHE_STORAGE_WRITE
-    }, 1);
-  }
-
-  DataType indexType = data->indexType == U32 ? TYPE_INDEX32 : TYPE_INDEX16;
-  uint32_t indexSize = data->indexType == U32 ? 4 : 2;
-
-  if (data->indexCount > 0) {
-    model->indexBuffer = lovrBufferCreate(&(BufferInfo) {
+  // Blend Shapes
+  if (data->blendedVertexCount > 0) {
+    BufferInfo bufferInfo = {
       .format = (DataField[]) {
-        { .length = data->indexCount, .stride = indexSize, .type = indexType }
+        { .length = data->blendedVertexCount, .stride = sizeof(BlendVertex), .fieldCount = 3 },
+        { .type = TYPE_F32x3, .offset = offsetof(BlendVertex, position) },
+        { .type = TYPE_F32x3, .offset = offsetof(BlendVertex, normal) },
+        { .type = TYPE_F32x3, .offset = offsetof(BlendVertex, tangent) }
       }
-    }, (void**) &indexData);
+    };
 
-    lovrAssertGoto(fail, model->indexBuffer, "Failed to create model index buffer: %s", lovrGetError());
+    void* blendData = NULL;
+    model->blendBuffer = lovrBufferCreate(&bufferInfo, &blendData);
+    lovrAssertGoto(fail, model->blendBuffer, "Failed to create model blend shape buffer: %s", lovrGetError());
+    memcpy(blendData, data->blendData, data->vertexCount * data->blendShapeCount * sizeof(BlendData));
   }
-
-  // Primitives are sorted to ensure animated/blended vertices are close together:
-  // - Skinned primitives come first
-  //   - Within a skin, the primitives with blend shapes come first
-  //   - Followed by the primitives without blend shapes
-  // - Primitives with blend shapes (but no skinning) are next
-  // - Then the remaining "non-dynamic" primitives follow
-  // Within each section, primitives are still sorted by their index
-  // All of a node's primitives will remain together, since skin/blend shapes are per-node
-
-  stack = stackPush(&thread.stack);
-  uint64_t* primitiveOrder = allocate(&thread.stack, data->primitiveCount * sizeof(uint64_t));
-  uint32_t* baseVertex = allocate(&thread.stack, data->primitiveCount * sizeof(uint32_t));
-
-  // The sort key only has 31 bits for the skin
-  lovrCheckGoto(fail, data->skinCount < (1u << 31), "Too many skins!");
-
-  for (uint32_t i = 0; i < data->primitiveCount; i++) {
-    primitiveOrder[i] = 0;
-    primitiveOrder[i] |= (uint64_t) data->primitives[i].skin << 33;
-    primitiveOrder[i] |= (uint64_t) (data->primitives[i].blendShapeCount == 0) << 32;
-    primitiveOrder[i] |= i;
-  }
-
-  qsort(primitiveOrder, data->primitiveCount, sizeof(uint64_t), u64cmp);
 
   // Draws
   model->draws = lovrCalloc(data->primitiveCount * sizeof(DrawInfo));
-  model->boundingBoxes = lovrMalloc(data->primitiveCount * 6 * sizeof(float));
-  for (uint32_t i = 0, vertexCursor = 0, indexCursor = 0; i < data->primitiveCount; i++) {
-    ModelPrimitive* primitive = &data->primitives[primitiveOrder[i] & ~0u];
-    ModelAttribute* position = primitive->attributes[ATTR_POSITION];
-    DrawInfo* draw = &model->draws[primitiveOrder[i] & ~0u];
+  for (uint32_t i = 0, drawIndex = 0; i < data->meshCount; i++) {
+    ModelMesh* mesh = &data->meshes[i];
 
-    switch (primitive->mode) {
-      case DRAW_POINT_LIST: draw->mode = DRAW_POINTS; break;
-      case DRAW_LINE_LIST: draw->mode = DRAW_LINES; break;
-      case DRAW_TRIANGLE_LIST: draw->mode = DRAW_TRIANGLES; break;
-      default: lovrSetError("Model uses an unsupported draw mode (lineloop, linestrip, strip, fan)"); goto fail;
-    }
+    for (uint32_t j = 0; j < mesh->primitiveCount; j++, drawIndex++) {
+      ModelPrimitive* primitive = &mesh->primitives[j];
+      DrawInfo* draw = &model->draws[drawIndex];
 
-    draw->material = !info->materials || primitive->material == ~0u ? NULL: model->materials[primitive->material];
-    draw->vertex.buffer = model->vertexBuffer;
+      switch (primitive->mode) {
+        case DRAW_POINT_LIST: draw->mode = DRAW_POINTS; break;
+        case DRAW_LINE_LIST: draw->mode = DRAW_LINES; break;
+        case DRAW_TRIANGLE_LIST: draw->mode = DRAW_TRIANGLES; break;
+        default: lovrSetError("Model uses an unsupported draw mode (lineloop, linestrip, strip, fan)"); goto fail;
+      }
 
-    if (primitive->indices) {
-      draw->index.buffer = model->indexBuffer;
-      draw->start = indexCursor;
-      draw->count = primitive->indices->count;
-      draw->baseVertex = vertexCursor;
-      indexCursor += draw->count;
-    } else {
-      draw->start = vertexCursor;
-      draw->count = position->count;
-    }
-
-    draw->bounds = model->boundingBoxes + i * 6;
-    draw->bounds[0] = (position->min[0] + position->max[0]) / 2.f;
-    draw->bounds[1] = (position->min[1] + position->max[1]) / 2.f;
-    draw->bounds[2] = (position->min[2] + position->max[2]) / 2.f;
-    draw->bounds[3] = (position->max[0] - position->min[0]) / 2.f;
-    draw->bounds[4] = (position->max[1] - position->min[1]) / 2.f;
-    draw->bounds[5] = (position->max[2] - position->min[2]) / 2.f;
-
-    baseVertex[primitiveOrder[i] & ~0u] = vertexCursor;
-    vertexCursor += position->count;
-  }
-
-  // Vertices
-  for (uint32_t i = 0; i < data->primitiveCount; i++) {
-    ModelPrimitive* primitive = &data->primitives[primitiveOrder[i] & ~0u];
-    ModelAttribute** attributes = primitive->attributes;
-    uint32_t count = attributes[ATTR_POSITION]->count;
-    size_t stride = sizeof(ModelVertex);
-
-    lovrModelDataCopyAttribute(data, attributes[ATTR_POSITION], vertexData + 0, F32, 3, false, count, stride, 0);
-    lovrModelDataCopyAttribute(data, attributes[ATTR_NORMAL], vertexData + 12, SN10x3, 1, false, count, stride, 0);
-    lovrModelDataCopyAttribute(data, attributes[ATTR_UV], vertexData + 16, F32, 2, false, count, stride, 0);
-    lovrModelDataCopyAttribute(data, attributes[ATTR_COLOR], vertexData + 24, U8, 4, true, count, stride, 255);
-    lovrModelDataCopyAttribute(data, attributes[ATTR_TANGENT], vertexData + 28, SN10x3, 1, false, count, stride, 0);
-    vertexData += count * stride;
-
-    if (data->skinnedVertexCount > 0 && primitive->skin != ~0u) {
-      lovrModelDataCopyAttribute(data, attributes[ATTR_JOINTS], skinData + 0, U8, 4, false, count, 8, 0);
-      lovrModelDataCopyAttribute(data, attributes[ATTR_WEIGHTS], skinData + 4, U8, 4, true, count, 8, 0);
-      skinData += count * 8;
-    }
-
-    if (primitive->indices) {
-      uint32_t indexCount = primitive->indices->count;
-      lovrModelDataCopyAttribute(data, primitive->indices, indexData, data->indexType, 1, false, indexCount, indexSize, 0);
-      indexData += indexCount * indexSize;
+      draw->material = !info->materials || primitive->material == ~0u ? NULL: model->materials[primitive->material];
+      draw->vertex.buffer = model->vertexBuffer;
+      draw->index.buffer = mesh->indices ? model->indexBuffer : NULL;
+      draw->start = primitive->start;
+      draw->count = primitive->count;
+      draw->bounds = primitive->bounds;
     }
   }
 
   // Blend shapes
   if (data->blendShapeCount > 0) {
-    for (uint32_t i = 0; i < data->blendShapeCount; i++) {
-      if (i == 0 || data->blendShapes[i - 1].node != data->blendShapes[i].node) {
-        model->blendGroupCount++;
-      }
-    }
-
-    model->blendGroups = lovrMalloc(model->blendGroupCount * sizeof(BlendGroup));
     model->blendShapeWeights = lovrMalloc(data->blendShapeCount * sizeof(float));
-
-    BlendGroup* group = model->blendGroups;
-
-    for (uint32_t i = 0; i < data->blendShapeCount; i++) {
-      ModelBlendShape* blendShape = &data->blendShapes[i];
-      ModelNode* node = &data->nodes[blendShape->node];
-      uint32_t groupVertexCount = 0;
-
-      for (uint32_t p = 0; p < node->primitiveCount; p++) {
-        ModelPrimitive* primitive = &data->primitives[node->primitiveIndex + p];
-        uint32_t vertexCount = primitive->attributes[ATTR_POSITION]->count;
-        size_t stride = sizeof(BlendVertex);
-
-        ModelBlendData* blendAttributes = &primitive->blendShapes[i - node->blendShapeIndex];
-        lovrModelDataCopyAttribute(data, blendAttributes->positions, blendData + offsetof(BlendVertex, position), F32, 3, false, vertexCount, stride, 0);
-        lovrModelDataCopyAttribute(data, blendAttributes->normals, blendData + offsetof(BlendVertex, normal), F32, 3, false, vertexCount, stride, 0);
-        lovrModelDataCopyAttribute(data, blendAttributes->tangents, blendData + offsetof(BlendVertex, tangent), F32, 3, false, vertexCount, stride, 0);
-        blendData += vertexCount * stride;
-        groupVertexCount += vertexCount;
-      }
-
-      if (i == 0 || blendShape[-1].node != blendShape[0].node) {
-        group->index = node->blendShapeIndex;
-        group->count = node->blendShapeCount;
-        group->vertexIndex = baseVertex[node->primitiveIndex];
-        group->vertexCount = groupVertexCount;
-        group++;
-      }
-    }
-
     lovrModelResetBlendShapes(model);
   }
 
@@ -5180,11 +5050,8 @@ Model* lovrModelCreate(const ModelInfo* info) {
   model->globalTransforms = lovrMalloc(16 * sizeof(float) * data->nodeCount);
   lovrModelResetNodeTransforms(model);
 
-  stackPop(&thread.stack, stack);
-
   return model;
 fail:
-  if (stack) stackPop(&thread.stack, stack);
   lovrModelDestroy(model);
   return NULL;
 }
@@ -5204,9 +5071,6 @@ Model* lovrModelClone(Model* parent) {
   model->indexBuffer = parent->indexBuffer;
   model->blendBuffer = parent->blendBuffer;
   model->skinBuffer = parent->skinBuffer;
-
-  model->blendGroups = parent->blendGroups;
-  model->blendGroupCount = parent->blendGroupCount;
 
   if (parent->vertexBuffer) {
     model->vertexBuffer = lovrBufferCreate(&parent->vertexBuffer->info, NULL);
@@ -5285,9 +5149,7 @@ void lovrModelDestroy(void* ref) {
   lovrRelease(model->info.data, lovrModelDataDestroy);
   lovrFree(model->localTransforms);
   lovrFree(model->globalTransforms);
-  lovrFree(model->boundingBoxes);
   lovrFree(model->blendShapeWeights);
-  lovrFree(model->blendGroups);
   lovrFree(model->meshes);
   lovrFree(model->draws);
   lovrFree(model);
@@ -5346,7 +5208,7 @@ bool lovrModelAnimate(Model* model, uint32_t animationIndex, float time, float a
       case PROP_TRANSLATION: n = 3; break;
       case PROP_SCALE: n = 3; break;
       case PROP_ROTATION: n = 4; break;
-      case PROP_WEIGHTS: n = data->nodes[node].blendShapeCount; break;
+      case PROP_WEIGHTS: n = data->meshes[data->nodes[node].mesh].blendShapeCount; break;
     }
 
     float* property = allocate(&thread.stack, n * sizeof(float));
@@ -5414,7 +5276,10 @@ bool lovrModelAnimate(Model* model, uint32_t animationIndex, float time, float a
       case PROP_TRANSLATION: dst = model->localTransforms[node].position; break;
       case PROP_SCALE: dst = model->localTransforms[node].scale; break;
       case PROP_ROTATION: dst = model->localTransforms[node].rotation; break;
-      case PROP_WEIGHTS: dst = &model->blendShapeWeights[data->nodes[node].blendShapeIndex]; break;
+      case PROP_WEIGHTS:;
+        ModelMesh* mesh = &data->meshes[data->nodes[node].mesh];
+        dst = &model->blendShapeWeights[mesh->blendShapes - data->blendShapes];
+        break;
     }
 
     if (alpha >= 1.f) {
@@ -5521,7 +5386,7 @@ Material* lovrModelGetMaterial(Model* model, uint32_t index) {
 static bool lovrModelAnimateVertices(Model* model) {
   ModelData* data = model->info.data;
 
-  bool blend = model->blendGroupCount > 0;
+  bool blend = !!model->blendShapeWeights;
   bool skin = data->skinCount > 0;
 
   if ((!blend && !skin) || (!model->transformsDirty && !model->blendShapesDirty) || model->lastVertexAnimation == state.tick || !model->vertexBuffer) {
@@ -5537,8 +5402,10 @@ static bool lovrModelAnimateVertices(Model* model) {
 
   if (blend) {
     Shader* shader = lovrGraphicsGetDefaultShader(SHADER_BLENDER);
-    uint32_t vertexCount = data->dynamicVertexCount;
+    uint32_t vertexCount = data->animatedVertexCount;
     uint32_t blendBufferCursor = 0;
+    uint32_t blendShapeCursor = 0;
+    uint32_t vertexCursor = 0;
     uint32_t chunkSize = 64;
 
     if (!shader) return false;
@@ -5552,28 +5419,28 @@ static bool lovrModelAnimateVertices(Model* model) {
 
     gpu_bind_pipeline(state.stream, shader->computePipeline, GPU_PIPELINE_COMPUTE);
 
-    for (uint32_t i = 0; i < model->blendGroupCount; i++) {
-      BlendGroup* group = &model->blendGroups[i];
+    for (uint32_t i = 0; i < data->meshCount; i++) {
+      ModelMesh* mesh = &data->meshes[i];
 
-      for (uint32_t j = 0; j < group->count; j += chunkSize) {
-        uint32_t count = MIN(group->count - j, chunkSize);
+      for (uint32_t j = 0; j < mesh->blendShapeCount; j += chunkSize) {
+        uint32_t blendShapeCount = MIN(mesh->blendShapeCount - j, chunkSize);
         bool inplace = j > 0;
 
         BufferView view = getBuffer(GPU_BUFFER_STREAM, chunkSize * sizeof(float), state.limits.uniformBufferAlign);
         if (!view.buffer) return false;
-        memcpy(view.pointer, model->blendShapeWeights + group->index + j, count * sizeof(float));
+        memcpy(view.pointer, model->blendShapeWeights + blendShapeCursor, blendShapeCount * sizeof(float));
         bindings[3].buffer = (gpu_buffer_binding) { view.buffer, view.offset, view.extent };
 
         gpu_bundle* bundle = getBundle(shader->layout, bindings, COUNTOF(bindings));
         if (!bundle) return false;
-        uint32_t constants[] = { group->vertexIndex, group->vertexCount, count, blendBufferCursor, inplace };
+        uint32_t constants[] = { vertexCursor, mesh->vertexCount, blendShapeCount, blendBufferCursor, inplace };
         uint32_t subgroupSize = state.device.subgroupSize;
 
         gpu_bind_bundles(state.stream, shader->gpu, &bundle, 0, 1, NULL, 0);
         gpu_push_constants(state.stream, shader->gpu, constants, sizeof(constants));
-        gpu_compute(state.stream, (group->vertexCount + subgroupSize - 1) / subgroupSize, 1, 1);
+        gpu_compute(state.stream, (mesh->vertexCount + subgroupSize - 1) / subgroupSize, 1, 1);
 
-        if (j + count < group->count) {
+        if (j + blendShapeCount < mesh->blendShapeCount) {
           gpu_sync(state.stream, &(gpu_barrier) {
             .prev = GPU_PHASE_SHADER_COMPUTE,
             .next = GPU_PHASE_SHADER_COMPUTE,
@@ -5582,8 +5449,11 @@ static bool lovrModelAnimateVertices(Model* model) {
           }, 1);
         }
 
-        blendBufferCursor += group->vertexCount * count;
+        blendBufferCursor += mesh->vertexCount * blendShapeCount;
+        blendShapeCursor += blendShapeCount;
       }
+
+      vertexCursor += mesh->vertexCount;
     }
 
     model->blendShapesDirty = false;
@@ -5611,43 +5481,64 @@ static bool lovrModelAnimateVertices(Model* model) {
 
     gpu_bind_pipeline(state.stream, shader->computePipeline, GPU_PIPELINE_COMPUTE);
 
-    for (uint32_t i = 0, baseVertex = 0; i < data->skinCount; i++) {
-      ModelSkin* skin = &data->skins[i];
+    uint32_t skinVertexCursor = 0;
+    ModelSkin* prevSkin = NULL;
 
-      uint32_t align = state.limits.uniformBufferAlign;
-      BufferView view = getBuffer(GPU_BUFFER_STREAM, skin->jointCount * 16 * sizeof(float), align);
-      if (!view.buffer) return false;
-      bindings[3].buffer = (gpu_buffer_binding) { view.buffer, view.offset, view.extent };
+    for (uint32_t i = 0; i < data->meshCount; i++) {
+      ModelMesh* mesh = &data->meshes[i];
+      ModelSkin* skin = NULL;
 
-      float transform[16];
-      float* joints = view.pointer;
-      for (uint32_t j = 0; j < skin->jointCount; j++) {
-        mat4_init(transform, model->globalTransforms + 16 * skin->joints[j]);
-        if (skin->inverseBindMatrices) mat4_mul(transform, skin->inverseBindMatrices + 16 * j);
-        memcpy(joints, transform, sizeof(transform));
-        joints += 16;
+      if (!mesh->skinData) continue;
+
+      for (uint32_t j = 0; j < data->nodeCount; j++) {
+        if (data->nodes[j].mesh == i && data->nodes[j].skin != ~0u) {
+          skin = &data->skins[data->nodes[j].skin];
+          break;
+        }
       }
 
-      gpu_bundle* bundle = getBundle(shader->layout, bindings, COUNTOF(bindings));
-      if (!bundle) return false;
-      gpu_bind_bundles(state.stream, shader->gpu, &bundle, 0, 1, NULL, 0);
+      if (!skin) {
+        continue;
+      }
 
-      // Animate in 2 passes: first animate vertices with blend shapes, then animate the rest
-      // We do this because the source buffer is different for blended vs. unblended vertices:
-      // - Unblended vertices should animate the original vertices from rawVertexBuffer
-      // - Blended vertices should animate the post-blended vertices in-place
-      for (uint32_t j = 0; j < 2; j++) {
-        uint32_t subgroupSize = state.device.subgroupSize; 
-        uint32_t verticesRemaining = j == 0 ? skin->blendedVertexCount : (skin->vertexCount - skin->blendedVertexCount);
-        uint32_t maxVerticesPerDispatch = (uint32_t) MIN((uint64_t) state.limits.workgroupCount[0] * subgroupSize, (uint64_t) verticesRemaining);
+      if (skin != prevSkin) {
+        uint32_t align = state.limits.uniformBufferAlign;
+        BufferView view = getBuffer(GPU_BUFFER_STREAM, skin->jointCount * 16 * sizeof(float), align);
+        if (!view.buffer) return false;
+        bindings[3].buffer = (gpu_buffer_binding) { view.buffer, view.offset, view.extent };
 
-        while (verticesRemaining > 0) {
-          uint32_t vertexCount = MIN(verticesRemaining, maxVerticesPerDispatch);
-          gpu_push_constants(state.stream, shader->gpu, (uint32_t[3]) { baseVertex, vertexCount, j == 0 }, 12);
-          gpu_compute(state.stream, (vertexCount + subgroupSize - 1) / subgroupSize, 1, 1);
-          verticesRemaining -= vertexCount;
-          baseVertex += vertexCount;
+        float transform[16];
+        float* joints = view.pointer;
+        for (uint32_t j = 0; j < skin->jointCount; j++) {
+          mat4_init(transform, model->globalTransforms + 16 * skin->joints[j]);
+          if (skin->inverseBindMatrices) mat4_mul(transform, skin->inverseBindMatrices + 16 * j);
+          memcpy(joints, transform, sizeof(transform));
+          joints += 16;
         }
+
+        gpu_bundle* bundle = getBundle(shader->layout, bindings, COUNTOF(bindings));
+        if (!bundle) return false;
+        gpu_bind_bundles(state.stream, shader->gpu, &bundle, 0, 1, NULL, 0);
+
+        prevSkin = skin;
+      }
+
+      uint32_t subgroupSize = state.device.subgroupSize;
+      uint32_t verticesRemaining = mesh->vertexCount;
+      uint32_t maxVerticesPerDispatch = (uint32_t) MIN((uint64_t) state.limits.workgroupCount[0] * subgroupSize, (uint64_t) verticesRemaining);
+      uint32_t baseVertex = mesh->vertices - data->vertices;
+      bool inplace = mesh->blendShapeCount > 0;
+
+      // TODO do we need to send both the raw vertex buffer offset and the vertex offset?
+      // Note: to get raw vertex buffer offset, maintain a cursor in this loop
+
+      while (verticesRemaining > 0) {
+        uint32_t vertexCount = MIN(verticesRemaining, maxVerticesPerDispatch);
+        gpu_push_constants(state.stream, shader->gpu, (uint32_t[4]) { skinVertexCursor, baseVertex, vertexCount, inplace }, 16);
+        gpu_compute(state.stream, (vertexCount + subgroupSize - 1) / subgroupSize, 1, 1);
+        verticesRemaining -= vertexCount;
+        skinVertexCursor += vertexCount;
+        baseVertex += vertexCount;
       }
     }
   }
@@ -8154,14 +8045,18 @@ bool lovrPassDrawMesh(Pass* pass, Mesh* mesh, float* transform, uint32_t instanc
 }
 
 static bool drawNode(Pass* pass, Model* model, uint32_t index, uint32_t instances) {
-  ModelNode* node = &model->info.data->nodes[index];
+  ModelData* data = model->info.data;
+  ModelNode* node = &data->nodes[index];
   mat4 globalTransform = model->globalTransforms + 16 * index;
 
-  for (uint32_t i = 0; i < node->primitiveCount; i++) {
-    DrawInfo draw = model->draws[node->primitiveIndex + i];
-    if (node->skin == ~0u) draw.transform = globalTransform;
-    draw.instances = instances;
-    if (!lovrPassDraw(pass, &draw)) return false;
+  if (node->mesh != ~0u) {
+    ModelMesh* mesh = &data->meshes[node->mesh];
+    for (uint32_t i = 0; i < mesh->primitiveCount; i++) {
+      DrawInfo draw = model->draws[mesh->primitives - data->primitives + i];
+      if (node->skin == ~0u) draw.transform = globalTransform;
+      draw.instances = instances;
+      if (!lovrPassDraw(pass, &draw)) return false;
+    }
   }
 
   for (uint32_t i = node->child; i != ~0u; i = model->info.data->nodes[i].sibling) {

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -8083,9 +8083,9 @@ static bool drawNode(Pass* pass, Model* model, uint32_t index, uint32_t instance
         .bounds = part->bounds,
         .vertex.buffer = model->vertexBuffer,
         .index.buffer = mesh->indexCount > 0 ? model->indexBuffer : NULL,
-        .start = part->start,
+        .start = (mesh->indexCount > 0 ? mesh->indexOffset : mesh->vertexOffset) + part->start,
         .count = part->count,
-        .baseVertex = part->baseVertex,
+        .baseVertex = mesh->vertexOffset + part->baseVertex,
         .instances = instances
       };
 
@@ -8152,9 +8152,9 @@ bool lovrPassDrawPart(Pass* pass, Model* model, uint32_t meshIndex, uint32_t par
       .bounds = part->bounds,
       .vertex.buffer = model->vertexBuffer,
       .index.buffer = mesh->indexCount > 0 ? model->indexBuffer : NULL,
-      .start = part->start,
+      .start = (mesh->indexCount > 0 ? mesh->indexOffset : mesh->vertexOffset) + part->start,
       .count = part->count,
-      .baseVertex = part->baseVertex,
+      .baseVertex = mesh->indexOffset + part->baseVertex,
       .instances = instances
     };
 

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -5351,10 +5351,9 @@ Mesh* lovrModelGetMesh(Model* model, uint32_t index) {
       lovrMeshSetMaterial(mesh, model->materials[part->material]);
     }
 
-    // Can't use lovrMeshSetBoundingBox because the bounds is already in center/half-extent form
-    // TODO make it the union of the parts
-    memcpy(mesh->bounds, part->bounds, sizeof(mesh->bounds));
-    mesh->hasBounds = true;
+    float bounds[6];
+    lovrModelDataGetMeshBoundingBox(modelData, index, bounds);
+    lovrMeshSetBoundingBox(mesh, bounds);
 
     model->meshes[index] = mesh;
   }

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -278,7 +278,6 @@ struct Model {
   uint32_t ref;
   Model* parent;
   ModelInfo info;
-  DrawInfo* draws;
   Buffer* rawVertexBuffer;
   Buffer* vertexBuffer;
   Buffer* indexBuffer;
@@ -4956,10 +4955,10 @@ Model* lovrModelCreate(const ModelInfo* info) {
       model->rawVertexBuffer = lovrBufferCreate(&bufferInfo, &vertexData);
       lovrAssertGoto(fail, model->rawVertexBuffer, "Failed to create model raw vertex buffer: %s", lovrGetError());
 
-      for (uint32_t i = 0; i < data->meshCount; i++) {
-        ModelMesh* mesh = &data->meshes[i];
-        if (!mesh->skinData && !mesh->blendData) continue;
-        memcpy(vertexData, mesh->vertices, mesh->vertexCount * sizeof(ModelVertex));
+      ModelMesh* mesh = data->meshes;
+      for (uint32_t i = 0; i < data->meshCount; i++, mesh++) {
+        if (mesh->skinDataOffset == ~0u && mesh->blendDataOffset == ~0u) continue;
+        memcpy(vertexData, data->vertices + mesh->vertexOffset, mesh->vertexCount * sizeof(ModelVertex));
         vertexData = (ModelVertex*) vertexData + mesh->vertexCount;
       }
     }
@@ -5012,38 +5011,6 @@ Model* lovrModelCreate(const ModelInfo* info) {
     model->blendBuffer = lovrBufferCreate(&bufferInfo, &blendData);
     lovrAssertGoto(fail, model->blendBuffer, "Failed to create model blend shape buffer: %s", lovrGetError());
     memcpy(blendData, data->blendData, data->blendedVertexCount * sizeof(BlendData));
-  }
-
-  // Draws
-  uint32_t baseVertex = 0;
-  model->draws = lovrCalloc(data->primitiveCount * sizeof(DrawInfo));
-  for (uint32_t i = 0, drawIndex = 0; i < data->meshCount; i++) {
-    ModelMesh* mesh = &data->meshes[i];
-
-    for (uint32_t j = 0; j < mesh->primitiveCount; j++, drawIndex++) {
-      ModelPrimitive* primitive = &mesh->primitives[j];
-      DrawInfo* draw = &model->draws[drawIndex];
-
-      switch (primitive->mode) {
-        case DRAW_POINT_LIST: draw->mode = DRAW_POINTS; break;
-        case DRAW_LINE_LIST: draw->mode = DRAW_LINES; break;
-        case DRAW_TRIANGLE_LIST: draw->mode = DRAW_TRIANGLES; break;
-        default: lovrSetError("Model uses an unsupported draw mode (lineloop, linestrip, strip, fan)"); goto fail;
-      }
-
-      draw->material = !info->materials || primitive->material == ~0u ? NULL: model->materials[primitive->material];
-      draw->vertex.buffer = model->vertexBuffer;
-      draw->start = primitive->start;
-      draw->count = primitive->count;
-      draw->bounds = primitive->bounds;
-
-      if (primitive->indexCount > 0) {
-        draw->index.buffer = model->indexBuffer;
-        draw->baseVertex = baseVertex;
-      }
-
-      baseVertex += primitive->vertexCount;
-    }
   }
 
   // Blend shapes
@@ -5102,13 +5069,6 @@ Model* lovrModelClone(Model* parent) {
     }, 1);
   }
 
-  model->draws = lovrMalloc(data->primitiveCount * sizeof(DrawInfo));
-
-  for (uint32_t i = 0; i < data->primitiveCount; i++) {
-    model->draws[i] = parent->draws[i];
-    model->draws[i].vertex.buffer = model->vertexBuffer;
-  }
-
   model->blendShapeWeights = lovrMalloc(data->blendShapeCount * sizeof(float));
   lovrModelResetBlendShapes(model);
 
@@ -5128,7 +5088,6 @@ void lovrModelDestroy(void* ref) {
     lovrFree(model->globalTransforms);
     lovrFree(model->blendShapeWeights);
     lovrFree(model->meshes);
-    lovrFree(model->draws);
     lovrFree(model);
     return;
   }
@@ -5144,7 +5103,7 @@ void lovrModelDestroy(void* ref) {
     lovrFree(model->textures);
   }
   if (model->meshes) {
-    for (uint32_t i = 0; i < data->primitiveCount; i++) {
+    for (uint32_t i = 0; i < data->meshCount; i++) {
       lovrRelease(model->meshes[i], lovrMeshDestroy);
     }
   }
@@ -5158,7 +5117,6 @@ void lovrModelDestroy(void* ref) {
   lovrFree(model->globalTransforms);
   lovrFree(model->blendShapeWeights);
   lovrFree(model->meshes);
-  lovrFree(model->draws);
   lovrFree(model);
 }
 
@@ -5354,24 +5312,50 @@ Buffer* lovrModelGetIndexBuffer(Model* model) {
 }
 
 Mesh* lovrModelGetMesh(Model* model, uint32_t index) {
-  ModelData* data = model->info.data;
-  lovrCheck(index < data->primitiveCount, "Invalid mesh index '%d' (Model has %d mesh%s)", index + 1, data->primitiveCount, data->primitiveCount == 1 ? "" : "es");
+  ModelData* modelData = model->info.data;
+  uint32_t meshCount = modelData->meshCount;
+  lovrCheck(index < meshCount, "Invalid mesh index '%d' (Model has %d mesh%s)", index + 1, meshCount, meshCount == 1 ? "" : "es");
 
   if (!model->meshes) {
-    model->meshes = lovrCalloc(data->primitiveCount * sizeof(Mesh*));
+    model->meshes = lovrCalloc(meshCount * sizeof(Mesh*));
   }
 
   if (!model->meshes[index]) {
-    DrawInfo* draw = &model->draws[index];
-    MeshInfo info = { .vertexBuffer = model->vertexBuffer, .storage = MESH_GPU };
-    Mesh* mesh = lovrMeshCreate(&info, NULL);
-    if (!mesh) return NULL;
-    if (draw->index.buffer) lovrMeshSetIndexBuffer(mesh, model->indexBuffer);
-    lovrMeshSetDrawMode(mesh, draw->mode);
-    lovrMeshSetDrawRange(mesh, draw->start, draw->count, draw->baseVertex);
-    lovrMeshSetMaterial(mesh, draw->material);
-    memcpy(mesh->bounds, draw->bounds, sizeof(mesh->bounds));
+    Mesh* mesh = lovrMeshCreate(&(MeshInfo) {
+      .vertexBuffer = model->vertexBuffer,
+      .storage = MESH_GPU
+    }, NULL);
+
+    if (!mesh) {
+      return NULL;
+    }
+
+    ModelMesh* data = &modelData->meshes[index];
+    ModelPart* part = &modelData->parts[0];
+
+    if (data->indexCount > 0) {
+      lovrMeshSetIndexBuffer(mesh, model->indexBuffer);
+      lovrMeshSetDrawRange(mesh, data->indexOffset, part->count, data->vertexOffset);
+    } else {
+      lovrMeshSetDrawRange(mesh, data->vertexOffset, part->count, 0);
+    }
+
+    switch (part->mode) {
+      case DRAW_POINT_LIST: lovrMeshSetDrawMode(mesh, DRAW_POINTS); break;
+      case DRAW_LINE_LIST: lovrMeshSetDrawMode(mesh, DRAW_LINES); break;
+      case DRAW_TRIANGLE_LIST: lovrMeshSetDrawMode(mesh, DRAW_TRIANGLES); break;
+      default: lovrUnreachable();
+    }
+
+    if (model->materials && part->material != ~0u) {
+      lovrMeshSetMaterial(mesh, model->materials[part->material]);
+    }
+
+    // Can't use lovrMeshSetBoundingBox because the bounds is already in center/half-extent form
+    // TODO make it the union of the parts
+    memcpy(mesh->bounds, part->bounds, sizeof(mesh->bounds));
     mesh->hasBounds = true;
+
     model->meshes[index] = mesh;
   }
 
@@ -5495,10 +5479,11 @@ static bool lovrModelAnimateVertices(Model* model) {
       ModelMesh* mesh = &data->meshes[i];
       ModelSkin* skin = NULL;
 
-      if (!mesh->skinData) {
+      if (mesh->skinDataOffset == ~0u) {
         continue;
       }
 
+      // Search through nodes to find the skin for this mesh
       for (uint32_t j = 0; j < data->nodeCount; j++) {
         if (data->nodes[j].mesh == i && data->nodes[j].skin != ~0u) {
           skin = &data->skins[data->nodes[j].skin];
@@ -5535,7 +5520,7 @@ static bool lovrModelAnimateVertices(Model* model) {
       uint32_t subgroupSize = state.device.subgroupSize;
       uint32_t verticesRemaining = mesh->vertexCount;
       uint32_t maxVerticesPerDispatch = (uint32_t) MIN((uint64_t) state.limits.workgroupCount[0] * subgroupSize, (uint64_t) verticesRemaining);
-      uint32_t baseVertex = mesh->vertices - data->vertices;
+      uint32_t baseVertex = mesh->vertexOffset;
       bool inplace = mesh->blendShapeCount > 0;
 
       while (verticesRemaining > 0) {
@@ -8057,11 +8042,25 @@ static bool drawNode(Pass* pass, Model* model, uint32_t index, uint32_t instance
 
   if (node->mesh != ~0u) {
     ModelMesh* mesh = &data->meshes[node->mesh];
-    for (uint32_t i = 0; i < mesh->primitiveCount; i++) {
-      DrawInfo draw = model->draws[mesh->primitives - data->primitives + i];
-      if (node->skin == ~0u) draw.transform = globalTransform;
-      draw.instances = instances;
-      if (!lovrPassDraw(pass, &draw)) return false;
+    ModelPart* part = mesh->parts;
+
+    for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
+      DrawInfo draw = {
+        .mode = part->mode == DRAW_POINT_LIST ? DRAW_POINTS : part->mode == DRAW_LINE_LIST ? DRAW_LINES : DRAW_TRIANGLES,
+        .material = model->materials && part->material != ~0u ? model->materials[part->material] : NULL,
+        .transform = node->skin == ~0u ? globalTransform : NULL,
+        .bounds = part->bounds,
+        .vertex.buffer = model->vertexBuffer,
+        .index.buffer = mesh->indexCount > 0 ? model->indexBuffer : NULL,
+        .start = part->start,
+        .count = part->count,
+        .baseVertex = part->baseVertex,
+        .instances = instances
+      };
+
+      if (!lovrPassDraw(pass, &draw)) {
+        return false;
+      }
     }
   }
 

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -5331,7 +5331,7 @@ Mesh* lovrModelGetMesh(Model* model, uint32_t index) {
     }
 
     ModelMesh* data = &modelData->meshes[index];
-    ModelPart* part = &modelData->parts[0];
+    ModelPart* part = &data->parts[0];
 
     if (data->indexCount > 0) {
       lovrMeshSetIndexBuffer(mesh, model->indexBuffer);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -8121,6 +8121,51 @@ bool lovrPassDrawModel(Pass* pass, Model* model, float* transform, uint32_t inst
   return true;
 }
 
+bool lovrPassDrawPart(Pass* pass, Model* model, uint32_t meshIndex, uint32_t partIndex, float* transform, uint32_t instances) {
+  lovrCheck(meshIndex < model->meta.meshCount, "Model mesh index %d is out of range", meshIndex + 1);
+  lovrCheck(partIndex == ~0u || partIndex < model->meta.meshes[meshIndex].partCount, "Model part index %d is out of range", partIndex + 1);
+
+  if (!lovrModelAnimateVertices(model)) {
+    return false;
+  }
+
+  if (model->transformsDirty) {
+    updateModelTransforms(model, model->meta.rootNode, (float[]) MAT4_IDENTITY);
+    model->transformsDirty = false;
+  }
+
+  ModelMesh* mesh = &model->meta.meshes[meshIndex];
+
+  uint32_t partCount = 1;
+  if (partIndex == ~0u) {
+    partIndex = 0;
+    partCount = mesh->partCount;
+  }
+
+  for (uint32_t i = 0; i < partCount; i++) {
+    ModelPart* part = &model->meta.parts[partIndex + i];
+
+    DrawInfo draw = {
+      .mode = part->mode == DRAW_POINT_LIST ? DRAW_POINTS : part->mode == DRAW_LINE_LIST ? DRAW_LINES : DRAW_TRIANGLES,
+      .material = model->materials && part->material != ~0u ? model->materials[part->material] : NULL,
+      .transform = transform, // TODO fix skinned mesh transforms?
+      .bounds = part->bounds,
+      .vertex.buffer = model->vertexBuffer,
+      .index.buffer = mesh->indexCount > 0 ? model->indexBuffer : NULL,
+      .start = part->start,
+      .count = part->count,
+      .baseVertex = part->baseVertex,
+      .instances = instances
+    };
+
+    if (!lovrPassDraw(pass, &draw)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 bool lovrPassDrawTexture(Pass* pass, Texture* texture, float* transform) {
   uint32_t key[] = { SHAPE_PLANE, STYLE_FILL, 1, 1 };
   ShapeVertex* vertices;

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4841,10 +4841,9 @@ void lovrMeshSetDrawMode(Mesh* mesh, DrawMode mode) {
   mesh->mode = mode;
 }
 
-void lovrMeshGetDrawRange(Mesh* mesh, uint32_t* start, uint32_t* count, uint32_t* offset) {
+void lovrMeshGetDrawRange(Mesh* mesh, uint32_t* start, uint32_t* count) {
   *start = mesh->drawStart;
   *count = mesh->drawCount;
-  *offset = mesh->baseVertex;
 }
 
 bool lovrMeshSetDrawRange(Mesh* mesh, uint32_t start, uint32_t count) {
@@ -5370,7 +5369,8 @@ Mesh* lovrModelGetMesh(Model* model, uint32_t index) {
     ModelPart* part = &data->parts[0];
 
     lovrMeshSetIndexBuffer(mesh, model->indexBuffer);
-    lovrMeshSetDrawRange(mesh, part->start, part->count, part->baseVertex);
+    lovrMeshSetDrawRange(mesh, part->start, part->count);
+    lovrMeshSetBaseVertex(mesh, part->baseVertex);
 
     switch (part->mode) {
       case DRAW_POINT_LIST: lovrMeshSetDrawMode(mesh, DRAW_POINTS); break;

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -277,7 +277,7 @@ typedef struct {
 struct Model {
   uint32_t ref;
   Model* parent;
-  ModelInfo info;
+  ModelMetadata meta;
   Buffer* rawVertexBuffer;
   Buffer* vertexBuffer;
   Buffer* indexBuffer;
@@ -4872,19 +4872,21 @@ static bool lovrMeshFlush(Mesh* mesh) {
 // Model
 
 Model* lovrModelCreate(const ModelInfo* info) {
-  ModelData* data = info->data;
   Model* model = lovrCalloc(sizeof(Model));
   model->ref = 1;
-  model->info = *info;
-  lovrRetain(info->data);
+  model->meta = info->data->meta;
+  lovrRetain(model->meta.blob);
+
+  ModelData* data = info->data;
+  ModelMetadata* meta = &model->meta;
 
   // Materials and Textures
   if (info->materials) {
-    model->textures = lovrCalloc(data->imageCount * sizeof(Texture*));
-    model->materials = lovrMalloc(data->materialCount * sizeof(Material*));
-    for (uint32_t i = 0; i < data->materialCount; i++) {
+    model->textures = lovrCalloc(meta->imageCount * sizeof(Texture*));
+    model->materials = lovrMalloc(meta->materialCount * sizeof(Material*));
+    for (uint32_t i = 0; i < meta->materialCount; i++) {
       MaterialInfo material;
-      ModelMaterial* properties = &data->materials[i];
+      ModelMaterial* properties = &meta->materials[i];
       memcpy(&material.data, properties, sizeof(MaterialData));
 
       struct { uint32_t index; Texture** texture; } textures[] = {
@@ -4905,17 +4907,19 @@ Model* lovrModelCreate(const ModelInfo* info) {
           *texture = NULL;
         } else {
           if (!model->textures[index]) {
+            Image* image = data->images[index];
+
             model->textures[index] = lovrTextureCreate(&(TextureInfo) {
               .type = TEXTURE_2D,
               .usage = TEXTURE_SAMPLE,
-              .format = lovrImageGetFormat(data->images[index]),
-              .width = lovrImageGetWidth(data->images[index], 0),
-              .height = lovrImageGetHeight(data->images[index], 0),
+              .format = lovrImageGetFormat(image),
+              .width = lovrImageGetWidth(image, 0),
+              .height = lovrImageGetHeight(image, 0),
               .layers = 1,
-              .mipmaps = info->mipmaps || lovrImageGetLevelCount(data->images[index]) > 1 ? ~0u : 1,
+              .mipmaps = info->mipmaps || lovrImageGetLevelCount(image) > 1 ? ~0u : 1,
               .samples = 1,
               .srgb = texture == &material.texture || texture == &material.glowTexture,
-              .images = &data->images[index],
+              .images = &image,
               .imageCount = 1
             });
 
@@ -4932,10 +4936,10 @@ Model* lovrModelCreate(const ModelInfo* info) {
   }
 
   // Vertices
-  if (data->vertexCount > 0) {
+  if (meta->vertexCount > 0) {
     BufferInfo bufferInfo = {
       .format = (DataField[]) {
-        { .length = data->vertexCount, .stride = sizeof(ModelVertex), .fieldCount = 5 },
+        { .length = meta->vertexCount, .stride = sizeof(ModelVertex), .fieldCount = 5 },
         { .name = "VertexPosition", .type = TYPE_F32x3, .offset = offsetof(ModelVertex, position) },
         { .name = "VertexNormal", .type = TYPE_SN10x3, .offset = offsetof(ModelVertex, normal) },
         { .name = "VertexUV", .type = TYPE_F32x2, .offset = offsetof(ModelVertex, uv) },
@@ -4947,16 +4951,16 @@ Model* lovrModelCreate(const ModelInfo* info) {
     void* vertexData = NULL;
     model->vertexBuffer = lovrBufferCreate(&bufferInfo, (void**) &vertexData);
     lovrAssertGoto(fail, model->vertexBuffer, "Failed to create model vertex buffer: %s", lovrGetError());
-    memcpy(vertexData, data->vertices, data->vertexCount * sizeof(ModelVertex));
+    memcpy(vertexData, data->vertices, meta->vertexCount * sizeof(ModelVertex));
 
     // Animated vertices are ones that are blended or skinned.  They need a copy of the original vertex
-    if (data->animatedVertexCount > 0) {
-      bufferInfo.format->length = data->animatedVertexCount;
+    if (meta->animatedVertexCount > 0) {
+      bufferInfo.format->length = meta->animatedVertexCount;
       model->rawVertexBuffer = lovrBufferCreate(&bufferInfo, &vertexData);
       lovrAssertGoto(fail, model->rawVertexBuffer, "Failed to create model raw vertex buffer: %s", lovrGetError());
 
-      ModelMesh* mesh = data->meshes;
-      for (uint32_t i = 0; i < data->meshCount; i++, mesh++) {
+      ModelMesh* mesh = meta->meshes;
+      for (uint32_t i = 0; i < meta->meshCount; i++, mesh++) {
         if (mesh->skinDataOffset == ~0u && mesh->blendDataOffset == ~0u) continue;
         memcpy(vertexData, data->vertices + mesh->vertexOffset, mesh->vertexCount * sizeof(ModelVertex));
         vertexData = (ModelVertex*) vertexData + mesh->vertexCount;
@@ -4965,26 +4969,26 @@ Model* lovrModelCreate(const ModelInfo* info) {
   }
 
   // Indices
-  if (data->indexCount > 0) {
+  if (meta->indexCount > 0) {
     BufferInfo bufferInfo = {
       .format = &(DataField) {
-        .length = data->indexCount,
-        .stride = data->indexSize,
-        .type = data->indexSize == 4 ? TYPE_INDEX32 : TYPE_INDEX16
+        .length = meta->indexCount,
+        .stride = meta->indexSize,
+        .type = meta->indexSize == 4 ? TYPE_INDEX32 : TYPE_INDEX16
       }
     };
 
     void* indexData = NULL;
     model->indexBuffer = lovrBufferCreate(&bufferInfo, &indexData);
     lovrAssertGoto(fail, model->indexBuffer, "Failed to create model index buffer: %s", lovrGetError());
-    memcpy(indexData, data->indices, data->indexCount * data->indexSize);
+    memcpy(indexData, data->indices, meta->indexCount * meta->indexSize);
   }
 
   // Joints
-  if (data->skinnedVertexCount > 0) {
+  if (meta->skinnedVertexCount > 0) {
     BufferInfo bufferInfo = {
       .format = (DataField[]) {
-        { .length = data->skinnedVertexCount, .stride = 8, .fieldCount = 2 },
+        { .length = meta->skinnedVertexCount, .stride = 8, .fieldCount = 2 },
         { .type = TYPE_UN8x4, .offset = 0 },
         { .type = TYPE_U8x4, .offset = 4 }
       }
@@ -4993,14 +4997,14 @@ Model* lovrModelCreate(const ModelInfo* info) {
     void* skinData = NULL;
     model->skinBuffer = lovrBufferCreate(&bufferInfo, &skinData);
     lovrAssertGoto(fail, model->skinBuffer, "Failed to create model skinning buffer: %s", lovrGetError());
-    memcpy(skinData, data->skinData, data->skinnedVertexCount * 8);
+    memcpy(skinData, data->skinData, meta->skinnedVertexCount * 8);
   }
 
   // Blend Shapes
-  if (data->blendedVertexCount > 0) {
+  if (meta->blendedVertexCount > 0) {
     BufferInfo bufferInfo = {
       .format = (DataField[]) {
-        { .length = data->blendedVertexCount, .stride = sizeof(BlendVertex), .fieldCount = 3 },
+        { .length = meta->blendedVertexCount, .stride = sizeof(BlendVertex), .fieldCount = 3 },
         { .type = TYPE_F32x3, .offset = offsetof(BlendVertex, position) },
         { .type = TYPE_F32x3, .offset = offsetof(BlendVertex, normal) },
         { .type = TYPE_F32x3, .offset = offsetof(BlendVertex, tangent) }
@@ -5010,18 +5014,18 @@ Model* lovrModelCreate(const ModelInfo* info) {
     void* blendData = NULL;
     model->blendBuffer = lovrBufferCreate(&bufferInfo, &blendData);
     lovrAssertGoto(fail, model->blendBuffer, "Failed to create model blend shape buffer: %s", lovrGetError());
-    memcpy(blendData, data->blendData, data->blendedVertexCount * sizeof(BlendData));
+    memcpy(blendData, data->blendData, meta->blendedVertexCount * sizeof(BlendData));
   }
 
   // Blend shapes
-  if (data->blendShapeCount > 0) {
-    model->blendShapeWeights = lovrMalloc(data->blendShapeCount * sizeof(float));
+  if (meta->blendShapeCount > 0) {
+    model->blendShapeWeights = lovrMalloc(meta->blendShapeCount * sizeof(float));
     lovrModelResetBlendShapes(model);
   }
 
   // Transforms
-  model->localTransforms = lovrMalloc(sizeof(NodeTransform) * data->nodeCount);
-  model->globalTransforms = lovrMalloc(16 * sizeof(float) * data->nodeCount);
+  model->localTransforms = lovrMalloc(sizeof(NodeTransform) * meta->nodeCount);
+  model->globalTransforms = lovrMalloc(16 * sizeof(float) * meta->nodeCount);
   lovrModelResetNodeTransforms(model);
 
   return model;
@@ -5031,12 +5035,13 @@ fail:
 }
 
 Model* lovrModelClone(Model* parent) {
-  ModelData* data = parent->info.data;
   Model* model = lovrCalloc(sizeof(Model));
   model->ref = 1;
   model->parent = parent;
-  model->info = parent->info;
+  model->meta = parent->meta;
   lovrRetain(parent);
+
+  ModelMetadata* meta = &model->meta;
 
   model->textures = parent->textures;
   model->materials = parent->materials;
@@ -5069,11 +5074,11 @@ Model* lovrModelClone(Model* parent) {
     }, 1);
   }
 
-  model->blendShapeWeights = lovrMalloc(data->blendShapeCount * sizeof(float));
+  model->blendShapeWeights = lovrMalloc(meta->blendShapeCount * sizeof(float));
   lovrModelResetBlendShapes(model);
 
-  model->localTransforms = lovrMalloc(sizeof(NodeTransform) * data->nodeCount);
-  model->globalTransforms = lovrMalloc(16 * sizeof(float) * data->nodeCount);
+  model->localTransforms = lovrMalloc(sizeof(NodeTransform) * meta->nodeCount);
+  model->globalTransforms = lovrMalloc(16 * sizeof(float) * meta->nodeCount);
   lovrModelResetNodeTransforms(model);
 
   return model;
@@ -5091,19 +5096,19 @@ void lovrModelDestroy(void* ref) {
     lovrFree(model);
     return;
   }
-  ModelData* data = model->info.data;
-  if (model->info.materials) {
-    for (uint32_t i = 0; i < data->materialCount; i++) {
+  ModelMetadata* meta = &model->meta;
+  if (model->materials) {
+    for (uint32_t i = 0; i < meta->materialCount; i++) {
       lovrRelease(model->materials[i], lovrMaterialDestroy);
     }
-    for (uint32_t i = 0; i < data->imageCount; i++) {
+    for (uint32_t i = 0; i < meta->imageCount; i++) {
       lovrRelease(model->textures[i], lovrTextureDestroy);
     }
     lovrFree(model->materials);
     lovrFree(model->textures);
   }
   if (model->meshes) {
-    for (uint32_t i = 0; i < data->meshCount; i++) {
+    for (uint32_t i = 0; i < meta->meshCount; i++) {
       lovrRelease(model->meshes[i], lovrMeshDestroy);
     }
   }
@@ -5112,7 +5117,7 @@ void lovrModelDestroy(void* ref) {
   lovrRelease(model->indexBuffer, lovrBufferDestroy);
   lovrRelease(model->blendBuffer, lovrBufferDestroy);
   lovrRelease(model->skinBuffer, lovrBufferDestroy);
-  lovrRelease(model->info.data, lovrModelDataDestroy);
+  lovrRelease(model->meta.blob, lovrBlobDestroy);
   lovrFree(model->localTransforms);
   lovrFree(model->globalTransforms);
   lovrFree(model->blendShapeWeights);
@@ -5120,31 +5125,30 @@ void lovrModelDestroy(void* ref) {
   lovrFree(model);
 }
 
-const ModelInfo* lovrModelGetInfo(Model* model) {
-  return &model->info;
+ModelMetadata* lovrModelGetMetadata(Model* model) {
+  return &model->meta;
 }
 
 void lovrModelResetNodeTransforms(Model* model) {
-  ModelData* data = model->info.data;
-  for (uint32_t i = 0; i < data->nodeCount; i++) {
+  ModelMetadata* meta = &model->meta;
+  for (uint32_t i = 0; i < meta->nodeCount; i++) {
     NodeTransform* transform = &model->localTransforms[i];
-    if (data->nodes[i].hasMatrix) {
-      mat4_getPosition(data->nodes[i].transform.matrix, transform->position);
-      mat4_getOrientation(data->nodes[i].transform.matrix, transform->rotation);
-      mat4_getScale(data->nodes[i].transform.matrix, transform->scale);
+    if (meta->nodes[i].hasMatrix) {
+      mat4_getPosition(meta->nodes[i].transform.matrix, transform->position);
+      mat4_getOrientation(meta->nodes[i].transform.matrix, transform->rotation);
+      mat4_getScale(meta->nodes[i].transform.matrix, transform->scale);
     } else {
-      vec3_init(transform->position, data->nodes[i].transform.translation);
-      quat_init(transform->rotation, data->nodes[i].transform.rotation);
-      vec3_init(transform->scale, data->nodes[i].transform.scale);
+      vec3_init(transform->position, meta->nodes[i].transform.translation);
+      quat_init(transform->rotation, meta->nodes[i].transform.rotation);
+      vec3_init(transform->scale, meta->nodes[i].transform.scale);
     }
   }
   model->transformsDirty = true;
 }
 
 void lovrModelResetBlendShapes(Model* model) {
-  ModelData* data = model->info.data;
-  for (uint32_t i = 0; i < data->blendShapeCount; i++) {
-    model->blendShapeWeights[i] = data->blendShapes[i].weight;
+  for (uint32_t i = 0; i < model->meta.blendShapeCount; i++) {
+    model->blendShapeWeights[i] = model->meta.blendShapes[i].weight;
   }
   model->blendShapesDirty = true;
 }
@@ -5152,9 +5156,9 @@ void lovrModelResetBlendShapes(Model* model) {
 bool lovrModelAnimate(Model* model, uint32_t animationIndex, float time, float alpha) {
   if (alpha <= 0.f) return true;
 
-  ModelData* data = model->info.data;
-  lovrCheck(animationIndex < data->animationCount, "Invalid animation index '%d' (Model has %d animation%s)", animationIndex + 1, data->animationCount, data->animationCount == 1 ? "" : "s");
-  ModelAnimation* animation = &data->animations[animationIndex];
+  ModelMetadata* meta = &model->meta;
+  lovrCheck(animationIndex < meta->animationCount, "Invalid animation index '%d' (Model has %d animation%s)", animationIndex + 1, meta->animationCount, meta->animationCount == 1 ? "" : "s");
+  ModelAnimation* animation = &meta->animations[animationIndex];
   time = fmodf(time, animation->duration);
 
   size_t stack = stackPush(&thread.stack);
@@ -5173,7 +5177,7 @@ bool lovrModelAnimate(Model* model, uint32_t animationIndex, float time, float a
       case PROP_TRANSLATION: n = 3; break;
       case PROP_SCALE: n = 3; break;
       case PROP_ROTATION: n = 4; break;
-      case PROP_WEIGHTS: n = data->meshes[data->nodes[node].mesh].blendShapeCount; break;
+      case PROP_WEIGHTS: n = meta->meshes[meta->nodes[node].mesh].blendShapeCount; break;
     }
 
     float* property = allocate(&thread.stack, n * sizeof(float));
@@ -5242,8 +5246,8 @@ bool lovrModelAnimate(Model* model, uint32_t animationIndex, float time, float a
       case PROP_SCALE: dst = model->localTransforms[node].scale; break;
       case PROP_ROTATION: dst = model->localTransforms[node].rotation; break;
       case PROP_WEIGHTS:;
-        ModelMesh* mesh = &data->meshes[data->nodes[node].mesh];
-        dst = &model->blendShapeWeights[mesh->blendShapes - data->blendShapes];
+        ModelMesh* mesh = &meta->meshes[meta->nodes[node].mesh];
+        dst = &model->blendShapeWeights[mesh->blendShapes - meta->blendShapes];
         break;
     }
 
@@ -5276,7 +5280,7 @@ void lovrModelGetNodeTransform(Model* model, uint32_t node, float position[3], f
     quat_init(rotation, model->localTransforms[node].rotation);
   } else {
     if (model->transformsDirty) {
-      updateModelTransforms(model, model->info.data->rootNode, (float[]) MAT4_IDENTITY);
+      updateModelTransforms(model, model->meta.rootNode, (float[]) MAT4_IDENTITY);
       model->transformsDirty = false;
     }
     mat4_getPosition(model->globalTransforms + 16 * node, position);
@@ -5312,8 +5316,8 @@ Buffer* lovrModelGetIndexBuffer(Model* model) {
 }
 
 Mesh* lovrModelGetMesh(Model* model, uint32_t index) {
-  ModelData* modelData = model->info.data;
-  uint32_t meshCount = modelData->meshCount;
+  ModelMetadata* meta = &model->meta;
+  uint32_t meshCount = meta->meshCount;
   lovrCheck(index < meshCount, "Invalid mesh index '%d' (Model has %d mesh%s)", index + 1, meshCount, meshCount == 1 ? "" : "es");
 
   if (!model->meshes) {
@@ -5330,7 +5334,7 @@ Mesh* lovrModelGetMesh(Model* model, uint32_t index) {
       return NULL;
     }
 
-    ModelMesh* data = &modelData->meshes[index];
+    ModelMesh* data = &meta->meshes[index];
     ModelPart* part = &data->parts[0];
 
     if (data->indexCount > 0) {
@@ -5352,7 +5356,7 @@ Mesh* lovrModelGetMesh(Model* model, uint32_t index) {
     }
 
     float bounds[6];
-    lovrModelDataGetMeshBoundingBox(modelData, index, bounds);
+    lovrModelMetadataGetMeshBoundingBox(meta, index, bounds);
     lovrMeshSetBoundingBox(mesh, bounds);
 
     model->meshes[index] = mesh;
@@ -5362,29 +5366,29 @@ Mesh* lovrModelGetMesh(Model* model, uint32_t index) {
 }
 
 Texture* lovrModelGetTexture(Model* model, uint32_t index) {
-  ModelData* data = model->info.data;
-  lovrCheck(index < data->imageCount, "Invalid texture index '%d' (Model has %d texture%s)", index + 1, data->imageCount, data->imageCount == 1 ? "" : "s");
+  uint32_t count = model->meta.imageCount;
+  lovrCheck(index < count, "Invalid texture index '%d' (Model has %d texture%s)", index + 1, count, count == 1 ? "" : "s");
   return model->textures[index];
 }
 
 Material* lovrModelGetMaterial(Model* model, uint32_t index) {
-  ModelData* data = model->info.data;
-  lovrCheck(index < data->materialCount, "Invalid material index '%d' (Model has %d material%s)", index + 1, data->materialCount, data->materialCount == 1 ? "" : "s");
+  uint32_t count = model->meta.materialCount;
+  lovrCheck(index < count, "Invalid material index '%d' (Model has %d material%s)", index + 1, count, count == 1 ? "" : "s");
   return model->materials[index];
 }
 
 static bool lovrModelAnimateVertices(Model* model) {
-  ModelData* data = model->info.data;
+  ModelMetadata* meta = &model->meta;
 
   bool blend = !!model->blendShapeWeights;
-  bool skin = data->skinCount > 0;
+  bool skin = meta->skinCount > 0;
 
   if ((!blend && !skin) || (!model->transformsDirty && !model->blendShapesDirty) || model->lastVertexAnimation == state.tick || !model->vertexBuffer) {
     return true;
   }
 
   if (model->transformsDirty) {
-    updateModelTransforms(model, model->info.data->rootNode, (float[]) MAT4_IDENTITY);
+    updateModelTransforms(model, meta->rootNode, (float[]) MAT4_IDENTITY);
     model->transformsDirty = false;
   }
 
@@ -5392,7 +5396,7 @@ static bool lovrModelAnimateVertices(Model* model) {
 
   if (blend) {
     Shader* shader = lovrGraphicsGetDefaultShader(SHADER_BLENDER);
-    uint32_t vertexCount = data->animatedVertexCount;
+    uint32_t vertexCount = meta->animatedVertexCount;
     uint32_t blendBufferCursor = 0;
     uint32_t blendShapeCursor = 0;
     uint32_t vertexCursor = 0;
@@ -5409,8 +5413,8 @@ static bool lovrModelAnimateVertices(Model* model) {
 
     gpu_bind_pipeline(state.stream, shader->computePipeline, GPU_PIPELINE_COMPUTE);
 
-    for (uint32_t i = 0; i < data->meshCount; i++) {
-      ModelMesh* mesh = &data->meshes[i];
+    for (uint32_t i = 0; i < meta->meshCount; i++) {
+      ModelMesh* mesh = &meta->meshes[i];
 
       for (uint32_t j = 0; j < mesh->blendShapeCount; j += chunkSize) {
         uint32_t blendShapeCount = MIN(mesh->blendShapeCount - j, chunkSize);
@@ -5463,9 +5467,9 @@ static bool lovrModelAnimateVertices(Model* model) {
     if (!shader) return false;
 
     gpu_binding bindings[] = {
-      { 0, GPU_SLOT_STORAGE_BUFFER, .buffer = { model->rawVertexBuffer->gpu, 0, data->skinnedVertexCount * sizeof(ModelVertex) } },
-      { 1, GPU_SLOT_STORAGE_BUFFER, .buffer = { model->vertexBuffer->gpu, 0, data->vertexCount * sizeof(ModelVertex) } },
-      { 2, GPU_SLOT_STORAGE_BUFFER, .buffer = { model->skinBuffer->gpu, 0, data->skinnedVertexCount * 8 } },
+      { 0, GPU_SLOT_STORAGE_BUFFER, .buffer = { model->rawVertexBuffer->gpu, 0, meta->skinnedVertexCount * sizeof(ModelVertex) } },
+      { 1, GPU_SLOT_STORAGE_BUFFER, .buffer = { model->vertexBuffer->gpu, 0, meta->vertexCount * sizeof(ModelVertex) } },
+      { 2, GPU_SLOT_STORAGE_BUFFER, .buffer = { model->skinBuffer->gpu, 0, meta->skinnedVertexCount * 8 } },
       { 3, GPU_SLOT_UNIFORM_BUFFER, .buffer = { NULL, 0, 0 } } // Filled in for each skin
     };
 
@@ -5474,8 +5478,8 @@ static bool lovrModelAnimateVertices(Model* model) {
     uint32_t skinVertexCursor = 0;
     ModelSkin* prevSkin = NULL;
 
-    for (uint32_t i = 0; i < data->meshCount; i++) {
-      ModelMesh* mesh = &data->meshes[i];
+    for (uint32_t i = 0; i < meta->meshCount; i++) {
+      ModelMesh* mesh = &meta->meshes[i];
       ModelSkin* skin = NULL;
 
       if (mesh->skinDataOffset == ~0u) {
@@ -5483,9 +5487,9 @@ static bool lovrModelAnimateVertices(Model* model) {
       }
 
       // Search through nodes to find the skin for this mesh
-      for (uint32_t j = 0; j < data->nodeCount; j++) {
-        if (data->nodes[j].mesh == i && data->nodes[j].skin != ~0u) {
-          skin = &data->skins[data->nodes[j].skin];
+      for (uint32_t j = 0; j < meta->nodeCount; j++) {
+        if (meta->nodes[j].mesh == i && meta->nodes[j].skin != ~0u) {
+          skin = &meta->skins[meta->nodes[j].skin];
           break;
         }
       }
@@ -8035,12 +8039,12 @@ bool lovrPassDrawMesh(Pass* pass, Mesh* mesh, float* transform, uint32_t instanc
 }
 
 static bool drawNode(Pass* pass, Model* model, uint32_t index, uint32_t instances) {
-  ModelData* data = model->info.data;
-  ModelNode* node = &data->nodes[index];
+  ModelMetadata* meta = &model->meta;
+  ModelNode* node = &meta->nodes[index];
   mat4 globalTransform = model->globalTransforms + 16 * index;
 
   if (node->mesh != ~0u) {
-    ModelMesh* mesh = &data->meshes[node->mesh];
+    ModelMesh* mesh = &meta->meshes[node->mesh];
     ModelPart* part = mesh->parts;
 
     for (uint32_t i = 0; i < mesh->partCount; i++, part++) {
@@ -8063,7 +8067,7 @@ static bool drawNode(Pass* pass, Model* model, uint32_t index, uint32_t instance
     }
   }
 
-  for (uint32_t i = node->child; i != ~0u; i = model->info.data->nodes[i].sibling) {
+  for (uint32_t i = node->child; i != ~0u; i = meta->nodes[i].sibling) {
     if (!drawNode(pass, model, i, instances)) {
       return false;
     }
@@ -8078,13 +8082,13 @@ bool lovrPassDrawModel(Pass* pass, Model* model, float* transform, uint32_t inst
   }
 
   if (model->transformsDirty) {
-    updateModelTransforms(model, model->info.data->rootNode, (float[]) MAT4_IDENTITY);
+    updateModelTransforms(model, model->meta.rootNode, (float[]) MAT4_IDENTITY);
     model->transformsDirty = false;
   }
 
   if (!lovrPassPush(pass, STACK_TRANSFORM)) return false;
   lovrPassTransform(pass, transform);
-  if (!drawNode(pass, model, model->info.data->rootNode, instances)) return false;
+  if (!drawNode(pass, model, model->meta.rootNode, instances)) return false;
   if (!lovrPassPop(pass, STACK_TRANSFORM)) return false;
   return true;
 }
@@ -8850,7 +8854,7 @@ static void updateModelTransforms(Model* model, uint32_t nodeIndex, float* paren
   mat4_rotateQuat(global, local->rotation);
   mat4_scale(global, local->scale[0], local->scale[1], local->scale[2]);
 
-  ModelNode* nodes = model->info.data->nodes;
+  ModelNode* nodes = model->meta.nodes;
   for (uint32_t i = nodes[nodeIndex].child; i != ~0u; i = nodes[i].sibling) {
     updateModelTransforms(model, i, global);
   }

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -5011,7 +5011,7 @@ Model* lovrModelCreate(const ModelInfo* info) {
     void* blendData = NULL;
     model->blendBuffer = lovrBufferCreate(&bufferInfo, &blendData);
     lovrAssertGoto(fail, model->blendBuffer, "Failed to create model blend shape buffer: %s", lovrGetError());
-    memcpy(blendData, data->blendData, data->vertexCount * data->blendShapeCount * sizeof(BlendData));
+    memcpy(blendData, data->blendData, data->blendedVertexCount * sizeof(BlendData));
   }
 
   // Draws

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4994,7 +4994,7 @@ Model* lovrModelCreate(const ModelInfo* info) {
     void* skinData = NULL;
     model->skinBuffer = lovrBufferCreate(&bufferInfo, &skinData);
     lovrAssertGoto(fail, model->skinBuffer, "Failed to create model skinning buffer: %s", lovrGetError());
-    memcpy(skinData, data->skinData, data->vertexCount * 8);
+    memcpy(skinData, data->skinData, data->skinnedVertexCount * 8);
   }
 
   // Blend Shapes
@@ -5015,6 +5015,7 @@ Model* lovrModelCreate(const ModelInfo* info) {
   }
 
   // Draws
+  uint32_t baseVertex = 0;
   model->draws = lovrCalloc(data->primitiveCount * sizeof(DrawInfo));
   for (uint32_t i = 0, drawIndex = 0; i < data->meshCount; i++) {
     ModelMesh* mesh = &data->meshes[i];
@@ -5032,10 +5033,16 @@ Model* lovrModelCreate(const ModelInfo* info) {
 
       draw->material = !info->materials || primitive->material == ~0u ? NULL: model->materials[primitive->material];
       draw->vertex.buffer = model->vertexBuffer;
-      draw->index.buffer = mesh->indices ? model->indexBuffer : NULL;
       draw->start = primitive->start;
       draw->count = primitive->count;
       draw->bounds = primitive->bounds;
+
+      if (primitive->indexCount > 0) {
+        draw->index.buffer = model->indexBuffer;
+        draw->baseVertex = baseVertex;
+      }
+
+      baseVertex += primitive->vertexCount;
     }
   }
 
@@ -5474,7 +5481,7 @@ static bool lovrModelAnimateVertices(Model* model) {
 
     gpu_binding bindings[] = {
       { 0, GPU_SLOT_STORAGE_BUFFER, .buffer = { model->rawVertexBuffer->gpu, 0, data->skinnedVertexCount * sizeof(ModelVertex) } },
-      { 1, GPU_SLOT_STORAGE_BUFFER, .buffer = { model->vertexBuffer->gpu, 0, data->skinnedVertexCount * sizeof(ModelVertex) } },
+      { 1, GPU_SLOT_STORAGE_BUFFER, .buffer = { model->vertexBuffer->gpu, 0, data->vertexCount * sizeof(ModelVertex) } },
       { 2, GPU_SLOT_STORAGE_BUFFER, .buffer = { model->skinBuffer->gpu, 0, data->skinnedVertexCount * 8 } },
       { 3, GPU_SLOT_UNIFORM_BUFFER, .buffer = { NULL, 0, 0 } } // Filled in for each skin
     };
@@ -5488,7 +5495,9 @@ static bool lovrModelAnimateVertices(Model* model) {
       ModelMesh* mesh = &data->meshes[i];
       ModelSkin* skin = NULL;
 
-      if (!mesh->skinData) continue;
+      if (!mesh->skinData) {
+        continue;
+      }
 
       for (uint32_t j = 0; j < data->nodeCount; j++) {
         if (data->nodes[j].mesh == i && data->nodes[j].skin != ~0u) {
@@ -5528,9 +5537,6 @@ static bool lovrModelAnimateVertices(Model* model) {
       uint32_t maxVerticesPerDispatch = (uint32_t) MIN((uint64_t) state.limits.workgroupCount[0] * subgroupSize, (uint64_t) verticesRemaining);
       uint32_t baseVertex = mesh->vertices - data->vertices;
       bool inplace = mesh->blendShapeCount > 0;
-
-      // TODO do we need to send both the raw vertex buffer offset and the vertex offset?
-      // Note: to get raw vertex buffer offset, maintain a cursor in this loop
 
       while (verticesRemaining > 0) {
         uint32_t vertexCount = MIN(verticesRemaining, maxVerticesPerDispatch);

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -464,8 +464,10 @@ void lovrMeshSetBoundingBox(Mesh* mesh, float box[6]);
 bool lovrMeshComputeBoundingBox(Mesh* mesh);
 DrawMode lovrMeshGetDrawMode(Mesh* mesh);
 void lovrMeshSetDrawMode(Mesh* mesh, DrawMode mode);
-void lovrMeshGetDrawRange(Mesh* mesh, uint32_t* start, uint32_t* count, uint32_t* offset);
-bool lovrMeshSetDrawRange(Mesh* mesh, uint32_t start, uint32_t count, uint32_t offset);
+void lovrMeshGetDrawRange(Mesh* mesh, uint32_t* start, uint32_t* count);
+bool lovrMeshSetDrawRange(Mesh* mesh, uint32_t start, uint32_t count);
+uint32_t lovrMeshGetBaseVertex(Mesh* mesh);
+void lovrMeshSetBaseVertex(Mesh* mesh, uint32_t base);
 Material* lovrMeshGetMaterial(Mesh* mesh);
 void lovrMeshSetMaterial(Mesh* mesh, Material* material);
 

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -8,6 +8,7 @@ struct Blob;
 struct Image;
 struct Rasterizer;
 struct ModelData;
+struct ModelMetadata;
 
 typedef struct Buffer Buffer;
 typedef struct Texture Texture;
@@ -484,7 +485,7 @@ typedef enum {
 Model* lovrModelCreate(const ModelInfo* info);
 Model* lovrModelClone(Model* model);
 void lovrModelDestroy(void* ref);
-const ModelInfo* lovrModelGetInfo(Model* model);
+struct ModelMetadata* lovrModelGetMetadata(Model* model);
 void lovrModelResetNodeTransforms(Model* model);
 void lovrModelResetBlendShapes(Model* model);
 bool lovrModelAnimate(Model* model, uint32_t animationIndex, float time, float alpha);

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -694,6 +694,7 @@ bool lovrPassSkybox(Pass* pass, Texture* texture);
 bool lovrPassFill(Pass* pass, Texture* texture);
 bool lovrPassMonkey(Pass* pass, float* transform);
 bool lovrPassDrawModel(Pass* pass, Model* model, float* transform, uint32_t instances);
+bool lovrPassDrawPart(Pass* pass, Model* model, uint32_t mesh, uint32_t part, float* transform, uint32_t instances);
 bool lovrPassDrawMesh(Pass* pass, Mesh* mesh, float* transform, uint32_t instances);
 bool lovrPassDrawTexture(Pass* pass, Texture* texture, float* transform);
 bool lovrPassMesh(Pass* pass, Buffer* vertices, Buffer* indices, float* transform, uint32_t start, uint32_t count, uint32_t instances, uint32_t baseVertex);

--- a/src/modules/headset/headset.c
+++ b/src/modules/headset/headset.c
@@ -4110,7 +4110,7 @@ static bool loadVisibilityMask(void) {
     info.indices += info.indexCountOutput;
   }
 
-  lovrMeshSetDrawRange(state.mask, 0, indexCount, 0);
+  lovrMeshSetDrawRange(state.mask, 0, indexCount);
 
   return true;
 }

--- a/src/modules/headset/headset.c
+++ b/src/modules/headset/headset.c
@@ -2817,8 +2817,6 @@ static ModelData* newModelDataFB(uint64_t key) {
   model->nodes[XR_HAND_JOINT_WRIST_EXT].parent = model->rootNode;
   model->nodes[model->jointCount].parent = model->rootNode;
 
-  lovrModelDataFinalize(model);
-
   return model;
 }
 

--- a/src/modules/headset/headset.c
+++ b/src/modules/headset/headset.c
@@ -2685,7 +2685,6 @@ static ModelData* newModelDataFB(uint64_t key) {
   model->meshCount = 1;
   model->skinCount = 1;
   model->nodeCount = 2 + jointCount;
-  model->primitiveCount = 1;
   model->jointCount = jointCount;
   model->vertexCount = vertexCount;
   model->indexCount = indexCount;
@@ -2721,24 +2720,10 @@ static ModelData* newModelDataFB(uint64_t key) {
 
   memcpy(model->indices, mesh.indices, model->indexCount * model->indexSize);
 
-  model->meshes[0] = (ModelMesh) {
-    .primitiveCount = 1,
-    .vertexCount = vertexCount,
-    .indexCount = indexCount,
-    .primitives = model->primitives,
-    .vertices = model->vertices,
-    .indices = model->indices,
-    .skinData = model->skinData
-  };
-
-  model->primitives[0] = (ModelPrimitive) {
-    .mode = DRAW_TRIANGLE_LIST,
-    .material = ~0u,
-    .start = 0,
-    .count = indexCount,
-    .vertexCount = vertexCount,
-    .indexCount = indexCount
-  };
+  model->meshes[0].vertexOffset = 0;
+  model->meshes[0].vertexCount = vertexCount;
+  model->meshes[0].indexOffset = 0;
+  model->meshes[0].indexCount = indexCount;
 
   model->skins[0] = (ModelSkin) {
     .jointCount = model->jointCount,
@@ -2760,6 +2745,7 @@ static ModelData* newModelDataFB(uint64_t key) {
       .child = ~0u,
       .sibling = ~0u,
       .parent = i == 0 ? ~0u : parent,
+      .mesh = ~0u,
       .skin = ~0u
     };
 

--- a/src/modules/headset/headset.c
+++ b/src/modules/headset/headset.c
@@ -2598,7 +2598,7 @@ static ModelData* newModelDataEXT(uint64_t key) {
     lovrRelease(blob, lovrBlobDestroy);
 
     if (modelData) {
-      modelData->id = key;
+      modelData->meta.id = key;
 
       if (!model->nodes) {
         uint32_t nodeCount = model->properties.animatableNodeCount;
@@ -2607,8 +2607,13 @@ static ModelData* newModelDataEXT(uint64_t key) {
 
         for (uint32_t n = 0; n < nodeCount; n++) {
           const char* name = nodeProperties[n].uniqueName;
-          size_t length = strlen(nodeProperties[n].uniqueName);
-          model->nodes[n] = map_get(modelData->nodeMap, hash64(name, length));
+          uint32_t hash = (uint32_t) hash64(name, strlen(name));
+          for (uint32_t m = 0; m < modelData->meta.nodeCount; m++) {
+            if (modelData->meta.nodeLookup[m] == hash) {
+              model->nodes[n] = m;
+              break;
+            }
+          }
         }
       }
     }
@@ -2681,15 +2686,15 @@ static ModelData* newModelDataFB(uint64_t key) {
 
   ModelData* model = lovrCalloc(sizeof(ModelData));
   model->ref = 1;
-  model->id = key;
-  model->meshCount = 1;
-  model->skinCount = 1;
-  model->nodeCount = 2 + jointCount;
-  model->jointCount = jointCount;
-  model->vertexCount = vertexCount;
-  model->indexCount = indexCount;
-  model->skinnedVertexCount = vertexCount;
-  model->indexSize = 2;
+  model->meta.id = key;
+  model->meta.meshCount = 1;
+  model->meta.skinCount = 1;
+  model->meta.nodeCount = 2 + jointCount;
+  model->meta.jointCount = jointCount;
+  model->meta.vertexCount = vertexCount;
+  model->meta.indexCount = indexCount;
+  model->meta.skinnedVertexCount = vertexCount;
+  model->meta.indexSize = 2;
   lovrModelDataAllocate(model);
 
   XrVector3f* positions = mesh.vertexPositions;
@@ -2718,27 +2723,29 @@ static ModelData* newModelDataFB(uint64_t key) {
     };
   }
 
-  memcpy(model->indices, mesh.indices, model->indexCount * model->indexSize);
+  ModelMetadata* meta = &model->meta;
 
-  model->meshes[0].vertexOffset = 0;
-  model->meshes[0].vertexCount = vertexCount;
-  model->meshes[0].indexOffset = 0;
-  model->meshes[0].indexCount = indexCount;
+  memcpy(model->indices, mesh.indices, meta->indexCount * meta->indexSize);
 
-  model->skins[0] = (ModelSkin) {
-    .jointCount = model->jointCount,
-    .joints = model->joints,
-    .inverseBindMatrices = model->inverseBindMatrices
+  meta->meshes[0].vertexOffset = 0;
+  meta->meshes[0].vertexCount = vertexCount;
+  meta->meshes[0].indexOffset = 0;
+  meta->meshes[0].indexCount = indexCount;
+
+  meta->skins[0] = (ModelSkin) {
+    .jointCount = meta->jointCount,
+    .joints = meta->joints,
+    .inverseBindMatrices = meta->inverseBindMatrices
   };
 
   // The nodes in the Model correspond directly to the joints in the skin, for convenience
-  for (uint32_t i = 0; i < model->jointCount; i++) {
-    model->joints[i] = i;
+  for (uint32_t i = 0; i < meta->jointCount; i++) {
+    meta->joints[i] = i;
 
     uint32_t parent = mesh.jointParents[i];
 
     // Joint node
-    model->nodes[i] = (ModelNode) {
+    meta->nodes[i] = (ModelNode) {
       .transform.translation = { 0.f, 0.f, 0.f },
       .transform.rotation = { 0.f, 0.f, 0.f, 1.f },
       .transform.scale = { 1.f, 1.f, 1.f },
@@ -2750,8 +2757,8 @@ static ModelData* newModelDataFB(uint64_t key) {
     };
 
     if (i > 0) {
-      model->nodes[i].sibling = model->nodes[parent].child;
-      model->nodes[parent].child = i;
+      meta->nodes[i].sibling = meta->nodes[parent].child;
+      meta->nodes[parent].child = i;
     }
 
     // Inverse bind matrix
@@ -2762,7 +2769,7 @@ static ModelData* newModelDataFB(uint64_t key) {
   }
 
   // Add a node that holds the skinned mesh
-  model->nodes[model->jointCount] = (ModelNode) {
+  meta->nodes[meta->jointCount] = (ModelNode) {
     .transform.translation = { 0.f, 0.f, 0.f },
     .transform.rotation = { 0.f, 0.f, 0.f, 1.f },
     .transform.scale = { 1.f, 1.f, 1.f },
@@ -2774,8 +2781,8 @@ static ModelData* newModelDataFB(uint64_t key) {
   };
 
   // The root node has the mesh node and root joint as children
-  model->rootNode = model->jointCount + 1;
-  model->nodes[model->rootNode] = (ModelNode) {
+  meta->rootNode = meta->jointCount + 1;
+  meta->nodes[meta->rootNode] = (ModelNode) {
     .hasMatrix = true,
     .transform = { MAT4_IDENTITY },
     .child = ~0u,
@@ -2786,10 +2793,10 @@ static ModelData* newModelDataFB(uint64_t key) {
   };
 
   // Add the 2 children to the root node
-  model->nodes[model->rootNode].child = XR_HAND_JOINT_WRIST_EXT;
-  model->nodes[XR_HAND_JOINT_WRIST_EXT].sibling = model->jointCount;
-  model->nodes[XR_HAND_JOINT_WRIST_EXT].parent = model->rootNode;
-  model->nodes[model->jointCount].parent = model->rootNode;
+  meta->nodes[meta->rootNode].child = XR_HAND_JOINT_WRIST_EXT;
+  meta->nodes[XR_HAND_JOINT_WRIST_EXT].sibling = meta->jointCount;
+  meta->nodes[XR_HAND_JOINT_WRIST_EXT].parent = meta->rootNode;
+  meta->nodes[meta->jointCount].parent = meta->rootNode;
 
   return model;
 }
@@ -2806,7 +2813,7 @@ ModelData* lovrHeadsetNewModelData(uint64_t key) {
 
 bool lovrHeadsetGetModelPose(Model* model, float* position, float* orientation) {
   if (state.extensions.renderModel) {
-    uint64_t key = lovrModelGetInfo(model)->data->id;
+    uint64_t key = lovrModelGetMetadata(model)->id;
 
     for (uint32_t i = 0; i < state.modelCount; i++) {
       if (state.modelKeys[i] != key) {
@@ -2823,7 +2830,7 @@ bool lovrHeadsetGetModelPose(Model* model, float* position, float* orientation) 
 
     return false;
   } else if (state.extensions.handTrackingMesh) {
-    Device device = lovrModelGetInfo(model)->data->id == 1 ? DEVICE_HAND_LEFT : DEVICE_HAND_RIGHT;
+    Device device = lovrModelGetMetadata(model)->id == 1 ? DEVICE_HAND_LEFT : DEVICE_HAND_RIGHT;
     return lovrHeadsetGetPose(device, position, orientation);
   }
 
@@ -2831,7 +2838,7 @@ bool lovrHeadsetGetModelPose(Model* model, float* position, float* orientation) 
 }
 
 static bool animateEXT(Model* model) {
-  uint64_t key = lovrModelGetInfo(model)->data->id;
+  uint64_t key = lovrModelGetMetadata(model)->id;
 
   for (uint32_t i = 0; i < state.modelCount; i++) {
     if (state.modelKeys[i] != key) {
@@ -2879,7 +2886,7 @@ static bool animateEXT(Model* model) {
 }
 
 static bool animateFB(Model* model) {
-  Device device = lovrModelGetInfo(model)->data->id == 1 ? DEVICE_HAND_LEFT : DEVICE_HAND_RIGHT;
+  Device device = lovrModelGetMetadata(model)->id == 1 ? DEVICE_HAND_LEFT : DEVICE_HAND_RIGHT;
   XrHandTrackerEXT tracker = state.handTrackers[device == DEVICE_HAND_RIGHT];
 
   XrHandJointsLocateInfoEXT locateInfo = {

--- a/src/modules/headset/headset.c
+++ b/src/modules/headset/headset.c
@@ -2682,83 +2682,71 @@ static ModelData* newModelDataFB(uint64_t key) {
   ModelData* model = lovrCalloc(sizeof(ModelData));
   model->ref = 1;
   model->id = key;
-  model->blobCount = 1;
-  model->bufferCount = 6;
-  model->attributeCount = 6;
-  model->primitiveCount = 1;
+  model->meshCount = 1;
   model->skinCount = 1;
-  model->jointCount = jointCount;
   model->nodeCount = 2 + jointCount;
+  model->primitiveCount = 1;
+  model->jointCount = jointCount;
+  model->vertexCount = vertexCount;
+  model->indexCount = indexCount;
+  model->skinnedVertexCount = vertexCount;
+  model->indexSize = 2;
   lovrModelDataAllocate(model);
 
-  model->blobs[0] = lovrBlobCreate(meshData, totalSize, "Hand Mesh Data");
+  XrVector3f* positions = mesh.vertexPositions;
+  XrVector3f* normals = mesh.vertexNormals;
+  XrVector2f* uvs = mesh.vertexUVs;
 
-  model->buffers[0] = (ModelBuffer) {
-    .offset = (char*) mesh.vertexPositions - (char*) meshData,
-    .data = (char*) mesh.vertexPositions,
-    .size = sizeof(mesh.vertexPositions[0]) * vertexCount,
-    .stride = sizeof(mesh.vertexPositions[0])
+  for (uint32_t i = 0; i < vertexCount; i++) {
+    model->vertices[i] = (ModelVertex) {
+      .position = { positions[i].x, positions[i].y, positions[i].z },
+      .normal =
+        ((((uint32_t) (int32_t) (normals[i].x * 511.f)) & 0x3ff) <<  0) |
+        ((((uint32_t) (int32_t) (normals[i].y * 511.f)) & 0x3ff) << 10) |
+        ((((uint32_t) (int32_t) (normals[i].z * 511.f)) & 0x3ff) << 20),
+      .uv = { uvs[i].x, uvs[i].y },
+      .color = { 0xff, 0xff, 0xff, 0xff }
+    };
+  }
+
+  XrVector4sFB* joints = mesh.vertexBlendIndices;
+  XrVector4f* weights = mesh.vertexBlendWeights;
+
+  for (uint32_t i = 0; i < vertexCount; i++) {
+    model->skinData[i] = (SkinData) {
+      .joints = { (uint8_t) joints[i].x, (uint8_t) joints[i].y, (uint8_t) joints[i].z, (uint8_t) joints[i].w },
+      .weights = { weights[i].x * 255.f + .5f, weights[i].y * 255.f + .5f, weights[i].z * 255.f + .5f, weights[i].w * 255.f + .5f },
+    };
+  }
+
+  memcpy(model->indices, mesh.indices, model->indexCount * model->indexSize);
+
+  model->meshes[0] = (ModelMesh) {
+    .primitiveCount = 1,
+    .vertexCount = vertexCount,
+    .indexCount = indexCount,
+    .primitives = model->primitives,
+    .vertices = model->vertices,
+    .indices = model->indices,
+    .skinData = model->skinData
   };
-
-  model->buffers[1] = (ModelBuffer) {
-    .offset = (char*) mesh.vertexNormals - (char*) meshData,
-    .data = (char*) mesh.vertexNormals,
-    .size = sizeof(mesh.vertexNormals[0]) * vertexCount,
-    .stride = sizeof(mesh.vertexNormals[0])
-  };
-
-  model->buffers[2] = (ModelBuffer) {
-    .offset = (char*) mesh.vertexUVs - (char*) meshData,
-    .data = (char*) mesh.vertexUVs,
-    .size = sizeof(mesh.vertexUVs[0]) * vertexCount,
-    .stride = sizeof(mesh.vertexUVs[0])
-  };
-
-  model->buffers[3] = (ModelBuffer) {
-    .offset = (char*) mesh.vertexBlendIndices - (char*) meshData,
-    .data = (char*) mesh.vertexBlendIndices,
-    .size = sizeof(mesh.vertexBlendIndices[0]) * vertexCount,
-    .stride = sizeof(mesh.vertexBlendIndices[0])
-  };
-
-  model->buffers[4] = (ModelBuffer) {
-    .offset = (char*) mesh.vertexBlendWeights - (char*) meshData,
-    .data = (char*) mesh.vertexBlendWeights,
-    .size = sizeof(mesh.vertexBlendWeights[0]) * vertexCount,
-    .stride = sizeof(mesh.vertexBlendWeights[0])
-  };
-
-  model->buffers[5] = (ModelBuffer) {
-    .offset = (char*) mesh.indices - (char*) meshData,
-    .data = (char*) mesh.indices,
-    .size = sizeof(mesh.indices[0]) * indexCount,
-    .stride = sizeof(mesh.indices[0])
-  };
-
-  model->attributes[0] = (ModelAttribute) { .buffer = 0, .type = F32, .components = 3, .count = vertexCount };
-  model->attributes[1] = (ModelAttribute) { .buffer = 1, .type = F32, .components = 3 };
-  model->attributes[2] = (ModelAttribute) { .buffer = 2, .type = F32, .components = 2 };
-  model->attributes[3] = (ModelAttribute) { .buffer = 3, .type = I16, .components = 4 };
-  model->attributes[4] = (ModelAttribute) { .buffer = 4, .type = F32, .components = 4 };
-  model->attributes[5] = (ModelAttribute) { .buffer = 5, .type = U16, .components = 1, .count = indexCount };
 
   model->primitives[0] = (ModelPrimitive) {
     .mode = DRAW_TRIANGLE_LIST,
-    .attributes = {
-      [ATTR_POSITION] = &model->attributes[0],
-      [ATTR_NORMAL] = &model->attributes[1],
-      [ATTR_UV] = &model->attributes[2],
-      [ATTR_JOINTS] = &model->attributes[3],
-      [ATTR_WEIGHTS] = &model->attributes[4]
-    },
-    .indices = &model->attributes[5],
-    .material = ~0u
+    .material = ~0u,
+    .start = 0,
+    .count = indexCount,
+    .vertexCount = vertexCount,
+    .indexCount = indexCount
+  };
+
+  model->skins[0] = (ModelSkin) {
+    .jointCount = model->jointCount,
+    .joints = model->joints,
+    .inverseBindMatrices = model->inverseBindMatrices
   };
 
   // The nodes in the Model correspond directly to the joints in the skin, for convenience
-  model->skins[0].joints = model->joints;
-  model->skins[0].jointCount = model->jointCount;
-  model->skins[0].inverseBindMatrices = inverseBindMatrices;
   for (uint32_t i = 0; i < model->jointCount; i++) {
     model->joints[i] = i;
 
@@ -2792,11 +2780,10 @@ static ModelData* newModelDataFB(uint64_t key) {
     .transform.translation = { 0.f, 0.f, 0.f },
     .transform.rotation = { 0.f, 0.f, 0.f, 1.f },
     .transform.scale = { 1.f, 1.f, 1.f },
-    .primitiveIndex = 0,
-    .primitiveCount = 1,
     .child = ~0u,
     .sibling = ~0u,
     .parent = ~0u,
+    .mesh = 0,
     .skin = 0
   };
 
@@ -2808,6 +2795,7 @@ static ModelData* newModelDataFB(uint64_t key) {
     .child = ~0u,
     .sibling = ~0u,
     .parent = ~0u,
+    .mesh = ~0u,
     .skin = ~0u
   };
 

--- a/test/lovr/data.lua
+++ b/test/lovr/data.lua
@@ -103,4 +103,85 @@ group('data', function()
       expect({ image:getPixel(3, 3) }).to.equal({ 9, 8, 0, 1 })
     end)
   end)
+
+  group('ModelData', function()
+    local blob = lovr.data.newBlob([[{
+      "asset": { "version": "2.0" },
+      "scene": 0,
+      "scenes": [{ "nodes": [0] }],
+      "nodes": [{ "mesh": 0 }],
+      "meshes": [
+        {
+          "primitives": [{ "attributes": { "POSITION": 0 } }]
+        }
+      ],
+      "buffers": [
+        {
+          "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAA",
+          "byteLength": 36
+        }
+      ],
+      "bufferViews": [
+        {
+          "buffer": 0,
+          "byteOffset": 0,
+          "byteLength": 36,
+          "target": 34962
+        }
+      ],
+      "accessors": [
+        {
+          "bufferView": 0,
+          "byteOffset": 0,
+          "componentType": 5126,
+          "count": 3,
+          "type": "VEC3",
+          "max": [1, 1, 0],
+          "min": [0, 0, 0]
+        }
+      ]
+    }]])
+
+    local model = lovr.data.newModelData(blob)
+
+    test('getMetadata', function()
+      expect(model:getMetadata()).to.equal(blob:getString())
+    end)
+
+    test('nodes', function()
+      expect(model:getRootNode()).to.equal(1)
+      expect(model:getNodeCount()).to.equal(1)
+      expect(model:getNodeName(1)).to.equal(nil)
+      expect(model:getNodeChild(1)).to.equal(nil)
+      expect(model:getNodeSibling(1)).to.equal(nil)
+      expect(model:getNodeParent(1)).to.equal(nil)
+      expect({ model:getNodeTransform(1) }).to.equal({ 0, 0, 0, 1, 1, 1, 0, 0, 0, 0 })
+      expect(model:getNodeMesh(1)).to.equal(1)
+      expect(model:getNodeSkin(1)).to.equal(nil)
+      expect(function() model:getNodeChild(2) end).to.fail()
+    end)
+
+    test('meshes', function()
+      expect(model:getMeshCount()).to.equal(1)
+      expect(model:getMeshBlendShapeCount(1)).to.equal(0)
+      expect(model:getMeshVertexCount(1)).to.equal(3)
+      expect(model:getMeshIndexCount(1)).to.equal(0)
+      expect({ model:getMeshVertex(1, 1) }).to.equal({ 0, 0, 0; 0, 0, 0; 0, 0; 255, 255, 255, 255; 0, 0, 0 })
+      expect({ model:getMeshVertex(1, 2) }).to.equal({ 1, 0, 0; 0, 0, 0; 0, 0; 255, 255, 255, 255; 0, 0, 0 })
+      expect({ model:getMeshVertex(1, 3) }).to.equal({ 0, 1, 0; 0, 0, 0; 0, 0; 255, 255, 255, 255; 0, 0, 0 })
+      expect(model:getMeshPartCount(1)).to.equal(1)
+      expect(model:getMeshDrawMode(1)).to.equal('triangles')
+      expect(model:getMeshDrawRange(1)).to.equal(1, 3)
+      expect(model:getMeshMaterial(1)).to.equal(nil)
+    end)
+
+    test('bounds', function()
+      expect(model:getWidth()).to.equal(1)
+      expect(model:getHeight()).to.equal(1)
+      expect(model:getDepth()).to.equal(0)
+      expect({ model:getDimensions() }).to.equal({ 1, 1, 0 })
+      expect({ model:getCenter() }).to.equal({ .5, .5, 0 })
+      expect({ model:getBoundingBox() }).to.equal({ 0, 1, 0, 1, 0, 0 })
+    end)
+  end)
 end)


### PR DESCRIPTION
Attempt to improve some of the pain points in ModelData and Model, described in #858.

The most exciting improvements are:

- `Model` no longer retains its `ModelData`.  So after you create a `Model`, the CPU data for its textures and mesh data can now be released, greatly reducing memory usage for projects that load a lot of big models.
- Creating a model will use multiple threads to load the textures now.  I was seeing around a 2x improvement in `lovr.graphics.newModel` load times, but it will vary based on the exact model and number of cores.
- Add a `Pass:drawPart` method that lets you draw part of a model (a mesh, or a part of a mesh).
- Add a `Model:meshes` iterator that lets you walk the nodes and meshes of a model.  This is a convenient way to draw each mesh explicitly, allowing you to change render states/shaders/etc. for each mesh in a model:

```lua
for node, mesh in model:meshes() do
  local transform = mat4(model:getNodeTransform(node))
  for i = 1, model:getMeshPartCount(mesh) do
    pass:drawPart(model, mesh, i, transform)
  end
end
```

Summary of other changes:

- Remove `Model:getData`, because Models don't store their ModelData anymore.
- Removed `Model(Data):getBoundingSphere`.  There are too many different ways to get the sphere, I think it's too opinionated for LÖVR to pick one.
- Deprecated `Model:getMesh`, `Model:getVertexBuffer`, and `Model:getIndexBuffer`.  It isn't very lovely to expose object internals, and it opens up potential for a ton of inconsistencies.  I don't think it's a good design.  Instead, you can create your own Meshes or Buffers from the data in a ModelData now.
- Change `:getNodeChildren` to `:getNodeChild` and `:getNodeSibling`.  It doesn't generate garbage.
- Change the distinction between meshes and "parts".  In the existing API, nodes could have a collection of meshes attached to them, where each mesh could have a unique material, draw mode, etc.  Now, nodes have a single mesh, and meshes can have multiple "parts" (they correspond to glTF primitives, similar to the old meshes).  This simplifies the API a bit (1 node per mesh), reduces the number of meshes in a model, and I think it better matches people's assumptions about what a mesh is.
  - I went back and forth on this quite a bit.
  - Mesh accessors like `:getMeshDrawRange`, `:getMeshMaterial`, etc. take a `part` index that defaults to 1.  If your models don't have multiple materials per mesh, you can ignore parts completely and let it default to 1.
- ModelData has accessors to get the vertices/indices of each mesh individually.
  - These already existed, but they were really difficult to use because each mesh could have its own vertex format.  The new ones are much easier to use.
  - You can also get the bounding box info for a single mesh in the model, or even a single part of a mesh.
- Models can't provide triangles anymore, so you can't do `lovr.audio.setGeometry(model)`, `lovr.physics.newConvexShape(model)`, etc.  You'll have to use a `ModelData` for that.
- Change the glTF importer to convert vertices at import, instead of converting them on the fly as they're uploaded to GPU buffers.  This simplifies the code a ton, as well as the vertex accessor APIs, because now model vertices are always in a consistent format.

Future stuff:

- You still need to use `Model` if you want animations.  I have some plans for animation APIs in Mesh, but those will be a separate change.