### PR TITLE
Add no-simulation argument

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -41,6 +41,7 @@ local conf = {
   headset = {
     connect = true,
     start = true,
+    simulatorFallback = true,
     debug = false,
     seated = false,
     mask = true,
@@ -157,8 +158,16 @@ function lovr.boot()
 
   if lovr.headset and conf.headset.connect then
     local ok, message = lovr.headset.connect()
-    if not ok and conf.headset.debug then
-      lovr.log(string.format('Could not connect to headset, falling back to simulator (%s)', message), 'warn', 'XR')
+    if not ok then
+      if conf.headset.simulatorFallback == false then
+        local msg = type(message) == 'string' and message or ''
+        io.stderr:write(('Headset connect failed: %s\n'):format(msg))
+        return function()
+          return 1
+        end
+      elseif conf.headset.debug then
+        lovr.log(string.format('Could not connect to headset, falling back to simulator (%s)', message), 'warn', 'XR')
+      end
     end
   end
 

--- a/etc/nogame/arg.lua
+++ b/etc/nogame/arg.lua
@@ -5,6 +5,7 @@ function lovr.arg(arg)
     console = { long = '--console', help = 'Attach Windows console' },
     debug = { long = '--debug', help = 'Enable debugging checks and logging' },
     simulator = { long = '--simulator', help = 'Force headset simulator' },
+    nosimulator = { long = '--no-simulator', help = 'Exit with status 1 if headset connect fails; no simulator fallback' },
     watch = { short = '-w', long = '--watch', help = 'Watch files and restart on change' }
   }
 
@@ -80,6 +81,14 @@ function lovr.arg(arg)
     if arg.simulator then
       conf.headset.connect = false
       conf.headset.start = false
+    end
+
+    if arg.nosimulator then
+      conf.headset.simulatorFallback = false
+    end
+
+    if arg.simulator and arg.nosimulator then
+      error('Incompatible options: --simulator and --no-simulator', 0)
     end
 
     if arg.watch then


### PR DESCRIPTION
Disables the simulation option and exits when OXR creation fails if its set. This allows LOVR to be run in automation and detect the FORM_FACTOR_UNAVAILABLE discussed below without a custom LUA script.