### PR TITLE
Fix init ordering in Source:clone() for phonon

### DIFF
--- a/src/modules/audio/audio.c
+++ b/src/modules/audio/audio.c
@@ -648,13 +648,14 @@ Source* lovrSourceClone(Source* source) {
     clone->converter = converter;
   }
 
+  clone->sound = source->sound;
+  lovrRetain(clone->sound);
+
   if (!phonon_source_init(clone)) {
     lovrSourceDestroy(clone);
     return false;
   }
 
-  clone->sound = source->sound;
-  lovrRetain(clone->sound);
   return clone;
 }
 


### PR DESCRIPTION
`source:clone()` crashes when LÖVR is built with phonon. Fix order of init operations.