### PR TITLE
check for conf.luau if Luau is used

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -118,7 +118,11 @@ function lovr.boot()
   else
     lovr.filesystem.setSource(source)
     if source ~= bundle then lovr.filesystem.unmount(bundle) end
-    if lovr.filesystem.isFile('conf.lua') then ok, failure = pcall(require, 'conf') end
+    if _VERSION == "Luau" then
+      if lovr.filesystem.isFile('conf.lua') or lovr.filesystem.isFile('conf.luau') then ok, failure = pcall(require, 'conf') end
+    else
+      if lovr.filesystem.isFile('conf.lua') then ok, failure = pcall(require, 'conf') end
+    end
     if ok and lovr.conf then ok, failure = pcall(lovr.conf, conf) end
   end
 


### PR DESCRIPTION
As I was testing the new Luau support I've noticed that we still try to look for `conf.lua` even when Luau is enabled which makes for slightly ugly codebase where just one file has .lua extension, not that the extension makes any difference 😅 