### PR TITLE
mat4 mul vector return the same vector format

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -814,3 +814,25 @@ int luax_readmat4(lua_State* L, int index, mat4 m, int scaleComponents) {
       return luax_typeerror(L, index, "number, table, vector, or Mat4");
   }
 }
+
+void luax_pushvec3(lua_State* L, float v[3], bool tableArray) {
+  if (tableArray) {
+    lua_createtable(L, 3, 0);
+    lua_pushnumber(L, v[0]);
+    lua_rawseti(L, -2, 1);
+    lua_pushnumber(L, v[1]);
+    lua_rawseti(L, -2, 2);
+    lua_pushnumber(L, v[2]);
+    lua_rawseti(L, -2, 3);
+  } else {
+    lua_createtable(L, 0, 3);
+    lua_pushnumber(L, v[0]);
+    lua_setfield(L, -2, "x");
+    lua_pushnumber(L, v[1]);
+    lua_setfield(L, -2, "y");
+    lua_pushnumber(L, v[2]);
+    lua_setfield(L, -2, "z");
+    lua_getmetatable(L, 2);
+    lua_setmetatable(L, -2);
+  }
+}

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -144,6 +144,7 @@ int luax_readvec3(lua_State* L, int index, float* v, const char* expected);
 int luax_readscale(lua_State* L, int index, float* v, int components, const char* expected);
 int luax_readquat(lua_State* L, int index, float* q, const char* expected);
 int luax_readmat4(lua_State* L, int index, float* m, int scaleComponents);
+void luax_pushvec3(lua_State* L, float v[3], bool tableArray);
 
 // Module helpers
 

--- a/src/api/l_math_mat4.c
+++ b/src/api/l_math_mat4.c
@@ -158,19 +158,15 @@ static int l_lovrMat4Mul(lua_State* L) {
     int index = luax_readvec3(L, 2, v, "number, vector, or Mat4");
     v[3] = luax_optfloat(L, index, 1.f);
     mat4_mulVec4(lovrMat4GetData(matrix), v);
+    if (lua_istable(L, 2)) {
+      luax_pushvec3(L, v, luax_len(L, 2) > 0);
+    } else {
 #ifdef LOVR_USE_LUAU
-    lua_pushvector(L, v[0], v[1], v[2]);
+      lua_pushvector(L, v[0], v[1], v[2]);
 #else
-    lua_createtable(L, 3, 0);
-    lua_pushnumber(L, v[0]);
-    lua_setfield(L, -2, "x");
-    lua_pushnumber(L, v[1]);
-    lua_setfield(L, -2, "y");
-    lua_pushnumber(L, v[2]);
-    lua_setfield(L, -2, "z");
-    lua_getmetatable(L, 2);
-    lua_setmetatable(L, -2);
+      luax_pushvec3(L, v, false);
 #endif
+    }
     return 1;
   }
 }
@@ -328,15 +324,7 @@ static int l_lovrMat4__mul(lua_State* L) {
     float v[3];
     luax_readvec3(L, 2, v, NULL);
     mat4_mulPoint(lovrMat4GetData(self), v);
-    lua_createtable(L, 3, 0);
-    lua_pushnumber(L, v[0]);
-    lua_setfield(L, -2, "x");
-    lua_pushnumber(L, v[1]);
-    lua_setfield(L, -2, "y");
-    lua_pushnumber(L, v[2]);
-    lua_setfield(L, -2, "z");
-    lua_getmetatable(L, 2);
-    lua_setmetatable(L, -2);
+    luax_pushvec3(L, v, luax_len(L, 2) > 0);
     return 1;
   }
 


### PR DESCRIPTION
```lua
local m = Mat4()
print('arr', Inspect(m * { 1, 1, 1 }))
print('arr2', Inspect(m:mul({ 1, 1, 1 })))
print('xyz', Inspect(m * { x = 1, y = 1, z = 1 }))
print('xyz2', Inspect(m:mul({ x = 1, y = 1, z = 1 })))
```

```
arr     { 1, 1, 1 }
arr2    { 1, 1, 1 }
xyz     {
  x = 1,
  y = 1,
  z = 1,
  <metatable> = {
    x = 1,
    y = 1,
    z = 1
  }
}
xyz2    {
  x = 1,
  y = 1,
  z = 1,
  <metatable> = {
    x = 1,
    y = 1,
    z = 1
  }
}
```