### PR TITLE
Fix world to collider local in shape containsPoint

### DIFF
--- a/src/modules/physics/physics.c
+++ b/src/modules/physics/physics.c
@@ -2104,9 +2104,9 @@ static void inverseTransformRay(float* origin, float* direction, float* position
 
 bool lovrShapeContainsPoint(Shape* shape, float point[3]) {
   if (shape->collider) {
-    float position[3], orientation[4];
-    lovrColliderGetPose(shape->collider, position, orientation);
-    inverseTransformPoint(point, position, orientation);
+    float local[3];
+    lovrColliderGetLocalPoint(shape->collider, point, local);
+    vec3_init(point, local);
   }
 
   inverseTransformPoint(point, shape->translation, shape->rotation);


### PR DESCRIPTION
I noticed that shape attached to collider does incorrect query on :containsPoint().

![containsPoint](https://github.com/user-attachments/assets/ef04f7a8-475b-4d1e-acf5-37cf891588d6)

I think the order of translation/rotation was wrong, but since inverseTransformPoint is used twice it was easier to switch to lovrColliderGetLocalPoint. The added benefit is that it will work better with motion interpolation.

Minimal reproduction:
```Lua
local world = lovr.physics.newWorld()

local c = world:newBoxCollider(1, 0, 0, 1, 4, 1)
c:setOrientation(math.pi/2, 0,0,1)

print(c:getShape():containsPoint(2, 0, 0)) -- should be true
```

I also checked `Shape:raycast()`, that one gives correct results.
