### PR TITLE
Hand Tracking Microgestures

### DIFF
--- a/src/modules/headset/headset.c
+++ b/src/modules/headset/headset.c
@@ -339,6 +339,7 @@ static struct {
     bool layerEquirect2;
     bool layerSettings;
     bool localFloor;
+    bool microgestures;
     bool ml2Controller;
     bool mxInk;
     bool overlay;
@@ -506,6 +507,7 @@ bool lovrHeadsetConnect(void) {
     { "XR_FB_touch_controller_pro", &state.extensions.touchPro, true },
     { "XR_LOGITECH_mx_ink_stylus_interaction", &state.extensions.mxInk, true },
     { "XR_META_automatic_layer_filter", &state.extensions.layerAutoFilter, true },
+    { "XR_META_hand_tracking_microgestures", &state.extensions.microgestures, true },
     { "XR_META_passthrough_preferences", &state.extensions.passthroughPreferences, true },
     { "XR_ML_ml2_controller_interaction", &state.extensions.ml2Controller, true },
     { "XR_MND_headless", &state.extensions.headless, true },
@@ -1271,6 +1273,14 @@ bool lovrHeadsetConnect(void) {
       { ACTION_GRIP_DOWN, "/user/hand/right/input/grasp_ext/value" },
       { ACTION_GRIP_AXIS, "/user/hand/left/input/grasp_ext/value" },
       { ACTION_GRIP_AXIS, "/user/hand/right/input/grasp_ext/value" },
+      { ACTION_DPAD_UP_DOWN, "/user/hand/left/input/swipe_forward_meta/click" },
+      { ACTION_DPAD_UP_DOWN, "/user/hand/right/input/swipe_forward_meta/click" },
+      { ACTION_DPAD_DOWN_DOWN, "/user/hand/left/input/swipe_backward_meta/click" },
+      { ACTION_DPAD_DOWN_DOWN, "/user/hand/right/input/swipe_backward_meta/click" },
+      { ACTION_DPAD_LEFT_DOWN, "/user/hand/left/input/swipe_left_meta/click" },
+      { ACTION_DPAD_LEFT_DOWN, "/user/hand/right/input/swipe_left_meta/click" },
+      { ACTION_DPAD_RIGHT_DOWN, "/user/hand/left/input/swipe_right_meta/click" },
+      { ACTION_DPAD_RIGHT_DOWN, "/user/hand/right/input/swipe_right_meta/click" },
       { 0, NULL }
     },
     [PROFILE_FRAME] = (Binding[]) {

--- a/src/modules/headset/headset.c
+++ b/src/modules/headset/headset.c
@@ -1414,6 +1414,16 @@ bool lovrHeadsetConnect(void) {
     }
   }
 
+  if (!state.extensions.microgestures) {
+    for (uint32_t i = 0; i < bindingCount[PROFILE_HAND]; i++) {
+      if (bindings[PROFILE_HAND][i].action == ACTION_DPAD_UP_DOWN) {
+        REMOVE_BINDINGS(bindings[PROFILE_HAND], bindingCount[PROFILE_HAND], i, 8);
+        bindingCount[PROFILE_HAND] -= 8;
+        break;
+      }
+    }
+  }
+
   XrPath path;
   XrActionSuggestedBinding suggestedBindings[64];
   for (uint32_t i = 0; i < MAX_PROFILES; i++) {


### PR DESCRIPTION
Map `XR_META_hand_tracking_microgestures` extension bindings to the dpad buttons.  You can swipe your thumb along your index finger to get dpad input.  Feels great!

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6a53ed3f-145e-4732-947e-fc87befda89b" />

Doesn't expose the "center" tap yet.  Should there be a `dpcenter` button, or maybe this could get mapped to `thumbrest`?