### PR TITLE
Replaced bump VRAM allocator with list allocator

### DIFF
--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -3409,10 +3409,19 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
         // If there's leftover room, mark the leftover free region, and shrink
         // the current region
         if (requiredPages < region->pageCount) {
-          gpu_alloc_entry* next = &allocator->regions[i + requiredPages];
-          next->allocated = false;
-          next->pageCount = region->pageCount - requiredPages;
+          gpu_alloc_entry* freeRegion = &allocator->regions[i + requiredPages];
+          freeRegion->allocated = false;
+          freeRegion->pageCount = region->pageCount - requiredPages;
           region->pageCount = requiredPages;
+
+          // Coalesce with the next region, if possible
+          uint32_t nextIndex = i + requiredPages + freeRegion->pageCount;
+          if (nextIndex < allocator->pageCount) {
+            gpu_alloc_entry* nextRegion = &allocator->regions[nextIndex];
+            if (!nextRegion->allocated) {
+              freeRegion->pageCount += nextRegion->pageCount;
+            }
+          }
         }
 
         allocator->block->refs++;
@@ -3448,19 +3457,25 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
         memory->pointer = NULL;
       }
 
-      allocator->block = memory;
+      memory->refs = 1;
 
-      // Mark the initial region
-      allocator->pageCount = blockSize / GPU_PAGE_SIZE;
-      allocator->regions[0].allocated = true;
-      allocator->regions[0].pageCount = requiredPages;
-
-      // If there's additional room in the block, mark the free region
-      if (requiredPages < allocator->pageCount) {
-        allocator->regions[requiredPages].allocated = false;
-        allocator->regions[requiredPages].pageCount = allocator->pageCount - requiredPages;
+      // Memory only receives an allocator if it can host multiple allocations
+      // (i.e. it has a fixed block size and this block is not oversized)
+      if(blockSize && info.size < blockSize) {
+        allocator->block = memory;
+  
+        // Mark the initial region
+        allocator->pageCount = blockSize / GPU_PAGE_SIZE;
+        allocator->regions[0].allocated = true;
+        allocator->regions[0].pageCount = requiredPages;
+  
+        // If there's additional room in the block, mark the free region
+        if (requiredPages < allocator->pageCount) {
+          allocator->regions[requiredPages].allocated = false;
+          allocator->regions[requiredPages].pageCount = allocator->pageCount - requiredPages;
+        }
       }
-      allocator->block->refs = 1;
+      
       *offset = 0;
       return memory;
     }
