### PR TITLE
foveation fixes

### DIFF
--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -1884,6 +1884,9 @@ bool gpu_pipeline_init_graphics(gpu_pipeline* pipeline, gpu_pipeline_info* info,
 
   if (state.extensions.dynamicRendering) {
     pipelineInfo.pNext = &renderingInfo;
+    if (info->foveated) {
+      pipelineInfo.flags |= VK_PIPELINE_CREATE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT;
+    }
   } else {
     bool depth = info->depth.format;
     uint32_t colorCount = info->attachmentCount;
@@ -3151,8 +3154,11 @@ bool gpu_init(gpu_config* config) {
     }
 
     if (state.extensions.foveation) {
+      VkPhysicalDeviceFragmentDensityMapFeaturesEXT supportedDensityMapFeatures = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT };
+      VkPhysicalDeviceFeatures2 query = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, .pNext = &supportedDensityMapFeatures };
+      vkGetPhysicalDeviceFeatures2(state.adapter, &query);
       fragmentDensityMapFeatures.fragmentDensityMap = true;
-      fragmentDensityMapFeatures.fragmentDensityMapNonSubsampledImages = true;
+      fragmentDensityMapFeatures.fragmentDensityMapNonSubsampledImages = supportedDensityMapFeatures.fragmentDensityMapNonSubsampledImages;
       CHAIN(fragmentDensityMapFeatures);
     }
 
@@ -4028,7 +4034,9 @@ static bool transitionAttachment(gpu_texture* texture, bool begin, bool resolve,
 }
 
 static VkImageLayout getNaturalLayout(uint32_t usage, VkImageAspectFlags aspect) {
-  if (usage & (GPU_TEXTURE_STORAGE | GPU_TEXTURE_COPY_SRC | GPU_TEXTURE_COPY_DST)) {
+  if (usage & GPU_TEXTURE_FOVEATION) {
+    return VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+  } else if (usage & (GPU_TEXTURE_STORAGE | GPU_TEXTURE_COPY_SRC | GPU_TEXTURE_COPY_DST)) {
     return VK_IMAGE_LAYOUT_GENERAL;
   } else if (usage & GPU_TEXTURE_SAMPLE) {
     return VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR;

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -3154,11 +3154,8 @@ bool gpu_init(gpu_config* config) {
     }
 
     if (state.extensions.foveation) {
-      VkPhysicalDeviceFragmentDensityMapFeaturesEXT supportedDensityMapFeatures = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT };
-      VkPhysicalDeviceFeatures2 query = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, .pNext = &supportedDensityMapFeatures };
-      vkGetPhysicalDeviceFeatures2(state.adapter, &query);
       fragmentDensityMapFeatures.fragmentDensityMap = true;
-      fragmentDensityMapFeatures.fragmentDensityMapNonSubsampledImages = supportedDensityMapFeatures.fragmentDensityMapNonSubsampledImages;
+      fragmentDensityMapFeatures.fragmentDensityMapNonSubsampledImages = true;
       CHAIN(fragmentDensityMapFeatures);
     }
 
@@ -4034,9 +4031,7 @@ static bool transitionAttachment(gpu_texture* texture, bool begin, bool resolve,
 }
 
 static VkImageLayout getNaturalLayout(uint32_t usage, VkImageAspectFlags aspect) {
-  if (usage & GPU_TEXTURE_FOVEATION) {
-    return VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
-  } else if (usage & (GPU_TEXTURE_STORAGE | GPU_TEXTURE_COPY_SRC | GPU_TEXTURE_COPY_DST)) {
+  if (usage & (GPU_TEXTURE_STORAGE | GPU_TEXTURE_COPY_SRC | GPU_TEXTURE_COPY_DST)) {
     return VK_IMAGE_LAYOUT_GENERAL;
   } else if (usage & GPU_TEXTURE_SAMPLE) {
     return VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR;


### PR DESCRIPTION
Copilot Prompt:

User: I think there is a bug in configuring the foveation for vulkan.
If the foveation is off no artifacts appear.
If the foveation is on artifacts apprear.
It looks like there is a small quad texture interleaved with the main framebuffer. it seems to be the same quad but at different locations per eye. the quad seem to show artifacts of repeated or old fragments, the color of the frags seem of.
Check the lovr graphics to see potential issues how the foveation is set up.


Here's a summary of the three bugs found and fixed in gpu_vk.c:

**1. Missing `VK_PIPELINE_CREATE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT` pipeline flag** (most likely cause of your artifacts)

When dynamic rendering (`VK_KHR_dynamic_rendering`) is active, pipelines used with fragment density maps **must** have VK_PIPELINE_CREATE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT. Without it, the driver compiles the pipeline unaware of fragment density variation — the fragment shader runs at uniform resolution, but the framebuffer has subsampled regions from the density map. This produces exactly what you see: small quad-shaped regions with stale/wrong fragments at different locations per eye (each eye's density map offsets differ).

**2. Wrong tracked layout for foveation textures** (gpu_vk.c)

`getNaturalLayout` fell through to `VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL_KHR` for `GPU_TEXTURE_FOVEATION` textures. The correct layout is `VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT`. While the layout tracking isn't currently used for explicit transitions of the foveation texture, this mismatch is wrong state that could cause issues with validation layers or future code.

**3. `fragmentDensityMapNonSubsampledImages` enabled unconditionally**

The feature was enabled without querying whether the physical device supports it. Now it queries the actual device support before enabling. If a device doesn't support non-subsampled images but foveation is requested, this could cause device creation failure or undefined behavior.



Tested on Meta Quest 3.
Artifacts are gone. 

This is ofc a vibe coding fix attempt. Please review carefully. Used copilot claude 4.6. 