### PR TITLE
Optionally retry on FORM_FACTOR_UNAVAILABLE

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -41,6 +41,7 @@ local conf = {
   headset = {
     connect = true,
     start = true,
+    retryonunavailable = false,
     debug = false,
     seated = false,
     mask = true,

--- a/etc/nogame/arg.lua
+++ b/etc/nogame/arg.lua
@@ -5,6 +5,7 @@ function lovr.arg(arg)
     console = { long = '--console', help = 'Attach Windows console' },
     debug = { long = '--debug', help = 'Enable debugging checks and logging' },
     simulator = { long = '--simulator', help = 'Force headset simulator' },
+    retryonunavailable = { long = '--retry-on-unavailable', help = 'Retry xrGetSystem when the headset is temporarily unavailable' },
     watch = { short = '-w', long = '--watch', help = 'Watch files and restart on change' }
   }
 
@@ -80,6 +81,10 @@ function lovr.arg(arg)
     if arg.simulator then
       conf.headset.connect = false
       conf.headset.start = false
+    end
+
+    if arg.retryonunavailable then
+      conf.headset.retryonunavailable = true
     end
 
     if arg.watch then

--- a/src/api/l_headset.c
+++ b/src/api/l_headset.c
@@ -1091,6 +1091,7 @@ int luaopen_lovr_headset(lua_State* L) {
 
   HeadsetConfig config = {
     .supersample = 1.f,
+    .retryUnavailable = false,
     .seated = false,
     .mask = true,
     .stencil = false,
@@ -1115,6 +1116,10 @@ int luaopen_lovr_headset(lua_State* L) {
 
       lua_getfield(L, -1, "debug");
       config.debug = lua_toboolean(L, -1);
+      lua_pop(L, 1);
+
+      lua_getfield(L, -1, "retryonunavailable");
+      config.retryUnavailable = lua_toboolean(L, -1);
       lua_pop(L, 1);
 
       lua_getfield(L, -1, "seated");

--- a/src/modules/headset/headset.c
+++ b/src/modules/headset/headset.c
@@ -616,7 +616,15 @@ bool lovrHeadsetConnect(void) {
     .formFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY
   };
 
-  XRG(xrGetSystem(state.instance, &systemInfo, &state.system), "xrGetSystem", fail);
+  XrResult getSystemRes = xrGetSystem(state.instance, &systemInfo, &state.system);
+  if (getSystemRes == XR_ERROR_FORM_FACTOR_UNAVAILABLE) {
+    lovrLog(LOG_INFO, "XR", "Got XR_ERROR_FORM_FACTOR_UNAVAILABLE, retrying until xrGetSystem succeeds");
+    while (getSystemRes == XR_ERROR_FORM_FACTOR_UNAVAILABLE) {
+      os_sleep(1.0);
+      getSystemRes = xrGetSystem(state.instance, &systemInfo, &state.system);
+    }
+  }
+  XRG(getSystemRes, "xrGetSystem", fail);
 
   XrSystemEyeGazeInteractionPropertiesEXT eyeGazeProperties = { .type = XR_TYPE_SYSTEM_EYE_GAZE_INTERACTION_PROPERTIES_EXT };
   XrSystemHandTrackingPropertiesEXT handTrackingProperties = { .type = XR_TYPE_SYSTEM_HAND_TRACKING_PROPERTIES_EXT };

--- a/src/modules/headset/headset.c
+++ b/src/modules/headset/headset.c
@@ -616,10 +616,14 @@ bool lovrHeadsetConnect(void) {
     .formFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY
   };
 
+  // OpenXR xrGetSystem: XR_ERROR_FORM_FACTOR_UNAVAILABLE means supported but temporarily
+  // unavailable; the runtime may return XR_SUCCESS on a later call (e.g. connect/warm-up).
+  // https://registry.khronos.org/OpenXR/specs/1.1/man/html/xrGetSystem.html
   XrResult getSystemRes = xrGetSystem(state.instance, &systemInfo, &state.system);
-  if (getSystemRes == XR_ERROR_FORM_FACTOR_UNAVAILABLE) {
+  if (getSystemRes == XR_ERROR_FORM_FACTOR_UNAVAILABLE && config->retryUnavailable) {
     lovrLog(LOG_INFO, "XR", "Got XR_ERROR_FORM_FACTOR_UNAVAILABLE, retrying until xrGetSystem succeeds");
     while (getSystemRes == XR_ERROR_FORM_FACTOR_UNAVAILABLE) {
+      // Wait for 1 second before retrying.
       os_sleep(1.0);
       getSystemRes = xrGetSystem(state.instance, &systemInfo, &state.system);
     }

--- a/src/modules/headset/headset.h
+++ b/src/modules/headset/headset.h
@@ -24,6 +24,7 @@ typedef enum {
 typedef struct {
   float supersample;
   bool debug;
+  bool retryUnavailable;
   bool seated;
   bool mask;
   bool stencil;


### PR DESCRIPTION
Apologies that we are going back and forth on this.   It turns out implementing a retry loop in the LUA gets really complicated due to the graphics init order.  The amount of boiler plate code required just to connect the headset seems excessive, as shown in this Gist:
https://gist.github.com/gareth-morgan-nv/82d9e3b242146f8028e4d60af73c873c

So this PR adds the same retry loop we pushed in the last PR, but this time its behind a command line flag which is false by default.