@@ -3472,48 +3487,49 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
 
 static void release(gpu_memory* memory, VkDeviceSize offset) {
   if (memory) {
-    if (--memory->refs == 0) {
-      condemn(memory->handle, VK_OBJECT_TYPE_DEVICE_MEMORY);
-      memory->handle = NULL;
+    gpu_allocator* allocator = NULL;
 
-      for (uint32_t i = 0; i < COUNTOF(state.allocators); i++) {
-        if (state.allocators[i].block == memory) {
-          state.allocators[i].block = NULL;
-        }
+    for (uint32_t i = 0; i < COUNTOF(state.allocators); i++) {
+      if (state.allocators[i].block == memory) {
+        allocator = &state.allocators[i];
+        break;
+      }
+    }
+      
+    if (--memory->refs == 0) {
+      // If the memory has an allocator, reset it, otherwise free the memory
+      if (allocator) {
+        gpu_alloc_entry* region = &allocator->regions[0];
+        region->allocated = false;
+        region->pageCount = allocator->pageCount;
+      } else {
+        condemn(memory->handle, VK_OBJECT_TYPE_DEVICE_MEMORY);
+        memory->handle = NULL;
       }
     } else {
-      for (uint32_t i = 0; i < COUNTOF(state.allocators); i++) {
-        gpu_allocator* allocator = &state.allocators[i];
-        if (allocator->block == memory) {
-          // Mark the region for this allocation as free
-          uint32_t pageOffset = offset / GPU_PAGE_SIZE;
-          gpu_alloc_entry* region = &allocator->regions[pageOffset];
-          region->allocated = false;
+      // Mark the region for this allocation as free
+      uint32_t pageOffset = offset / GPU_PAGE_SIZE;
+      gpu_alloc_entry* region = &allocator->regions[pageOffset];
+      region->allocated = false;
 
-          // See if we can coalesce this region with the next region
-          uint32_t nextOffset = pageOffset + region->pageCount;
-          if (nextOffset < allocator->pageCount) {
-            gpu_alloc_entry* nextRegion = &allocator->regions[nextOffset];
-            if (!nextRegion->allocated) {
-              region->pageCount += nextRegion->pageCount;
-            }
-          }
+      // See if we can coalesce this region with the next region
+      uint32_t nextOffset = pageOffset + region->pageCount;
+      if (nextOffset < allocator->pageCount) {
+        gpu_alloc_entry* nextRegion = &allocator->regions[nextOffset];
+        if (!nextRegion->allocated) {
+          region->pageCount += nextRegion->pageCount;
+        }
+      }
 
-          // See if we can coalesce with the previous region. We have to loop
-          // through regions from the beginning because we don't know where the
-          // last region started
-          for(uint32_t j = 0; j < allocator->pageCount; j += allocator->regions[j].pageCount) {
-            gpu_alloc_entry* previousRegion = &allocator->regions[j];
-            if (pageOffset == j + previousRegion->pageCount) {
-              // We found the previous region, coalesce if it's free
-              if (!previousRegion->allocated) {
-                previousRegion->pageCount += region->pageCount;
-              }
-
-              // Since we found the previous region, we break no matter if we
-              // coalesced or not
-              break;
-            }
+      // See if we can coalesce with the previous region. We have to loop
+      // through regions from the beginning because we don't know where the
+      // last region started
+      for(uint32_t i = 0; i < pageOffset; i += allocator->regions[i].pageCount) {
+        gpu_alloc_entry* previousRegion = &allocator->regions[i];
+        if (i + previousRegion->pageCount == pageOffset) {
+          // We found the previous region, coalesce if it's free
+          if (!previousRegion->allocated) {
+            previousRegion->pageCount += region->pageCount;
           }
         }
       }

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -3460,8 +3460,8 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
       memory->refs = 1;
 
       // Memory only receives an allocator if it can host multiple allocations
-      // (i.e. it has a fixed block size and this block is not oversized)
-      if(blockSize && info.size < blockSize) {
+      // (i.e. it has a fixed block size and this block is not full/oversized)
+      if(blockSize && (requiredPages * GPU_PAGE_SIZE) < blockSize) {
         allocator->block = memory;
   
         // Mark the initial region
@@ -3469,11 +3469,10 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
         allocator->regions[0].allocated = true;
         allocator->regions[0].pageCount = requiredPages;
   
-        // If there's additional room in the block, mark the free region
-        if (requiredPages < allocator->pageCount) {
-          allocator->regions[requiredPages].allocated = false;
-          allocator->regions[requiredPages].pageCount = allocator->pageCount - requiredPages;
-        }
+        // Mark the free region at the end. We know there's a free region
+        // because we don't let allocators manage full or oversized blocks
+        allocator->regions[requiredPages].allocated = false;
+        allocator->regions[requiredPages].pageCount = allocator->pageCount - requiredPages;
       }
       
       *offset = 0;

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -33,12 +33,14 @@ typedef struct gpu_memory gpu_memory;
 struct gpu_buffer {
   VkBuffer handle;
   gpu_memory* memory;
+  VkDeviceSize offset;
 };
 
 struct gpu_texture {
   VkImage handle;
   VkImageView view;
   gpu_memory* memory;
+  VkDeviceSize offset;
   VkImageAspectFlagBits aspect;
   VkImageLayout layout;
   uint32_t samples;
@@ -98,6 +100,14 @@ size_t gpu_sizeof_tally(void) { return sizeof(gpu_tally); }
 
 #define FRAME_DEPTH 2
 
+// GPU memory blocks are divided into 16 KB pages. Allocators have arrays with
+// an entry for every page, which they use to track regions of allocated and
+// free spaces.
+
+#define GPU_PAGE_BITS 14
+#define GPU_PAGE_SIZE (1 << (GPU_PAGE_BITS))
+#define GPU_ALLOC_PAGES_LENGTH ((1 << 28) / (GPU_PAGE_SIZE))
+
 struct gpu_memory {
   VkDeviceMemory handle;
   void* pointer;
@@ -125,8 +135,14 @@ typedef enum {
 } gpu_memory_type;
 
 typedef struct {
+  uint16_t allocated : 1;
+  uint16_t pageCount : 15;
+} gpu_alloc_entry;
+
+typedef struct {
   gpu_memory* block;
-  uint32_t cursor;
+  gpu_alloc_entry regions[GPU_ALLOC_PAGES_LENGTH];
+  uint32_t pageCount;
   uint16_t memoryType;
   uint16_t memoryFlags;
 } gpu_allocator;
@@ -241,7 +257,7 @@ enum { LINEAR, SRGB };
 #define MORGUE_MASK (COUNTOF(state.morgue.data) - 1)
 
 static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkDeviceSize* offset);
-static void release(gpu_memory* memory);
+static void release(gpu_memory* memory, VkDeviceSize offset);
 static void condemn(void* handle, VkObjectType type);
 static void expunge(uint64_t tick);
 static uint64_t getFinishedTick(void);
@@ -418,23 +434,22 @@ bool gpu_buffer_init(gpu_buffer* buffer, gpu_buffer_info* info) {
 
   nickname(buffer->handle, VK_OBJECT_TYPE_BUFFER, info->label);
 
-  VkDeviceSize offset;
   VkMemoryRequirements requirements;
   vkGetBufferMemoryRequirements(state.device, buffer->handle, &requirements);
 
-  if ((buffer->memory = allocate((gpu_memory_type) info->type, requirements, &offset)) == NULL) {
+  if ((buffer->memory = allocate((gpu_memory_type) info->type, requirements, &buffer->offset)) == NULL) {
     vkDestroyBuffer(state.device, buffer->handle, NULL);
     return false;
   }
 
-  VK(vkBindBufferMemory(state.device, buffer->handle, buffer->memory->handle, offset), "vkBindBufferMemory") {
+  VK(vkBindBufferMemory(state.device, buffer->handle, buffer->memory->handle, buffer->offset), "vkBindBufferMemory") {
     vkDestroyBuffer(state.device, buffer->handle, NULL);
-    release(buffer->memory);
+    release(buffer->memory, buffer->offset);
     return false;
   }
 
   if (info->pointer) {
-    *info->pointer = buffer->memory->pointer ? (char*) buffer->memory->pointer + offset : NULL;
+    *info->pointer = buffer->memory->pointer ? (char*) buffer->memory->pointer + buffer->offset : NULL;
   }
 
   return true;
@@ -443,7 +458,7 @@ bool gpu_buffer_init(gpu_buffer* buffer, gpu_buffer_info* info) {
 void gpu_buffer_destroy(gpu_buffer* buffer) {
   if (!buffer->memory) return;
   condemn(buffer->handle, VK_OBJECT_TYPE_BUFFER);
-  release(buffer->memory);
+  release(buffer->memory, buffer->offset);
 }
 
 // Texture
@@ -550,24 +565,23 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
     default: memoryType = transient ? GPU_MEMORY_TEXTURE_LAZY_COLOR : GPU_MEMORY_TEXTURE_COLOR; break;
   }
 
-  VkDeviceSize offset;
   VkMemoryRequirements requirements;
   vkGetImageMemoryRequirements(state.device, texture->handle, &requirements);
 
-  if ((texture->memory = allocate(memoryType, requirements, &offset)) == NULL) {
+  if ((texture->memory = allocate(memoryType, requirements, &texture->offset)) == NULL) {
     vkDestroyImage(state.device, texture->handle, NULL);
     return false;
   }
 
-  VK(vkBindImageMemory(state.device, texture->handle, texture->memory->handle, offset), "vkBindImageMemory") {
+  VK(vkBindImageMemory(state.device, texture->handle, texture->memory->handle, texture->offset), "vkBindImageMemory") {
     vkDestroyImage(state.device, texture->handle, NULL);
-    release(texture->memory);
+    release(texture->memory, texture->offset);
     return false;
   }
 
   if (!gpu_texture_init_view(texture, &viewInfo)) {
     vkDestroyImage(state.device, texture->handle, NULL);
-    release(texture->memory);
+    release(texture->memory, texture->offset);
     return false;
   }
 
@@ -763,7 +777,7 @@ void gpu_texture_destroy(gpu_texture* texture) {
   if (texture->imported) return;
   if (!texture->memory) return;
   condemn(texture->handle, VK_OBJECT_TYPE_IMAGE);
-  release(texture->memory);
+  release(texture->memory, texture->offset);
 }
 
 // Surface
@@ -3381,13 +3395,31 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
   };
 
   uint32_t blockSize = blockSizes[type];
-  uint32_t cursor = ALIGN(allocator->cursor, info.alignment);
+  ASSERT(blockSize <= (GPU_ALLOC_PAGES_LENGTH * GPU_PAGE_SIZE), "Block size larger than allocator can handle") return NULL;
 
-  if (allocator->block && cursor + info.size <= blockSize) {
-    allocator->cursor = cursor + info.size;
-    allocator->block->refs++;
-    *offset = cursor;
-    return allocator->block;
+  uint32_t requiredPages = ALIGN(info.size, GPU_PAGE_SIZE) / GPU_PAGE_SIZE;
+
+  if (allocator->block) {
+    // Search through regions for a free region of sufficient size
+    for(uint32_t i = 0; i < allocator->pageCount; i += allocator->regions[i].pageCount) {
+      gpu_alloc_entry* region = &allocator->regions[i];
+      if (!region->allocated && requiredPages <= region->pageCount) {
+        region->allocated = true;
+
+        // If there's leftover room, mark the leftover free region, and shrink
+        // the current region
+        if (requiredPages < region->pageCount) {
+          gpu_alloc_entry* next = &allocator->regions[i + requiredPages];
+          next->allocated = false;
+          next->pageCount = region->pageCount - requiredPages;
+          region->pageCount = requiredPages;
+        }
+
+        allocator->block->refs++;
+        *offset = i * GPU_PAGE_SIZE;
+        return allocator->block;
+      }
+    }
   }
 
   // If there wasn't an active block or it overflowed, find an empty block to allocate
@@ -3417,7 +3449,17 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
       }
 
       allocator->block = memory;
-      allocator->cursor = info.size;
+
+      // Mark the initial region
+      allocator->pageCount = blockSize / GPU_PAGE_SIZE;
+      allocator->regions[0].allocated = true;
+      allocator->regions[0].pageCount = requiredPages;
+
+      // If there's additional room in the block, mark the free region
+      if (requiredPages < allocator->pageCount) {
+        allocator->regions[requiredPages].allocated = false;
+        allocator->regions[requiredPages].pageCount = allocator->pageCount - requiredPages;
+      }
       allocator->block->refs = 1;
       *offset = 0;
       return memory;
@@ -3428,15 +3470,52 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
   return NULL;
 }
 
-static void release(gpu_memory* memory) {
-  if (memory && --memory->refs == 0) {
-    condemn(memory->handle, VK_OBJECT_TYPE_DEVICE_MEMORY);
-    memory->handle = NULL;
+static void release(gpu_memory* memory, VkDeviceSize offset) {
+  if (memory) {
+    if (--memory->refs == 0) {
+      condemn(memory->handle, VK_OBJECT_TYPE_DEVICE_MEMORY);
+      memory->handle = NULL;
 
-    for (uint32_t i = 0; i < COUNTOF(state.allocators); i++) {
-      if (state.allocators[i].block == memory) {
-        state.allocators[i].block = NULL;
-        state.allocators[i].cursor = 0;
+      for (uint32_t i = 0; i < COUNTOF(state.allocators); i++) {
+        if (state.allocators[i].block == memory) {
+          state.allocators[i].block = NULL;
+        }
+      }
+    } else {
+      for (uint32_t i = 0; i < COUNTOF(state.allocators); i++) {
+        gpu_allocator* allocator = &state.allocators[i];
+        if (allocator->block == memory) {
+          // Mark the region for this allocation as free
+          uint32_t pageOffset = offset / GPU_PAGE_SIZE;
+          gpu_alloc_entry* region = &allocator->regions[pageOffset];
+          region->allocated = false;
+
+          // See if we can coalesce this region with the next region
+          uint32_t nextOffset = pageOffset + region->pageCount;
+          if (nextOffset < allocator->pageCount) {
+            gpu_alloc_entry* nextRegion = &allocator->regions[nextOffset];
+            if (!nextRegion->allocated) {
+              region->pageCount += nextRegion->pageCount;
+            }
+          }
+
+          // See if we can coalesce with the previous region. We have to loop
+          // through regions from the beginning because we don't know where the
+          // last region started
+          for(uint32_t j = 0; j < allocator->pageCount; j += allocator->regions[j].pageCount) {
+            gpu_alloc_entry* previousRegion = &allocator->regions[j];
+            if (pageOffset == j + previousRegion->pageCount) {
+              // We found the previous region, coalesce if it's free
+              if (!previousRegion->allocated) {
+                previousRegion->pageCount += region->pageCount;
+              }
+
+              // Since we found the previous region, we break no matter if we
+              // coalesced or not
+              break;
+            }
+          }
+        }
       }
     }
   }

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -108,12 +108,6 @@ size_t gpu_sizeof_tally(void) { return sizeof(gpu_tally); }
 #define GPU_PAGE_SIZE (1 << (GPU_PAGE_BITS))
 #define GPU_ALLOC_PAGES_LENGTH ((1 << 28) / (GPU_PAGE_SIZE))
 
-struct gpu_memory {
-  VkDeviceMemory handle;
-  void* pointer;
-  uint32_t refs;
-};
-
 typedef enum {
   GPU_MEMORY_BUFFER_STATIC,
   GPU_MEMORY_BUFFER_STREAM,
@@ -133,6 +127,13 @@ typedef enum {
   GPU_MEMORY_TEXTURE_LAZY_D32FS8,
   GPU_MEMORY_COUNT
 } gpu_memory_type;
+
+struct gpu_memory {
+  VkDeviceMemory handle;
+  void* pointer;
+  uint32_t refs;
+  gpu_memory_type type;
+};
 
 typedef struct {
   uint16_t allocated : 1;
@@ -3457,6 +3458,7 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
         memory->pointer = NULL;
       }
 
+      memory->type = type;
       memory->refs = 1;
 
       // Memory only receives an allocator if it can host multiple allocations
@@ -3486,18 +3488,11 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
 
 static void release(gpu_memory* memory, VkDeviceSize offset) {
   if (memory) {
-    gpu_allocator* allocator = NULL;
-
-    for (uint32_t i = 0; i < COUNTOF(state.allocators); i++) {
-      if (state.allocators[i].block == memory) {
-        allocator = &state.allocators[i];
-        break;
-      }
-    }
+    gpu_allocator* allocator = &state.allocators[state.allocatorLookup[memory->type]];
       
     if (--memory->refs == 0) {
-      // If the memory has an allocator, reset it, otherwise free the memory
-      if (allocator) {
+      // If the allocator manages this block, reset it, otherwise free the memory
+      if (allocator->block == memory) {
         gpu_alloc_entry* region = &allocator->regions[0];
         region->allocated = false;
         region->pageCount = allocator->pageCount;
@@ -3505,7 +3500,7 @@ static void release(gpu_memory* memory, VkDeviceSize offset) {
         condemn(memory->handle, VK_OBJECT_TYPE_DEVICE_MEMORY);
         memory->handle = NULL;
       }
-    } else {
+    } else if (allocator->block == memory) {
       // Mark the region for this allocation as free
       uint32_t pageOffset = offset / GPU_PAGE_SIZE;
       gpu_alloc_entry* region = &allocator->regions[pageOffset];


### PR DESCRIPTION
# Summary

This pull request replaces Lovr's current bump allocator for VRAM with a simple linear allocator that tracks regions of allocated and free space, allowing freed regions within a block to be reused. Previously, regions within a block could not be reused until the entire block was freed, and even a single living allocation would keep an entire block alive, which could lead to memory starvation.

# Background

A recent discussion in the "internals" channel on the Discord raised the issue that Lovr can exhaust video memory. Out of curiosity, I decided to take a look at the internals and saw that the existing manager was very simple, and thought I would make an attempt at an alternative that could address the issue.

Currently, Lovr allocates video memory from Vulkan in "blocks," which come in a variety of sizes, but often 256 MB. Then, a CPU-side allocator creates allocations within the block using a simple bump allocator: a cursor maintains a position within the block, and an allocation advances the cursor and returns the newly reserved space. The allocator will also increment a reference counter. To free an allocation, the allocator simply decrements the reference counter. If the reference counter hits zero, there are no more allocations within the block, and the allocator will release the entire block back to Vulkan.

This allocator is extremely simple. It is also extremely fast: allocations and frees are both O(1). However, there is a significant limitation. The allocator cannot reuse freed regions within a block. Memory cannot be reused until after the entire block is returned to Vulkan. If there's even a single long-lived allocation within a block, the entire block cannot be freed, and its memory cannot be reused. A mouse cursor, for example, would be a tiny allocation that may live for the life of the entire app. If its block fills up with other data that's then released, the mouse cursor alone will force the block to stay alive, with most of the space unusable. A small number of long-lived allocations across multiple blocks may force Lovr to exhaust VRAM.

# Proposed Solution

The allocator I implemented here is the simplest one I could imagine that could address the issue. It subdivides blocks into 16 KB "pages", and then tracks "regions" of these pages. Each allocator has a fixed-length array of potential region entries, one entry for each page. Since the largest fixed size block is 256 MB, these arrays have 256 MB / 16 KB -> 16,384 entries. A region entry has a flag for whether it's allocated, and a length.

To allocate, the allocator performs a linear scan over the regions, searching for a free region of sufficient size. It then allocates enough space for the allocation, and, if there's leftover space in the region, creates a new unallocated region.

All allocations are aligned to the 16 KB pages. The alignment of the requested allocation is not otherwise taken into account because, unless I misunderstand GPU memory alignment requirements, 16 KB satisfies any GPU alignment requirement.

To free memory, the allocator marks its corresponding region as unallocated, and coalesces the region with the preceding and succeeding regions, if possible.

The allocator continues to use the reference counter from the previous system, and frees blocks when the reference count hits zero. Also, continuing from the previous system, if an allocation overflows a block, requiring a new block, the allocator loses track of fine-grain knowledge of the previous block, and will no longer attempt to reuse memory within it, causing it to again only be able to free after all allocations within are released.

# Downsides, Tradeoffs, and Alternatives

This allocator was the simplest alternative I could think of that addresses the issue with the previous system. However, it has its own limitations.

This allocator adds 32 KB of memory for each allocator to manage the entry lists (2 bytes per entry, 16k entries). Less memory could be used with, say, dynamically-allocated linked list nodes, at the cost of requiring many dynamic allocations. More memory could be required to implement other alternative allocators.

There is simply no beating the O(1) performance of the previous bump allocator, however this allocator is also about the slowest possible alternative, requiring an O(n) scan of regions for both allocations and deallocations. In the worst case, this could require visiting all 16k entries. However, in practice there will likely be far fewer regions. A 32-bit 256x256 texture takes 16 pages, and a 32-bit 4k texture takes 4,096 pages. Plus, even if there are many regions, they're accessed in sequential order in a linear array, which is cache-friendly, and the queried logic is extremely simple. That said, a free-list allocator, while being O(n), would only scan over free regions, not all regions, and a buddy allocator would be a sublinear O(log(n)).

This allocator can only reuse memory within a single block per allocator. If allocations overflow a block, the allocator will only track fine-grained regions on the new block, and the previous block will behave like it did in the previous system, only freeing after all allocations within are freed. An alternative allocator could be designed to manage _all_ blocks.

Pages are 16 KB. Consequently, smaller allocations will waste space. The page size was chosen to try to balance reasonably fine granularity against the size of the per-allocator entry list. 16 KB pages and 256 MB blocks allow entries to be two bytes, finer granularity or larger blocks would require larger list entries.