### PR TITLE
Fix Shader:clone() rejecting option flags with the 'flag_' prefix

### DIFF
--- a/src/api/l_graphics_shader.c
+++ b/src/api/l_graphics_shader.c
@@ -15,7 +15,12 @@ static int l_lovrShaderClone(lua_State* L) {
     ShaderFlag flag = { 0 };
     flag.value = lua_isboolean(L, -1) ? (double) lua_toboolean(L, -1) : lua_tonumber(L, -1);
     switch (lua_type(L, -2)) {
-      case LUA_TSTRING: flag.name = lua_tostring(L, -2); break;
+      case LUA_TSTRING:
+        size_t length;
+        const char* name = lua_tolstring(L, -2, &length);
+        size_t offset = length > 5 && !memcmp(name, "flag_", 5) ? 5 : 0;
+        flag.name = name + offset;
+        break;
       case LUA_TNUMBER: flag.id = lua_tointeger(L, -2); break;
       default:
         arr_free(&flags);


### PR DESCRIPTION
Shader:clone() rejects valid option flags if they are given as string names with the "flag_" prefix.

Ex:
```lua
function lovr.load()
	local shader = lovr.graphics.newShader("unlit", "unlit")
	-- works
	local shader2 = shader:clone{ tonemap = true }
	-- Error: "Unknown shader flag flag_tonemap"
	local shader3 = shader:clone{ flag_tonemap = true }
end
```

Fix this by skipping over the "flag_" prefix in `l_lovrShaderClone()` prior to hashing, as is done in `lovrShaderCreate()`.