### PR TITLE
Texture Streaming

### DIFF
--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -1055,6 +1055,10 @@ static int l_lovrGraphicsNewTexture(lua_State* L) {
     }
     lua_pop(L, 1);
 
+    lua_getfield(L, index, "stream");
+    info->stream = lua_toboolean(L, -1);
+    lua_pop(L, 1);
+
     lua_getfield(L, index, "label");
     info->label = lovrStrdup(lua_tostring(L, -1));
     lua_pop(L, 1);
@@ -1692,6 +1696,10 @@ static int l_lovrGraphicsNewModel(lua_State* L) {
 
     lua_getfield(L, 2, "mipmaps");
     info->mipmaps = lua_isnil(L, -1) || lua_toboolean(L, -1);
+    lua_pop(L, 1);
+
+    lua_getfield(L, 2, "stream");
+    info->stream = lua_toboolean(L, -1);
     lua_pop(L, 1);
 
     lua_getfield(L, 2, "raytracer");

--- a/src/api/l_graphics_model.c
+++ b/src/api/l_graphics_model.c
@@ -253,6 +253,13 @@ static int l_lovrModelGetMaterial(lua_State* L) {
   return 1;
 }
 
+static int l_lovrModelIsReady(lua_State* L) {
+  Model* model = luax_checktype(L, 1, Model);
+  bool ready = lovrModelIsReady(model);
+  lua_pushboolean(L, ready);
+  return 1;
+}
+
 static int l_lovrModelBuildRaytracer(lua_State* L) {
   Model* model = luax_checktype(L, 1, Model);
   luax_assert(L, lovrModelBuildRaytracer(model));
@@ -402,6 +409,7 @@ const luaL_Reg lovrModel[] = {
   { "getMaterialCount", l_lovrModelMetaGetMaterialCount },
   { "getMaterialName", l_lovrModelMetaGetMaterialName },
   { "getMaterial", l_lovrModelGetMaterial },
+  { "isReady", l_lovrModelIsReady },
 
   { "buildRaytracer", l_lovrModelBuildRaytracer },
 

--- a/src/api/l_graphics_texture.c
+++ b/src/api/l_graphics_texture.c
@@ -85,6 +85,13 @@ static int l_lovrTextureHasUsage(lua_State* L) {
   return 1;
 }
 
+static int l_lovrTextureIsReady(lua_State* L) {
+  Texture* texture = luax_checktype(L, 1, Texture);
+  bool ready = lovrTextureIsReady(texture);
+  lua_pushboolean(L, ready);
+  return 1;
+}
+
 static int l_lovrTextureNewReadback(lua_State* L) {
   Texture* texture = luax_totype(L, 1, Texture);
   uint32_t offset[4], extent[3];
@@ -276,6 +283,7 @@ const luaL_Reg lovrTexture[] = {
   { "getMipmapCount", l_lovrTextureGetMipmapCount },
   { "getSampleCount", l_lovrTextureGetSampleCount },
   { "hasUsage", l_lovrTextureHasUsage },
+  { "isReady", l_lovrTextureIsReady },
   { "newReadback", l_lovrTextureNewReadback },
   { "getPixels", l_lovrTextureGetPixels },
   { "setPixels", l_lovrTextureSetPixels },

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -257,17 +257,18 @@ typedef struct {
   uintptr_t handle;
   const char* label;
   struct {
-    gpu_stream* stream;
-    gpu_buffer* buffer;
-    uint32_t* levelOffsets;
+    void** levelData;
     uint32_t levelCount;
-    bool generateMipmaps;
+    uint32_t* layerSizes;
+    bool async;
   } upload;
 } gpu_texture_info;
 
 bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info);
 bool gpu_texture_init_view(gpu_texture* texture, gpu_texture_view_info* info);
 void gpu_texture_destroy(gpu_texture* texture);
+bool gpu_texture_is_uploaded(gpu_texture* texture);
+void gpu_texture_acquire(gpu_texture* texture, gpu_stream* stream);
 
 // Surface
 

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -29,6 +29,7 @@
 // Objects
 
 typedef struct gpu_memory gpu_memory;
+typedef struct gpu_upload gpu_upload;
 
 struct gpu_buffer {
   VkBuffer handle;
@@ -57,8 +58,8 @@ struct gpu_texture {
   VkImageView view;
   gpu_memory* memory;
   VkDeviceSize offset;
-  uint32_t uploadId;
-  gpu_buffer stagingBuffer;
+  gpu_upload* upload;
+  uint32_t uploadTick;
   gpu_upload_type uploadType;
   VkImageAspectFlagBits aspect;
   VkImageLayout layout;
@@ -103,7 +104,6 @@ struct gpu_tally {
 struct gpu_stream {
   VkCommandBuffer commands;
   gpu_stream* next;
-  uint32_t id;
 };
 
 size_t gpu_sizeof_buffer(void) { return sizeof(gpu_buffer); }
@@ -171,6 +171,14 @@ typedef struct {
   VkMemoryPropertyFlags memoryFlags;
   gpu_alloc_entry regions[GPU_MAX_PAGES];
 } gpu_allocator;
+
+struct gpu_upload {
+  struct gpu_upload* next;
+  gpu_buffer buffer;
+  gpu_texture* texture;
+  VkBufferImageCopy copies[16];
+  uint32_t copyCount;
+};
 
 typedef struct gpu_victim {
   struct gpu_victim* next;
@@ -247,9 +255,8 @@ typedef struct {
 
 typedef struct gpu_thread_state {
   struct gpu_thread_state* next;
-  gpu_stream_pool* streamPools;
-  gpu_stream_pool* activeStreamPool;
-  gpu_stream_pool uploadStreamPool[2];
+  gpu_stream_pool* streamPools[2];
+  gpu_stream_pool* activeStreamPool[2];
   char error[255];
   bool initialized;
 } gpu_thread_state;
@@ -266,11 +273,8 @@ static struct {
   VkDevice device;
   VkQueue queue[2];
   uint32_t queueFamilyIndex[2];
-  mtx_t queueLock[2];
-  VkSemaphore semaphore;
-  VkSemaphore uploadSemaphore[2];
-  uint32_t uploadId[2];
-  uint32_t tick;
+  VkSemaphore semaphore[2];
+  atomic_uint tick;
   uint32_t frame;
   VkPipelineCache pipelineCache;
   VkDebugUtilsMessengerEXT messenger;
@@ -279,7 +283,9 @@ static struct {
   mtx_t allocatorLock;
   gpu_memory memory[1024];
   _Atomic(gpu_thread_state*) threads;
-  gpu_morgue morgue;
+  gpu_upload* uploads;
+  mtx_t uploadLock;
+  gpu_morgue morgue[2];
 } state;
 
 // Helpers
@@ -298,10 +304,11 @@ enum { GRAPHICS, TRANSFER };
 #define FRAME_MASK (FRAME_DEPTH - 1)
 
 static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkDeviceSize* offset);
-static void release(gpu_memory* memory, VkDeviceSize offset);
-static void condemn(void* handle, VkObjectType type);
-static void expunge(uint64_t tick);
-static uint64_t getFinishedTick(void);
+static void release(gpu_memory* memory, VkDeviceSize offset, int queue);
+static void condemn(void* handle, VkObjectType type, int queue);
+static void expunge(void);
+static uint64_t getFinishedTick(int queue);
+static gpu_stream* getStream(int queue, const char* label);
 static bool hasLayer(VkLayerProperties* layers, uint32_t count, const char* layer);
 static bool hasExtension(VkExtensionProperties* extensions, uint32_t count, const char* extension);
 static VkBufferUsageFlags getBufferUsage(gpu_buffer_type type);
@@ -495,7 +502,7 @@ bool gpu_buffer_init(gpu_buffer* buffer, gpu_buffer_info* info) {
 
   VK(vkBindBufferMemory(state.device, buffer->handle, buffer->memory->handle, buffer->offset), "vkBindBufferMemory") {
     vkDestroyBuffer(state.device, buffer->handle, NULL);
-    release(buffer->memory, buffer->offset);
+    release(buffer->memory, buffer->offset, GRAPHICS);
     return false;
   }
 
@@ -508,8 +515,8 @@ bool gpu_buffer_init(gpu_buffer* buffer, gpu_buffer_info* info) {
 
 void gpu_buffer_destroy(gpu_buffer* buffer) {
   if (!buffer->memory) return;
-  condemn(buffer->handle, VK_OBJECT_TYPE_BUFFER);
-  release(buffer->memory, buffer->offset);
+  condemn(buffer->handle, VK_OBJECT_TYPE_BUFFER, GRAPHICS);
+  release(buffer->memory, buffer->offset, GRAPHICS);
 }
 
 gpu_address gpu_buffer_get_address(gpu_buffer* buffer, uint32_t offset) {
@@ -641,7 +648,7 @@ bool gpu_tree_init(gpu_tree* tree, gpu_tree_info* info) {
 }
 
 void gpu_tree_destroy(gpu_tree* tree) {
-  condemn(tree->handle, VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR);
+  condemn(tree->handle, VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR, GRAPHICS);
   state.config.fnFree(tree->geometries);
   state.config.fnFree(tree->ranges);
   gpu_buffer_destroy(&tree->buffer);
@@ -671,10 +678,7 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
     default: texture->aspect = VK_IMAGE_ASPECT_COLOR_BIT; break;
   }
 
-  texture->uploadId = ~0u;
-  texture->uploadType = UPLOAD_NONE;
-  texture->stagingBuffer.handle = VK_NULL_HANDLE;
-  texture->stagingBuffer.memory = NULL;
+  texture->upload = NULL;
   texture->layout = getNaturalLayout(info->usage, texture->aspect);
   texture->samples = info->samples;
   texture->layers = info->type == GPU_TEXTURE_3D ? 0 : info->size[2];
@@ -800,13 +804,13 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
 
   VK(vkBindImageMemory(state.device, texture->handle, texture->memory->handle, texture->offset), "vkBindImageMemory") {
     vkDestroyImage(state.device, texture->handle, NULL);
-    release(texture->memory, texture->offset);
+    release(texture->memory, texture->offset, GRAPHICS);
     return false;
   }
 
   if (!gpu_texture_init_view(texture, &viewInfo)) {
     vkDestroyImage(state.device, texture->handle, NULL);
-    release(texture->memory, texture->offset);
+    release(texture->memory, texture->offset, GRAPHICS);
     return false;
   }
 
@@ -872,104 +876,17 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
 
       texture->uploadType = UPLOAD_HOST;
     } else {
-      // GC any upload command buffers that are complete
+      gpu_upload* upload = state.config.fnAlloc(sizeof(gpu_upload));
 
-      for (uint32_t i = 0; i < COUNTOF(thread.uploadStreamPool); i++) {
-        gpu_stream_pool* pool = &thread.uploadStreamPool[i];
-
-        if (!pool->head) continue;
-
-        uint64_t completed = 0;
-        vkGetSemaphoreCounterValueKHR(state.device, state.uploadSemaphore[i], &completed);
-
-        while (pool->head && pool->head->id <= completed) {
-          gpu_stream* stream = pool->head;
-
-          vkFreeCommandBuffers(state.device, pool->handle, 1, &stream->commands);
-
-          if (!stream->next) {
-            pool->tail = NULL;
-          }
-
-          pool->head = stream->next;
-
-          state.config.fnFree(stream);
-        }
-      }
-
-      // Get a command buffer to use
-
-      int queue = info->upload.async && state.queue[TRANSFER] ? TRANSFER : GRAPHICS;
-      gpu_stream_pool* pool = &thread.uploadStreamPool[queue];
-
-      if (!pool->handle) {
-        VkCommandPoolCreateInfo poolInfo = {
-          .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
-          .flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
-          .queueFamilyIndex = state.queueFamilyIndex[queue]
-        };
-
-        VK(vkCreateCommandPool(state.device, &poolInfo, NULL, &pool->handle), "vkCreateCommandPool") {
-          gpu_texture_destroy(texture);
-          return false;
-        }
-      }
-
-      VkCommandBufferAllocateInfo commandBufferInfo = {
-        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
-        .commandPool = pool->handle,
-        .commandBufferCount = 1
-      };
-
-      gpu_stream* stream = state.config.fnAlloc(sizeof(gpu_stream));
-
-      if (!stream) {
+      if (!upload) {
         gpu_texture_destroy(texture);
         return false;
       }
 
-      VK(vkAllocateCommandBuffers(state.device, &commandBufferInfo, &stream->commands), "vkAllocateCommandBuffers") {
-        state.config.fnFree(stream);
-        gpu_texture_destroy(texture);
-        return false;
-      }
-
-      VkCommandBufferBeginInfo beginfo = {
-        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
-        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
-      };
-
-      VK(vkBeginCommandBuffer(stream->commands, &beginfo), "vkBeginCommandBuffer") {
-        vkFreeCommandBuffers(state.device, pool->handle, 1, &stream->commands);
-        state.config.fnFree(stream);
-        gpu_texture_destroy(texture);
-        return false;
-      }
-
-      // Transition to TRANSFER_DST
-
-      VkImageLayout layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-
-      vkCmdPipelineBarrier2KHR(stream->commands, &(VkDependencyInfoKHR) {
-        .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR,
-        .imageMemoryBarrierCount = 1,
-        .pImageMemoryBarriers = &(VkImageMemoryBarrier2KHR) {
-          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2_KHR,
-          .image = image,
-          .subresourceRange = subresource,
-          .srcStageMask = VK_PIPELINE_STAGE_2_NONE_KHR,
-          .dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR,
-          .srcAccessMask = VK_ACCESS_2_NONE_KHR,
-          .dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR,
-          .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-          .newLayout = layout
-        }
-      });
-
-      // Allocate a buffer, copy the data to it, copy it to the texture
+      upload->texture = texture;
+      upload->copyCount = 0;
 
       uint32_t totalSize = 0;
-
       for (uint32_t i = 0; i < levels; i++) {
         totalSize += layers * info->upload.layerSizes[i];
       }
@@ -983,18 +900,15 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
         .label = "Texture Staging Buffer"
       };
 
-      if (!gpu_buffer_init(&texture->stagingBuffer, &bufferInfo)) {
-        vkFreeCommandBuffers(state.device, pool->handle, 1, &stream->commands);
-        state.config.fnFree(stream);
+      if (!gpu_buffer_init(&upload->buffer, &bufferInfo)) {
         gpu_texture_destroy(texture);
         return false;
       }
 
-      uint32_t offset = 0;
-      VkBufferImageCopy copies[16];
+      uint32_t cursor = 0;
       for (uint32_t i = 0; i < levels; i++) {
-        copies[i] = (VkBufferImageCopy) {
-          .bufferOffset = offset,
+        upload->copies[upload->copyCount++] = (VkBufferImageCopy) {
+          .bufferOffset = cursor,
           .imageSubresource.aspectMask = texture->aspect,
           .imageSubresource.mipLevel = i,
           .imageSubresource.baseArrayLayer = 0,
@@ -1005,90 +919,22 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
         };
 
         for (uint32_t j = 0; j < layers; j++) {
-          memcpy((char*) data + offset, info->upload.levelData[i * layers + j], info->upload.layerSizes[i]);
-          offset += info->upload.layerSizes[i];
+          memcpy((char*) data + cursor, info->upload.levelData[i * layers + j], info->upload.layerSizes[i]);
+          cursor += info->upload.layerSizes[i];
         }
       }
 
-      vkCmdCopyBufferToImage(stream->commands, texture->stagingBuffer.handle, image, layout, levels, copies);
+      texture->uploadType = info->upload.async && state.queue[TRANSFER] ? UPLOAD_TRANSFER : UPLOAD_GRAPHICS;
+      texture->uploadTick = ~0u;
+      texture->upload = upload;
 
-      // Transition back to natural layout, do queue family ownership transfer if needed
-
-      vkCmdPipelineBarrier2KHR(stream->commands, &(VkDependencyInfoKHR) {
-        .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR,
-        .imageMemoryBarrierCount = 1,
-        .pImageMemoryBarriers = &(VkImageMemoryBarrier2KHR) {
-          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2_KHR,
-          .image = image,
-          .subresourceRange = subresource,
-          .srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR,
-          .dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR,
-          .srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR,
-          .dstAccessMask = VK_ACCESS_2_MEMORY_READ_BIT_KHR | VK_ACCESS_2_MEMORY_WRITE_BIT_KHR,
-          .srcQueueFamilyIndex = state.queueFamilyIndex[queue],
-          .dstQueueFamilyIndex = state.queueFamilyIndex[GRAPHICS],
-          .oldLayout = layout,
-          .newLayout = texture->layout
-        }
-      });
-
-      // Submit to the queue
-
-      VK(vkEndCommandBuffer(stream->commands), "vkEndCommandBuffer") {
-        vkFreeCommandBuffers(state.device, pool->handle, 1, &stream->commands);
-        state.config.fnFree(stream);
-        gpu_texture_destroy(texture);
-        return false;
-      }
-
-      mtx_lock(&state.queueLock[queue]);
-
-      stream->id = ++state.uploadId[queue];
-
-      VkSubmitInfo submit = {
-        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-        .pNext = &(VkTimelineSemaphoreSubmitInfo) {
-          .sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO,
-          .signalSemaphoreValueCount = 1,
-          .pSignalSemaphoreValues = (uint64_t[1]) { stream->id }
-        },
-        .signalSemaphoreCount = 1,
-        .pSignalSemaphores = &state.uploadSemaphore[queue],
-        .commandBufferCount = 1,
-        .pCommandBuffers = &stream->commands
-      };
-
-      VK(vkQueueSubmit(state.queue[queue], 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
-        mtx_unlock(&state.queueLock[queue]);
-        vkFreeCommandBuffers(state.device, pool->handle, 1, &stream->commands);
-        state.config.fnFree(stream);
-        gpu_texture_destroy(texture);
-        return false;
-      }
-
-      mtx_unlock(&state.queueLock[queue]);
-
-      // Subbookkeeping
-
-      stream->next = NULL;
-
-      if (pool->tail) {
-        pool->tail->next = stream;
-      } else {
-        pool->head = stream;
-      }
-
-      pool->tail = stream;
-
-      if (queue == TRANSFER) {
-        texture->uploadId = stream->id;
-        texture->uploadType = UPLOAD_TRANSFER;
-      } else {
-        texture->uploadType = UPLOAD_GRAPHICS;
-        gpu_buffer_destroy(&texture->stagingBuffer);
-        memset(&texture->stagingBuffer, 0, sizeof(gpu_buffer));
-      }
+      mtx_lock(&state.uploadLock);
+      upload->next = state.uploads;
+      state.uploads = upload;
+      mtx_unlock(&state.uploadLock);
     }
+  } else {
+    texture->uploadType = UPLOAD_NONE;
   }
 
   return true;
@@ -1100,6 +946,7 @@ bool gpu_texture_init_view(gpu_texture* texture, gpu_texture_view_info* info) {
     texture->handle = info->source->handle;
     texture->memory = NULL;
     texture->imported = false;
+    texture->upload = NULL;
     texture->layout = info->source->layout;
     texture->samples = info->source->samples;
     texture->layers = info->type == GPU_TEXTURE_3D ? 0 : layers;
@@ -1165,42 +1012,31 @@ bool gpu_texture_init_view(gpu_texture* texture, gpu_texture_view_info* info) {
 }
 
 void gpu_texture_destroy(gpu_texture* texture) {
-  if (texture->uploadId != ~0u && texture->uploadType == UPLOAD_TRANSFER) {
-    VkSemaphoreWaitInfo info = {
-      .sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO,
-      .semaphoreCount = 1,
-      .pSemaphores = &state.uploadSemaphore[TRANSFER],
-      .pValues = (uint64_t[1]) { texture->uploadId }
-    };
-
-    vkWaitSemaphoresKHR(state.device, &info, UINT64_MAX);
+  // If the texture has a pending upload, cancel it
+  mtx_lock(&state.uploadLock);
+  if (texture->upload) {
+    texture->upload->texture = NULL;
   }
+  mtx_unlock(&state.uploadLock);
 
-  condemn(texture->view, VK_OBJECT_TYPE_IMAGE_VIEW);
-  gpu_buffer_destroy(&texture->stagingBuffer);
+  condemn(texture->view, VK_OBJECT_TYPE_IMAGE_VIEW, GRAPHICS);
   if (texture->imported) return;
   if (!texture->memory) return;
-  condemn(texture->handle, VK_OBJECT_TYPE_IMAGE);
-  release(texture->memory, texture->offset);
+  condemn(texture->handle, VK_OBJECT_TYPE_IMAGE, GRAPHICS);
+  release(texture->memory, texture->offset, GRAPHICS);
 }
 
 bool gpu_texture_is_uploaded(gpu_texture* texture) {
-  if (texture->uploadId == ~0u || texture->uploadType == UPLOAD_NONE || texture->uploadType == UPLOAD_HOST) {
+  if (texture->uploadType != UPLOAD_TRANSFER) {
     return true;
   }
 
-  uint64_t counter;
-  VkSemaphore semaphore = state.uploadSemaphore[texture->uploadType == UPLOAD_TRANSFER ? TRANSFER : GRAPHICS];
-  VK(vkGetSemaphoreCounterValueKHR(state.device, semaphore, &counter), "vkGetSemaphoreCounterValue") {
+  uint64_t finished;
+  VK(vkGetSemaphoreCounterValueKHR(state.device, state.semaphore[TRANSFER], &finished), "vkGetSemaphoreCounterValue") {
     return false;
   }
 
-  if (counter >= texture->uploadId) {
-    texture->uploadId = ~0u;
-    return true;
-  }
-
-  return false;
+  return finished >= texture->uploadTick;
 }
 
 void gpu_texture_acquire(gpu_texture* texture, gpu_stream* stream) {
@@ -1225,9 +1061,6 @@ void gpu_texture_acquire(gpu_texture* texture, gpu_stream* stream) {
     barrier.dstQueueFamilyIndex = state.queueFamilyIndex[GRAPHICS];
     barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     barrier.newLayout = texture->layout;
-    vkDestroyBuffer(state.device, texture->stagingBuffer.handle, NULL);
-    release(texture->stagingBuffer.memory, texture->stagingBuffer.offset);
-    memset(&texture->stagingBuffer, 0, sizeof(gpu_buffer));
   } else if (texture->uploadType == UPLOAD_NONE) {
     barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     barrier.newLayout = texture->layout;
@@ -1530,21 +1363,18 @@ bool gpu_surface_present(void) {
     .pNext = &(VkTimelineSemaphoreSubmitInfo) {
       .sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO,
       .waitSemaphoreValueCount = 1,
-      .pWaitSemaphoreValues = (uint64_t[1]) { state.tick },
+      .pWaitSemaphoreValues = (uint64_t[1]) { atomic_load(&state.tick) },
       .signalSemaphoreValueCount = 1,
       .pSignalSemaphoreValues = (uint64_t[1]) { 0 }
     },
     .waitSemaphoreCount = 1,
-    .pWaitSemaphores = &state.semaphore,
+    .pWaitSemaphores = &state.semaphore[GRAPHICS],
     .pWaitDstStageMask = &waitStage,
     .signalSemaphoreCount = 1,
     .pSignalSemaphores = &presentSemaphore
   };
 
-  mtx_lock(&state.queueLock[GRAPHICS]);
-
   VK(vkQueueSubmit(state.queue[GRAPHICS], 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
-    mtx_unlock(&state.queueLock[GRAPHICS]);
     return false;
   }
 
@@ -1558,8 +1388,6 @@ bool gpu_surface_present(void) {
   };
 
   VkResult result = vkQueuePresentKHR(state.queue[GRAPHICS], &present);
-
-  mtx_unlock(&state.queueLock[GRAPHICS]);
 
   if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
     gpu_surface_resize(~0u, ~0u);
@@ -1628,7 +1456,7 @@ bool gpu_sampler_init(gpu_sampler* sampler, gpu_sampler_info* info) {
 }
 
 void gpu_sampler_destroy(gpu_sampler* sampler) {
-  condemn(sampler->handle, VK_OBJECT_TYPE_SAMPLER);
+  condemn(sampler->handle, VK_OBJECT_TYPE_SAMPLER, GRAPHICS);
 }
 
 // Layout
@@ -1679,7 +1507,7 @@ bool gpu_layout_init(gpu_layout* layout, gpu_layout_info* info) {
 }
 
 void gpu_layout_destroy(gpu_layout* layout) {
-  condemn(layout->handle, VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT);
+  condemn(layout->handle, VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT, GRAPHICS);
 }
 
 // Shader
@@ -1743,7 +1571,7 @@ void gpu_shader_destroy(gpu_shader* shader) {
   // The spec says it's safe to destroy shaders while still in use
   if (shader->handles[0]) vkDestroyShaderModule(state.device, shader->handles[0], NULL);
   if (shader->handles[1]) vkDestroyShaderModule(state.device, shader->handles[1], NULL);
-  condemn(shader->pipelineLayout, VK_OBJECT_TYPE_PIPELINE_LAYOUT);
+  condemn(shader->pipelineLayout, VK_OBJECT_TYPE_PIPELINE_LAYOUT, GRAPHICS);
 }
 
 // Bundles
@@ -1821,7 +1649,7 @@ bool gpu_bundle_pool_init(gpu_bundle_pool* pool, gpu_bundle_pool_info* info) {
 }
 
 void gpu_bundle_pool_destroy(gpu_bundle_pool* pool) {
-  condemn(pool->handle, VK_OBJECT_TYPE_DESCRIPTOR_POOL);
+  condemn(pool->handle, VK_OBJECT_TYPE_DESCRIPTOR_POOL, GRAPHICS);
 }
 
 void gpu_bundle_write(gpu_bundle** bundles, gpu_bundle_info* infos, uint32_t count) {
@@ -2274,7 +2102,7 @@ bool gpu_pipeline_init_graphics(gpu_pipeline* pipeline, gpu_pipeline_info* info,
       return false;
     }
 
-    condemn(pipelineInfo.renderPass, VK_OBJECT_TYPE_RENDER_PASS);
+    condemn(pipelineInfo.renderPass, VK_OBJECT_TYPE_RENDER_PASS, GRAPHICS);
   }
 
   VkResult result = vkCreateGraphicsPipelines(state.device, state.pipelineCache, 1, &pipelineInfo, NULL, &pipeline->handle);
@@ -2348,7 +2176,7 @@ bool gpu_pipeline_init_compute(gpu_pipeline* pipeline, gpu_compute_pipeline_info
 }
 
 void gpu_pipeline_destroy(gpu_pipeline* pipeline) {
-  condemn(pipeline->handle, VK_OBJECT_TYPE_PIPELINE);
+  condemn(pipeline->handle, VK_OBJECT_TYPE_PIPELINE, GRAPHICS);
 }
 
 void gpu_pipeline_get_cache(void* data, size_t* size) {
@@ -2379,7 +2207,7 @@ bool gpu_tally_init(gpu_tally* tally, gpu_tally_info* info) {
 }
 
 void gpu_tally_destroy(gpu_tally* tally) {
-  condemn(tally->handle, VK_OBJECT_TYPE_QUERY_POOL);
+  condemn(tally->handle, VK_OBJECT_TYPE_QUERY_POOL, GRAPHICS);
 }
 
 // Stream
@@ -2393,81 +2221,7 @@ gpu_stream* gpu_stream_begin(const char* label) {
     }
   }
 
-  gpu_stream_pool* pool = thread.activeStreamPool;
-
-  if (!pool) {
-    // Find an existing pool to reuse
-    for (gpu_stream_pool* p = thread.streamPools; p; p = p->next) {
-      if (gpu_is_complete(p->tick)) {
-        pool = p;
-        VK(vkResetCommandPool(state.device, pool->handle, 0), "vkResetCommandPool") return NULL;
-        pool->tail = NULL;
-        break;
-      }
-    }
-
-    // No pool available?  Make a new one
-    if (!pool) {
-      pool = state.config.fnAlloc(sizeof(gpu_stream_pool));
-      ASSERT(pool, "Out of memory") return NULL;
-
-      VkCommandPoolCreateInfo poolInfo = {
-        .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
-        .flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
-        .queueFamilyIndex = state.queueFamilyIndex[GRAPHICS]
-      };
-
-      VK(vkCreateCommandPool(state.device, &poolInfo, NULL, &pool->handle), "vkCreateCommandPool") {
-        state.config.fnFree(pool);
-        return NULL;
-      }
-
-      pool->next = thread.streamPools;
-      thread.streamPools = pool;
-
-      pool->head = NULL;
-      pool->tail = NULL;
-      pool->tick = 0;
-    }
-
-    thread.activeStreamPool = pool;
-  }
-
-  gpu_stream* stream = pool->tail ? pool->tail->next : pool->head;
-
-  if (!stream) {
-    stream = state.config.fnAlloc(sizeof(gpu_stream));
-    ASSERT(stream, "Out of memory") return NULL;
-    stream->next = NULL;
-
-    VkCommandBufferAllocateInfo info = {
-      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
-      .commandPool = pool->handle,
-      .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
-      .commandBufferCount = 1
-    };
-
-    VK(vkAllocateCommandBuffers(state.device, &info, &stream->commands), "vkAllocateCommandBuffers") {
-      state.config.fnFree(stream);
-      return NULL;
-    }
-
-    if (pool->tail) {
-      pool->tail->next = stream;
-    } else {
-      pool->head = stream;
-    }
-  }
-
-  VkCommandBufferBeginInfo beginfo = {
-    .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
-    .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
-  };
-
-  VK(vkBeginCommandBuffer(stream->commands, &beginfo), "vkBeginCommandBuffer") return NULL;
-  nickname(stream->commands, VK_OBJECT_TYPE_COMMAND_BUFFER, label);
-  pool->tail = stream;
-  return stream;
+  return getStream(GRAPHICS, label);
 }
 
 bool gpu_stream_end(gpu_stream* stream) {
@@ -2737,7 +2491,7 @@ void gpu_render_begin(gpu_stream* stream, gpu_canvas* canvas) {
 
     VkRenderPass renderPass;
     VK(vkCreateRenderPass2KHR(state.device, &passInfo, NULL, &renderPass), "vkCreateRenderPass2KHR") {} // Ignoring error
-    condemn(renderPass, VK_OBJECT_TYPE_RENDER_PASS);
+    condemn(renderPass, VK_OBJECT_TYPE_RENDER_PASS, GRAPHICS);
 
     // Framebuffer
 
@@ -2783,7 +2537,7 @@ void gpu_render_begin(gpu_stream* stream, gpu_canvas* canvas) {
 
     VkFramebuffer framebuffer;
     VK(vkCreateFramebuffer(state.device, &framebufferInfo, NULL, &framebuffer), "vkCreateFramebuffer") {} // Ignoring error
-    condemn(framebuffer, VK_OBJECT_TYPE_FRAMEBUFFER);
+    condemn(framebuffer, VK_OBJECT_TYPE_FRAMEBUFFER, GRAPHICS);
 
     // Do it!
 
@@ -3577,10 +3331,6 @@ bool gpu_init(gpu_config* config) {
 
     ASSERT(state.queueFamilyIndex[GRAPHICS] != ~0u, "No graphics queue family available") goto fail;
 
-    for (uint32_t i = 0; i < COUNTOF(state.queue); i++) {
-      mtx_init(&state.queueLock[i], mtx_plain);
-    }
-
     // Device
 
     VkDeviceQueueCreateInfo queueInfo[2] = {
@@ -3699,10 +3449,11 @@ bool gpu_init(gpu_config* config) {
     // Textures
 
     VkImageUsageFlags transient = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
+    VkImageUsageFlags hostCopy = state.extensions.hostImageCopy ? VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT : 0;
 
     struct { VkFormat format; VkImageUsageFlags usage; } imageFlags[] = {
       [GPU_MEMORY_TEXTURE_COLOR] = { VK_FORMAT_R8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT },
-      [GPU_MEMORY_TEXTURE_HOST_COLOR] = { VK_FORMAT_R8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_HOST_TRANSFER_BIT },
+      [GPU_MEMORY_TEXTURE_HOST_COLOR] = { VK_FORMAT_R8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT | hostCopy },
       [GPU_MEMORY_TEXTURE_D16] = { VK_FORMAT_D16_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT },
       [GPU_MEMORY_TEXTURE_D24] = { VK_FORMAT_X8_D24_UNORM_PACK32, VK_IMAGE_USAGE_SAMPLED_BIT },
       [GPU_MEMORY_TEXTURE_D32F] = { VK_FORMAT_D32_SFLOAT, VK_IMAGE_USAGE_SAMPLED_BIT },
@@ -3788,10 +3539,8 @@ bool gpu_init(gpu_config* config) {
     }
   };
 
-  VK(vkCreateSemaphore(state.device, &timelineSemaphoreInfo, NULL, &state.semaphore), "vkCreateSemaphore") goto fail;
-
-  for (uint32_t i = 0; i < COUNTOF(state.uploadSemaphore); i++) {
-    VK(vkCreateSemaphore(state.device, &timelineSemaphoreInfo, NULL, &state.uploadSemaphore[i]), "vkCreateSemaphore") goto fail;
+  for (uint32_t i = 0; i < COUNTOF(state.semaphore); i++) {
+    VK(vkCreateSemaphore(state.device, &timelineSemaphoreInfo, NULL, &state.semaphore[i]), "vkCreateSemaphore") goto fail;
   }
 
   // Pipeline cache
@@ -3813,7 +3562,9 @@ bool gpu_init(gpu_config* config) {
 
   VK(vkCreatePipelineCache(state.device, &cacheInfo, NULL, &state.pipelineCache), "vkCreatePipelineCache") goto fail;
 
-  mtx_init(&state.morgue.lock, mtx_plain);
+  mtx_init(&state.morgue[GRAPHICS].lock, mtx_plain);
+  mtx_init(&state.morgue[TRANSFER].lock, mtx_plain);
+  mtx_init(&state.uploadLock, mtx_plain);
 
   return true;
 fail:
@@ -3823,42 +3574,34 @@ fail:
 
 void gpu_destroy(void) {
   if (state.device) vkDeviceWaitIdle(state.device);
-  expunge(UINT64_MAX);
+  expunge();
   for (gpu_thread_state* t = state.threads, *next; t; t = next) {
-    for (uint32_t i = 0; i < COUNTOF(t->uploadStreamPool); i++) {
-      gpu_stream_pool* pool = &t->uploadStreamPool[i];
-      vkDestroyCommandPool(state.device, pool->handle, NULL);
-      while (pool->head) {
-        gpu_stream* next = pool->head->next;
-        state.config.fnFree(pool->head);
-        pool->head = next;
+    for (uint32_t i = 0; i < 2; i++) {
+      for (gpu_stream_pool* pool = t->streamPools[i], *next; pool; pool = next) {
+        vkDestroyCommandPool(state.device, pool->handle, NULL);
+        for (gpu_stream* stream = pool->head, *next; stream; stream = next) {
+          next = stream->next;
+          state.config.fnFree(stream);
+        }
+        next = pool->next;
+        state.config.fnFree(pool);
       }
-    }
-    for (gpu_stream_pool* pool = t->streamPools, *next; pool; pool = next) {
-      vkDestroyCommandPool(state.device, pool->handle, NULL);
-      for (gpu_stream* stream = pool->head, *next; stream; stream = next) {
-        next = stream->next;
-        state.config.fnFree(stream);
-      }
-      next = pool->next;
-      state.config.fnFree(pool);
     }
     next = t->next;
     memset(t, 0, sizeof(*t));
   }
-  for (gpu_victim* victim = state.morgue.pool, *next; victim; victim = next) {
-    next = victim->next;
-    state.config.fnFree(victim);
+  for (uint32_t i = 0; i < COUNTOF(state.morgue); i++) {
+    for (gpu_victim* victim = state.morgue[i].pool, *next; victim; victim = next) {
+      next = victim->next;
+      state.config.fnFree(victim);
+    }
+    mtx_destroy(&state.morgue[i].lock);
   }
-  mtx_destroy(&state.morgue.lock);
+  mtx_destroy(&state.uploadLock);
   mtx_destroy(&state.allocatorLock);
-  for (uint32_t i = 0; i < COUNTOF(state.queueLock); i++) {
-    mtx_destroy(&state.queueLock[i]);
-  }
   if (state.pipelineCache) vkDestroyPipelineCache(state.device, state.pipelineCache, NULL);
-  vkDestroySemaphore(state.device, state.semaphore, NULL);
-  for (uint32_t i = 0; i < COUNTOF(state.uploadSemaphore); i++) {
-    vkDestroySemaphore(state.device, state.uploadSemaphore[i], NULL);
+  for (uint32_t i = 0; i < COUNTOF(state.semaphore); i++) {
+    vkDestroySemaphore(state.device, state.semaphore[i], NULL);
   }
   for (uint32_t i = 0; i < COUNTOF(state.memory); i++) {
     if (state.memory[i].handle) vkFreeMemory(state.device, state.memory[i].handle, NULL);
@@ -3921,6 +3664,117 @@ bool gpu_get_memory_info(uint64_t* budget, uint64_t* usage) {
 }
 
 bool gpu_submit(gpu_stream** streams, uint32_t count, uint32_t tick) {
+  mtx_lock(&state.uploadLock);
+  gpu_stream* uploadStream[2] = { 0 };
+
+  while (state.uploads) {
+    gpu_upload* upload = state.uploads;
+
+    // Handle case where texture was already destroyed
+    if (!upload->texture) {
+      vkDestroyBuffer(state.device, upload->buffer.handle, NULL);
+      release(upload->buffer.memory, upload->buffer.offset, GRAPHICS); // Exact queue doesn't matter
+      gpu_upload* next = upload->next;
+      state.config.fnFree(upload);
+      state.uploads = next;
+      continue;
+    }
+
+    int queue = upload->texture->uploadType == UPLOAD_GRAPHICS ? GRAPHICS : TRANSFER;
+    gpu_stream* stream = uploadStream[queue];
+    gpu_texture* texture = upload->texture;
+
+    if (!stream) {
+      stream = getStream(queue, "Texture Uploads");
+
+      if (!stream) {
+        mtx_unlock(&state.uploadLock);
+        return false;
+      }
+
+      uploadStream[queue] = stream;
+    }
+
+    VkImageSubresourceRange subresource = {
+      .aspectMask = texture->aspect,
+      .levelCount = VK_REMAINING_MIP_LEVELS,
+      .layerCount = VK_REMAINING_ARRAY_LAYERS
+    };
+
+    VkImageLayout layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+
+    vkCmdPipelineBarrier2KHR(stream->commands, &(VkDependencyInfoKHR) {
+      .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR,
+      .imageMemoryBarrierCount = 1,
+      .pImageMemoryBarriers = &(VkImageMemoryBarrier2KHR) {
+        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2_KHR,
+        .image = texture->handle,
+        .subresourceRange = subresource,
+        .srcStageMask = VK_PIPELINE_STAGE_2_NONE_KHR,
+        .dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR,
+        .srcAccessMask = VK_ACCESS_2_NONE_KHR,
+        .dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR,
+        .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+        .newLayout = layout
+      }
+    });
+
+    vkCmdCopyBufferToImage(stream->commands, upload->buffer.handle, texture->handle, layout, upload->copyCount, upload->copies);
+
+    vkCmdPipelineBarrier2KHR(stream->commands, &(VkDependencyInfoKHR) {
+      .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR,
+      .imageMemoryBarrierCount = 1,
+      .pImageMemoryBarriers = &(VkImageMemoryBarrier2KHR) {
+        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2_KHR,
+        .image = texture->handle,
+        .subresourceRange = subresource,
+        .srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR,
+        .dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR,
+        .srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR,
+        .dstAccessMask = VK_ACCESS_2_MEMORY_READ_BIT_KHR | VK_ACCESS_2_MEMORY_WRITE_BIT_KHR,
+        .srcQueueFamilyIndex = state.queueFamilyIndex[queue],
+        .dstQueueFamilyIndex = state.queueFamilyIndex[GRAPHICS],
+        .oldLayout = layout,
+        .newLayout = texture->layout
+      }
+    });
+
+    texture->upload = NULL;
+    texture->uploadTick = tick;
+    condemn(upload->buffer.handle, VK_OBJECT_TYPE_BUFFER, queue);
+    release(upload->buffer.memory, upload->buffer.offset, queue);
+    gpu_upload* next = upload->next;
+    state.config.fnFree(upload);
+    state.uploads = next;
+  }
+
+  for (uint32_t q = 0; q < 2; q++) {
+    if (!uploadStream[q]) continue;
+
+    VK(vkEndCommandBuffer(uploadStream[q]->commands), "vkEndCommandBuffer") {
+      return false;
+    }
+
+    VkSubmitInfo submit = {
+      .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+      .pNext = &(VkTimelineSemaphoreSubmitInfo) {
+        .sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO,
+        .signalSemaphoreValueCount = q == TRANSFER,
+        .pSignalSemaphoreValues = (uint64_t[1]) { tick }
+      },
+      .signalSemaphoreCount = q == TRANSFER,
+      .pSignalSemaphores = &state.semaphore[q],
+      .commandBufferCount = 1,
+      .pCommandBuffers = &uploadStream[q]->commands
+    };
+
+    VK(vkQueueSubmit(state.queue[q], 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
+      return false;
+    }
+  }
+
+  mtx_unlock(&state.uploadLock);
+
   VkCommandBuffer stack[64];
   VkCommandBuffer* commandBuffers = stack;
 
@@ -3934,9 +3788,11 @@ bool gpu_submit(gpu_stream** streams, uint32_t count, uint32_t tick) {
   }
 
   for (gpu_thread_state* t = state.threads; t; t = t->next) {
-    if (t->activeStreamPool) {
-      t->activeStreamPool->tick = tick;
-      t->activeStreamPool = NULL;
+    for (int q = 0; q < 2; q++) {
+      if (t->activeStreamPool[q]) {
+        t->activeStreamPool[q]->tick = tick;
+        t->activeStreamPool[q] = NULL;
+      }
     }
   }
 
@@ -3955,22 +3811,15 @@ bool gpu_submit(gpu_stream** streams, uint32_t count, uint32_t tick) {
     .pWaitSemaphores = &state.surface.acquireSemaphore,
     .pWaitDstStageMask = &waitStage,
     .signalSemaphoreCount = 1,
-    .pSignalSemaphores = &state.semaphore,
+    .pSignalSemaphores = &state.semaphore[GRAPHICS],
     .commandBufferCount = count,
     .pCommandBuffers = commandBuffers
   };
 
-  mtx_lock(&state.queueLock[GRAPHICS]);
-
   VK(vkQueueSubmit(state.queue[GRAPHICS], 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
-    mtx_unlock(&state.queueLock[GRAPHICS]);
     if (commandBuffers != stack) state.config.fnFree(commandBuffers);
     return false;
   }
-
-  mtx_unlock(&state.queueLock[GRAPHICS]);
-
-  expunge(getFinishedTick());
 
   if (commandBuffers != stack) state.config.fnFree(commandBuffers);
 
@@ -3979,19 +3828,21 @@ bool gpu_submit(gpu_stream** streams, uint32_t count, uint32_t tick) {
     state.surface.acquireTick[state.frame & FRAME_MASK] = tick;
   }
 
-  state.tick = tick;
+  atomic_store(&state.tick, tick);
+  expunge();
+
   return true;
 }
 
 bool gpu_is_complete(uint32_t tick) {
-  return getFinishedTick() >= (uint64_t) tick;
+  return getFinishedTick(GRAPHICS) >= (uint64_t) tick;
 }
 
 bool gpu_wait_tick(uint32_t tick) {
   VkSemaphoreWaitInfo info = {
     .sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO,
     .semaphoreCount = 1,
-    .pSemaphores = &state.semaphore,
+    .pSemaphores = &state.semaphore[GRAPHICS],
     .pValues = (uint64_t[1]) { tick }
   };
 
@@ -4172,7 +4023,7 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
   return NULL;
 }
 
-static void release(gpu_memory* memory, VkDeviceSize offset) {
+static void release(gpu_memory* memory, VkDeviceSize offset, int queue) {
   if (!memory) {
     return;
   }
@@ -4188,7 +4039,7 @@ static void release(gpu_memory* memory, VkDeviceSize offset) {
       region->allocated = false;
       region->pageCount = allocator->pageCount;
     } else {
-      condemn(memory->handle, VK_OBJECT_TYPE_DEVICE_MEMORY);
+      condemn(memory->handle, VK_OBJECT_TYPE_DEVICE_MEMORY, queue);
       memory->handle = NULL;
     }
   } else if (allocator->block == memory) {
@@ -4223,10 +4074,10 @@ static void release(gpu_memory* memory, VkDeviceSize offset) {
   mtx_unlock(&state.allocatorLock);
 }
 
-static void condemn(void* handle, VkObjectType type) {
+static void condemn(void* handle, VkObjectType type, int queue) {
   if (!handle) return;
 
-  gpu_morgue* morgue = &state.morgue;
+  gpu_morgue* morgue = &state.morgue[queue];
   gpu_victim* victim = morgue->pool;
 
   mtx_lock(&morgue->lock);
@@ -4239,7 +4090,7 @@ static void condemn(void* handle, VkObjectType type) {
 
   victim->next = NULL;
   victim->type = type;
-  victim->tick = state.tick + 1;
+  victim->tick = atomic_load(&state.tick) + 1;
   victim->handle = handle;
 
   if (morgue->tail) {
@@ -4253,47 +4104,133 @@ static void condemn(void* handle, VkObjectType type) {
   mtx_unlock(&morgue->lock);
 }
 
-static void expunge(uint64_t tick) {
-  gpu_morgue* morgue = &state.morgue;
+static void expunge(void) {
+  for (uint32_t i = 0; i < COUNTOF(state.morgue); i++) {
+    uint64_t tick = getFinishedTick(i);
+    gpu_morgue* morgue = &state.morgue[i];
 
-  mtx_lock(&morgue->lock);
+    mtx_lock(&morgue->lock);
 
-  while (morgue->head && tick >= morgue->head->tick) {
-    gpu_victim* victim = morgue->head;
+    while (morgue->head && tick >= morgue->head->tick) {
+      gpu_victim* victim = morgue->head;
 
-    switch (victim->type) {
-      case VK_OBJECT_TYPE_BUFFER: vkDestroyBuffer(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_IMAGE: vkDestroyImage(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_IMAGE_VIEW: vkDestroyImageView(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_SAMPLER: vkDestroySampler(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT: vkDestroyDescriptorSetLayout(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_DESCRIPTOR_POOL: vkDestroyDescriptorPool(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_PIPELINE_LAYOUT: vkDestroyPipelineLayout(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_PIPELINE: vkDestroyPipeline(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_QUERY_POOL: vkDestroyQueryPool(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_RENDER_PASS: vkDestroyRenderPass(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_FRAMEBUFFER: vkDestroyFramebuffer(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR: vkDestroyAccelerationStructureKHR(state.device, victim->handle, NULL); break;
-      case VK_OBJECT_TYPE_DEVICE_MEMORY: vkFreeMemory(state.device, victim->handle, NULL); break;
-      default: LOG("Trying to destroy invalid Vulkan object type!"); break;
+      switch (victim->type) {
+        case VK_OBJECT_TYPE_BUFFER: vkDestroyBuffer(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_IMAGE: vkDestroyImage(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_IMAGE_VIEW: vkDestroyImageView(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_SAMPLER: vkDestroySampler(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT: vkDestroyDescriptorSetLayout(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_DESCRIPTOR_POOL: vkDestroyDescriptorPool(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_PIPELINE_LAYOUT: vkDestroyPipelineLayout(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_PIPELINE: vkDestroyPipeline(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_QUERY_POOL: vkDestroyQueryPool(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_RENDER_PASS: vkDestroyRenderPass(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_FRAMEBUFFER: vkDestroyFramebuffer(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR: vkDestroyAccelerationStructureKHR(state.device, victim->handle, NULL); break;
+        case VK_OBJECT_TYPE_DEVICE_MEMORY: vkFreeMemory(state.device, victim->handle, NULL); break;
+        default: LOG("Trying to destroy invalid Vulkan object type!"); break;
+      }
+
+      morgue->head = victim->next;
+      if (!morgue->head) {
+        morgue->tail = NULL;
+      }
+
+      victim->next = morgue->pool;
+      morgue->pool = victim;
     }
 
-    morgue->head = victim->next;
-    if (!morgue->head) {
-      morgue->tail = NULL;
-    }
-
-    victim->next = morgue->pool;
-    morgue->pool = victim;
+    mtx_unlock(&morgue->lock);
   }
-
-  mtx_unlock(&morgue->lock);
 }
 
-static uint64_t getFinishedTick(void) {
+static uint64_t getFinishedTick(int queue) {
   uint64_t value;
-  VK(vkGetSemaphoreCounterValueKHR(state.device, state.semaphore, &value), "vkGetSemaphoreCounterValue") return 0;
+  VK(vkGetSemaphoreCounterValueKHR(state.device, state.semaphore[queue], &value), "vkGetSemaphoreCounterValue") return 0;
   return value;
+}
+
+static gpu_stream* getStream(int queue, const char* label) {
+  gpu_stream_pool* pool = thread.activeStreamPool[queue];
+
+  // gpu_submit was called since this command pool was used, need to start a new pool
+  if (pool && pool->tick <= atomic_load(&state.tick)) {
+    pool = NULL;
+  }
+
+  if (!pool) {
+    // Find an existing pool to reuse
+    for (gpu_stream_pool* p = thread.streamPools[queue]; p; p = p->next) {
+      if (getFinishedTick(queue) >= (uint64_t) p->tick) {
+        pool = p;
+        VK(vkResetCommandPool(state.device, pool->handle, 0), "vkResetCommandPool") return NULL;
+        pool->tail = NULL;
+        break;
+      }
+    }
+
+    // Couldn't find a pool to use?  Make a new one
+    if (!pool) {
+      pool = state.config.fnAlloc(sizeof(gpu_stream_pool));
+      ASSERT(pool, "Out of memory") return NULL;
+
+      VkCommandPoolCreateInfo poolInfo = {
+        .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+        .flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
+        .queueFamilyIndex = state.queueFamilyIndex[queue]
+      };
+
+      VK(vkCreateCommandPool(state.device, &poolInfo, NULL, &pool->handle), "vkCreateCommandPool") {
+        state.config.fnFree(pool);
+        return NULL;
+      }
+
+      pool->next = thread.streamPools[queue];
+      thread.streamPools[queue] = pool;
+
+      pool->head = NULL;
+      pool->tail = NULL;
+    }
+
+    thread.activeStreamPool[queue] = pool;
+    pool->tick = atomic_load(&state.tick) + 1;
+  }
+
+  gpu_stream* stream = pool->tail ? pool->tail->next : pool->head;
+
+  if (!stream) {
+    stream = state.config.fnAlloc(sizeof(gpu_stream));
+    ASSERT(stream, "Out of memory") return NULL;
+    stream->next = NULL;
+
+    VkCommandBufferAllocateInfo info = {
+      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+      .commandPool = pool->handle,
+      .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+      .commandBufferCount = 1
+    };
+
+    VK(vkAllocateCommandBuffers(state.device, &info, &stream->commands), "vkAllocateCommandBuffers") {
+      state.config.fnFree(stream);
+      return NULL;
+    }
+
+    if (pool->tail) {
+      pool->tail->next = stream;
+    } else {
+      pool->head = stream;
+    }
+  }
+
+  VkCommandBufferBeginInfo beginfo = {
+    .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+    .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
+  };
+
+  VK(vkBeginCommandBuffer(stream->commands, &beginfo), "vkBeginCommandBuffer") return NULL;
+  nickname(stream->commands, VK_OBJECT_TYPE_COMMAND_BUFFER, label);
+  pool->tail = stream;
+  return stream;
 }
 
 static bool hasLayer(VkLayerProperties* layers, uint32_t count, const char* layer) {

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -226,6 +226,7 @@ typedef struct {
   bool shaderFloatControls;
   bool spirv14;
   bool rayQuery;
+  bool hostImageCopy;
 } gpu_extensions;
 
 // State
@@ -3018,7 +3019,8 @@ bool gpu_init(gpu_config* config) {
       { "VK_EXT_scalar_block_layout", true, &state.extensions.scalarBlockLayout },
       { "VK_EXT_fragment_density_map", true, &state.extensions.foveation },
       { "VK_EXT_pipeline_creation_cache_control", true, &state.extensions.pipelineCacheControl },
-      { "VK_EXT_memory_budget", true, &state.extensions.memoryBudget }
+      { "VK_EXT_memory_budget", true, &state.extensions.memoryBudget },
+      { "VK_EXT_host_image_copy", true, &state.extensions.hostImageCopy }
     };
 
     uint32_t extensionCount = 0;
@@ -3116,6 +3118,7 @@ bool gpu_init(gpu_config* config) {
     VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bufferDeviceAddressFeatures = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR };
     VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR };
     VkPhysicalDeviceRayQueryFeaturesKHR rayQueryFeatures = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR };
+    VkPhysicalDeviceHostImageCopyFeaturesEXT hostImageCopyFeatures = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT };
 
     vkGetPhysicalDeviceFeatures2(state.adapter, &supported);
 
@@ -3186,6 +3189,11 @@ bool gpu_init(gpu_config* config) {
     if (state.extensions.rayQuery) {
       rayQueryFeatures.rayQuery = true;
       CHAIN(rayQueryFeatures);
+    }
+
+    if (state.extensions.hostImageCopy) {
+      hostImageCopyFeatures.hostImageCopy = true;
+      CHAIN(hostImageCopyFeatures);
     }
 
     if (config->features) {

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -135,6 +135,7 @@ typedef enum {
   GPU_MEMORY_BUFFER_DOWNLOAD,
   GPU_MEMORY_BUFFER_TREE,
   GPU_MEMORY_TEXTURE_COLOR,
+  GPU_MEMORY_TEXTURE_HOST_COLOR,
   GPU_MEMORY_TEXTURE_D16,
   GPU_MEMORY_TEXTURE_D24,
   GPU_MEMORY_TEXTURE_D32F,
@@ -237,6 +238,8 @@ typedef struct {
   bool shaderFloatControls;
   bool spirv14;
   bool rayQuery;
+  bool copy2;
+  bool formatFlags2;
   bool hostImageCopy;
 } gpu_extensions;
 
@@ -784,7 +787,7 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
     case GPU_FORMAT_D32F: memoryType = transient ? GPU_MEMORY_TEXTURE_LAZY_D32F : GPU_MEMORY_TEXTURE_D32F; break;
     case GPU_FORMAT_D24S8: memoryType = transient ? GPU_MEMORY_TEXTURE_LAZY_D24S8 : GPU_MEMORY_TEXTURE_D24S8; break;
     case GPU_FORMAT_D32FS8: memoryType = transient ? GPU_MEMORY_TEXTURE_LAZY_D32FS8 : GPU_MEMORY_TEXTURE_D32FS8; break;
-    default: memoryType = transient ? GPU_MEMORY_TEXTURE_LAZY_COLOR : GPU_MEMORY_TEXTURE_COLOR; break;
+    default: memoryType = transient ? GPU_MEMORY_TEXTURE_LAZY_COLOR : hostCopy ? GPU_MEMORY_TEXTURE_HOST_COLOR : GPU_MEMORY_TEXTURE_COLOR; break;
   }
 
   VkMemoryRequirements requirements;
@@ -3308,6 +3311,8 @@ bool gpu_init(gpu_config* config) {
       { "VK_KHR_synchronization2", true, &state.extensions.synchronization2 },
       { "VK_KHR_dynamic_rendering", true, &state.extensions.dynamicRendering },
       { "VK_KHR_timeline_semaphore", true, &state.extensions.timelineSemaphore },
+      { "VK_KHR_copy_commands2", true, &state.extensions.copy2 },
+      { "VK_KHR_format_feature_flags2", true, &state.extensions.formatFlags2 },
       { "VK_EXT_descriptor_indexing", true, &state.extensions.descriptorIndexing },
       { "VK_EXT_scalar_block_layout", true, &state.extensions.scalarBlockLayout },
       { "VK_EXT_fragment_density_map", true, &state.extensions.foveation },
@@ -3697,6 +3702,7 @@ bool gpu_init(gpu_config* config) {
 
     struct { VkFormat format; VkImageUsageFlags usage; } imageFlags[] = {
       [GPU_MEMORY_TEXTURE_COLOR] = { VK_FORMAT_R8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT },
+      [GPU_MEMORY_TEXTURE_HOST_COLOR] = { VK_FORMAT_R8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_HOST_TRANSFER_BIT },
       [GPU_MEMORY_TEXTURE_D16] = { VK_FORMAT_D16_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT },
       [GPU_MEMORY_TEXTURE_D24] = { VK_FORMAT_X8_D24_UNORM_PACK32, VK_IMAGE_USAGE_SAMPLED_BIT },
       [GPU_MEMORY_TEXTURE_D32F] = { VK_FORMAT_D32_SFLOAT, VK_IMAGE_USAGE_SAMPLED_BIT },
@@ -4026,6 +4032,7 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
     [GPU_MEMORY_BUFFER_DOWNLOAD] = 0,
     [GPU_MEMORY_BUFFER_TREE] = 1 << 24,
     [GPU_MEMORY_TEXTURE_COLOR] = 1 << 26,
+    [GPU_MEMORY_TEXTURE_HOST_COLOR] = 1 << 26,
     [GPU_MEMORY_TEXTURE_D16] = 1 << 26,
     [GPU_MEMORY_TEXTURE_D24] = 1 << 26,
     [GPU_MEMORY_TEXTURE_D32F] = 1 << 26,

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -248,8 +248,8 @@ static struct {
   VkInstance instance;
   VkPhysicalDevice adapter;
   VkDevice device;
-  VkQueue queue;
-  uint32_t queueFamilyIndex;
+  VkQueue queue[2];
+  uint32_t queueFamilyIndex[2];
   uint32_t tick;
   uint32_t frame;
   VkSemaphore semaphore;
@@ -267,6 +267,7 @@ static struct {
 
 enum { CPU, GPU };
 enum { LINEAR, SRGB };
+enum { GRAPHICS, TRANSFER };
 
 #define MIN(a, b) (a < b ? a : b)
 #define MAX(a, b) (a > b ? a : b)
@@ -991,7 +992,7 @@ bool gpu_surface_init(gpu_surface_info* info) {
 #endif
 
   VkBool32 presentable;
-  vkGetPhysicalDeviceSurfaceSupportKHR(state.adapter, state.queueFamilyIndex, surface->handle, &presentable);
+  vkGetPhysicalDeviceSurfaceSupportKHR(state.adapter, state.queueFamilyIndex[GRAPHICS], surface->handle, &presentable);
 
   // The most correct thing to do is to incorporate presentation support into the init-time process
   // for selecting a physical device and queue family.  We currently choose not to do this
@@ -1248,7 +1249,7 @@ bool gpu_surface_present(void) {
     .pSignalSemaphores = &presentSemaphore
   };
 
-  VK(vkQueueSubmit(state.queue, 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
+  VK(vkQueueSubmit(state.queue[GRAPHICS], 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
     return false;
   }
 
@@ -1261,7 +1262,7 @@ bool gpu_surface_present(void) {
     .pImageIndices = &surface->imageIndex
   };
 
-  VkResult result = vkQueuePresentKHR(state.queue, &present);
+  VkResult result = vkQueuePresentKHR(state.queue[GRAPHICS], &present);
 
   if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
     gpu_surface_resize(~0u, ~0u);
@@ -2116,7 +2117,7 @@ gpu_stream* gpu_stream_begin(const char* label) {
       VkCommandPoolCreateInfo poolInfo = {
         .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
         .flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
-        .queueFamilyIndex = state.queueFamilyIndex
+        .queueFamilyIndex = state.queueFamilyIndex[GRAPHICS]
       };
 
       VK(vkCreateCommandPool(state.device, &poolInfo, NULL, &pool->handle), "vkCreateCommandPool") {
@@ -3246,36 +3247,58 @@ bool gpu_init(gpu_config* config) {
 
     // Queue Family
 
-    state.queueFamilyIndex = ~0u;
     uint32_t queueFamilyCount = 0;
     vkGetPhysicalDeviceQueueFamilyProperties(state.adapter, &queueFamilyCount, NULL);
     VkQueueFamilyProperties* queueFamilies = config->fnAlloc(queueFamilyCount * sizeof(*queueFamilies));
     ASSERT(queueFamilies, "Out of memory") goto fail;
     vkGetPhysicalDeviceQueueFamilyProperties(state.adapter, &queueFamilyCount, queueFamilies);
-    uint32_t mask = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT;
+
+    state.queueFamilyIndex[GRAPHICS] = ~0u;
+    state.queueFamilyIndex[TRANSFER] = ~0u;
 
     for (uint32_t i = 0; i < queueFamilyCount; i++) {
-      if ((queueFamilies[i].queueFlags & mask) == mask) {
-        state.queueFamilyIndex = i;
-        break;
+      VkQueueFlags flags = queueFamilies[i].queueFlags;
+      uint32_t graphicsMask = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT;
+
+      if (state.queueFamilyIndex[GRAPHICS] == ~0u && (flags & graphicsMask) == graphicsMask) {
+        state.queueFamilyIndex[GRAPHICS] = i;
+      } else if (state.queueFamilyIndex[TRANSFER] == ~0u && (flags & VK_QUEUE_TRANSFER_BIT) == VK_QUEUE_TRANSFER_BIT) {
+        state.queueFamilyIndex[TRANSFER] = i;
       }
     }
 
     config->fnFree(queueFamilies);
-    ASSERT(state.queueFamilyIndex != ~0u, "No GPU queue families available") goto fail;
+
+    ASSERT(state.queueFamilyIndex[GRAPHICS] != ~0u, "No graphics queue family available") goto fail;
+
+    if (state.queueFamilyIndex[TRANSFER] == ~0u) {
+      state.queueFamilyIndex[TRANSFER] = state.queueFamilyIndex[GRAPHICS];
+    }
 
     // Device
+
+    uint32_t queueCount = state.queueFamilyIndex[TRANSFER] == state.queueFamilyIndex[GRAPHICS] ? 1 : 2;
+
+    VkDeviceQueueCreateInfo queueInfo[2] = {
+      {
+        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+        .queueFamilyIndex = state.queueFamilyIndex[GRAPHICS],
+        .pQueuePriorities = &(float) { 1.f },
+        .queueCount = 1
+      },
+      {
+        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+        .queueFamilyIndex = state.queueFamilyIndex[TRANSFER],
+        .pQueuePriorities = &(float) { 1.f },
+        .queueCount = 1
+      }
+    };
 
     VkDeviceCreateInfo deviceInfo = {
       .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
       .pNext = &enabled,
-      .queueCreateInfoCount = 1,
-      .pQueueCreateInfos = &(VkDeviceQueueCreateInfo) {
-        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
-        .queueFamilyIndex = state.queueFamilyIndex,
-        .pQueuePriorities = &(float) { 1.f },
-        .queueCount = 1
-      },
+      .queueCreateInfoCount = queueCount,
+      .pQueueCreateInfos = queueInfo,
       .enabledExtensionCount = enabledExtensionCount,
       .ppEnabledExtensionNames = enabledExtensions
     };
@@ -3286,7 +3309,14 @@ bool gpu_init(gpu_config* config) {
       VK(vkCreateDevice(state.adapter, &deviceInfo, NULL, &state.device), "vkCreateDevice") goto fail;
     }
 
-    vkGetDeviceQueue(state.device, state.queueFamilyIndex, 0, &state.queue);
+    vkGetDeviceQueue(state.device, state.queueFamilyIndex[GRAPHICS], 0, &state.queue[GRAPHICS]);
+
+    if (queueCount > 1) {
+      vkGetDeviceQueue(state.device, state.queueFamilyIndex[TRANSFER], 0, &state.queue[TRANSFER]);
+    } else {
+      state.queue[TRANSFER] = state.queue[GRAPHICS];
+    }
+
     GPU_FOREACH_DEVICE(GPU_LOAD_DEVICE);
   }
 
@@ -3608,7 +3638,7 @@ bool gpu_submit(gpu_stream** streams, uint32_t count, uint32_t tick) {
     .pCommandBuffers = commandBuffers
   };
 
-  VK(vkQueueSubmit(state.queue, 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
+  VK(vkQueueSubmit(state.queue[GRAPHICS], 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
     if (commandBuffers != stack) state.config.fnFree(commandBuffers);
     return false;
   }
@@ -3660,7 +3690,7 @@ uintptr_t gpu_vk_get_device(void) {
 }
 
 uintptr_t gpu_vk_get_queue(uint32_t* queueFamilyIndex, uint32_t* queueIndex) {
-  return *queueFamilyIndex = state.queueFamilyIndex, *queueIndex = 0, (uintptr_t) state.queue;
+  return *queueFamilyIndex = state.queueFamilyIndex[GRAPHICS], *queueIndex = 0, (uintptr_t) state.queue[GRAPHICS];
 }
 
 // Helpers

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -45,11 +45,21 @@ struct gpu_tree {
   gpu_buffer scratch;
 };
 
+typedef enum {
+  UPLOAD_NONE,
+  UPLOAD_HOST,
+  UPLOAD_GRAPHICS,
+  UPLOAD_TRANSFER
+} gpu_upload_type;
+
 struct gpu_texture {
   VkImage handle;
   VkImageView view;
   gpu_memory* memory;
   VkDeviceSize offset;
+  uint32_t uploadId;
+  gpu_buffer stagingBuffer;
+  gpu_upload_type uploadType;
   VkImageAspectFlagBits aspect;
   VkImageLayout layout;
   uint32_t samples;
@@ -93,6 +103,7 @@ struct gpu_tally {
 struct gpu_stream {
   VkCommandBuffer commands;
   gpu_stream* next;
+  uint32_t id;
 };
 
 size_t gpu_sizeof_buffer(void) { return sizeof(gpu_buffer); }
@@ -235,6 +246,7 @@ typedef struct gpu_thread_state {
   struct gpu_thread_state* next;
   gpu_stream_pool* streamPools;
   gpu_stream_pool* activeStreamPool;
+  gpu_stream_pool uploadStreamPool[2];
   char error[255];
   bool initialized;
 } gpu_thread_state;
@@ -251,9 +263,12 @@ static struct {
   VkDevice device;
   VkQueue queue[2];
   uint32_t queueFamilyIndex[2];
+  mtx_t queueLock[2];
+  VkSemaphore semaphore;
+  VkSemaphore uploadSemaphore[2];
+  uint32_t uploadId[2];
   uint32_t tick;
   uint32_t frame;
-  VkSemaphore semaphore;
   VkPipelineCache pipelineCache;
   VkDebugUtilsMessengerEXT messenger;
   gpu_allocator allocators[GPU_MEMORY_COUNT];
@@ -322,6 +337,7 @@ static void error(const char* message);
   X(vkGetPhysicalDeviceSurfaceSupportKHR)\
   X(vkGetPhysicalDeviceSurfaceCapabilitiesKHR)\
   X(vkGetPhysicalDeviceSurfaceFormatsKHR)\
+  X(vkGetPhysicalDeviceImageFormatProperties2)\
   X(vkEnumerateDeviceExtensionProperties)\
   X(vkCreateDevice)\
   X(vkDestroyDevice)\
@@ -342,6 +358,7 @@ static void error(const char* message);
   X(vkDestroyCommandPool)\
   X(vkResetCommandPool)\
   X(vkAllocateCommandBuffers)\
+  X(vkFreeCommandBuffers)\
   X(vkBeginCommandBuffer)\
   X(vkEndCommandBuffer)\
   X(vkCreateFence)\
@@ -427,7 +444,9 @@ static void error(const char* message);
   X(vkGetAccelerationStructureBuildSizesKHR)\
   X(vkCreateAccelerationStructureKHR)\
   X(vkDestroyAccelerationStructureKHR)\
-  X(vkCmdBuildAccelerationStructuresKHR)
+  X(vkCmdBuildAccelerationStructuresKHR)\
+  X(vkCopyMemoryToImageEXT)\
+  X(vkTransitionImageLayoutEXT)
 
 // Used to load/declare Vulkan functions without lots of clutter
 #define GPU_LOAD_ANONYMOUS(fn) fn = (PFN_##fn) vkGetInstanceProcAddr(NULL, #fn);
@@ -649,6 +668,10 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
     default: texture->aspect = VK_IMAGE_ASPECT_COLOR_BIT; break;
   }
 
+  texture->uploadId = ~0u;
+  texture->uploadType = UPLOAD_NONE;
+  texture->stagingBuffer.handle = VK_NULL_HANDLE;
+  texture->stagingBuffer.memory = NULL;
   texture->layout = getNaturalLayout(info->usage, texture->aspect);
   texture->samples = info->samples;
   texture->layers = info->type == GPU_TEXTURE_3D ? 0 : info->size[2];
@@ -696,10 +719,40 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
       ((info->usage & GPU_TEXTURE_COPY_SRC) ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : 0) |
       ((info->usage & GPU_TEXTURE_COPY_DST) ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0) |
       ((info->usage & GPU_TEXTURE_FOVEATION) ? VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT : 0) |
-      ((info->usage == GPU_TEXTURE_RENDER) ? VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT : 0) |
-      (info->upload.levelCount > 0 ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0) |
-      (info->upload.generateMipmaps ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : 0)
+      ((info->usage == GPU_TEXTURE_RENDER) ? VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT : 0)
   };
+
+  bool hostCopy = false;
+
+  if (info->upload.levelCount > 0) {
+    VkHostImageCopyDevicePerformanceQueryEXT performance = {
+      .sType = VK_STRUCTURE_TYPE_HOST_IMAGE_COPY_DEVICE_PERFORMANCE_QUERY_EXT
+    };
+
+    if (state.extensions.hostImageCopy) {
+      VkPhysicalDeviceImageFormatInfo2 formatInfo = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2,
+        .format = imageInfo.format,
+        .type = imageInfo.imageType,
+        .usage = imageInfo.usage | VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT,
+        .flags = imageInfo.flags
+      };
+
+      VkImageFormatProperties2 properties = {
+        .sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2,
+        .pNext = &performance
+      };
+
+      vkGetPhysicalDeviceImageFormatProperties2(state.adapter, &formatInfo, &properties);
+    }
+
+    if (performance.optimalDeviceAccess) {
+      imageInfo.usage |= VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT;
+      hostCopy = true;
+    } else {
+      imageInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    }
+  }
 
   VkFormat formats[2];
   VkImageFormatListCreateInfo imageFormatList;
@@ -754,118 +807,285 @@ bool gpu_texture_init(gpu_texture* texture, gpu_texture_info* info) {
     return false;
   }
 
-  if (info->upload.stream) {
+  if (info->upload.levelCount > 0) {
     VkImage image = texture->handle;
-    VkCommandBuffer commands = info->upload.stream->commands;
-    uint32_t levelCount = info->upload.levelCount;
-    gpu_buffer* buffer = info->upload.buffer;
+    uint32_t layers = info->size[2];
+    uint32_t levels = info->upload.levelCount;
 
-    VkImageMemoryBarrier2KHR transition = {
-      .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2_KHR,
-      .image = image,
-      .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-      .newLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-      .subresourceRange.aspectMask = texture->aspect,
-      .subresourceRange.baseMipLevel = 0,
-      .subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS,
-      .subresourceRange.baseArrayLayer = 0,
-      .subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS
+    VkImageSubresourceRange subresource = {
+      .aspectMask = texture->aspect,
+      .levelCount = VK_REMAINING_MIP_LEVELS,
+      .layerCount = VK_REMAINING_ARRAY_LAYERS
     };
 
-    VkDependencyInfoKHR barrier = {
-      .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR,
-      .pImageMemoryBarriers = &transition,
-      .imageMemoryBarrierCount = 1
-    };
+    if (hostCopy) {
+      vkTransitionImageLayoutEXT(state.device, 1, &(VkHostImageLayoutTransitionInfoEXT) {
+        .sType = VK_STRUCTURE_TYPE_HOST_IMAGE_LAYOUT_TRANSITION_INFO_EXT,
+        .image = image,
+        .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+        .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+        .subresourceRange = subresource
+      });
 
-    if (levelCount > 0) {
-      transition.srcStageMask = VK_PIPELINE_STAGE_2_NONE_KHR;
-      transition.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR;
-      transition.srcAccessMask = VK_ACCESS_2_NONE_KHR;
-      transition.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR;
-      transition.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-      transition.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-      vkCmdPipelineBarrier2KHR(commands, &barrier);
+      VkMemoryToImageCopyEXT stack[16];
+      VkMemoryToImageCopyEXT* regions = levels * layers > COUNTOF(stack) ?
+        state.config.fnAlloc(levels * layers * sizeof(*regions)) :
+        stack;
 
+      for (uint32_t i = 0; i < levels; i++) {
+        for (uint32_t j = 0; j < layers; j++) {
+          regions[i * layers + j] = (VkMemoryToImageCopyEXT) {
+            .sType = VK_STRUCTURE_TYPE_MEMORY_TO_IMAGE_COPY_EXT,
+            .pHostPointer = info->upload.levelData[i * layers + j],
+            .imageSubresource.aspectMask = texture->aspect,
+            .imageSubresource.mipLevel = i,
+            .imageSubresource.baseArrayLayer = texture->layers ? j : 0,
+            .imageSubresource.layerCount = 1,
+            .imageOffset.z = texture->layers ? 0 : j,
+            .imageExtent.width = MAX(info->size[0] >> i, 1),
+            .imageExtent.height = MAX(info->size[1] >> i, 1),
+            .imageExtent.depth = 1
+          };
+        }
+      }
+
+      vkCopyMemoryToImageEXT(state.device, &(VkCopyMemoryToImageInfoEXT) {
+        .sType = VK_STRUCTURE_TYPE_COPY_MEMORY_TO_IMAGE_INFO_EXT,
+        .dstImage = image,
+        .dstImageLayout = VK_IMAGE_LAYOUT_GENERAL,
+        .regionCount = levels * layers,
+        .pRegions = regions
+      });
+
+      if (regions != stack) state.config.fnFree(regions);
+
+      vkTransitionImageLayoutEXT(state.device, 1, &(VkHostImageLayoutTransitionInfoEXT) {
+        .sType = VK_STRUCTURE_TYPE_HOST_IMAGE_LAYOUT_TRANSITION_INFO_EXT,
+        .image = image,
+        .oldLayout = VK_IMAGE_LAYOUT_GENERAL,
+        .newLayout = texture->layout,
+        .subresourceRange = subresource
+      });
+
+      texture->uploadType = UPLOAD_HOST;
+    } else {
+      // GC any upload command buffers that are complete
+
+      for (uint32_t i = 0; i < COUNTOF(thread.uploadStreamPool); i++) {
+        gpu_stream_pool* pool = &thread.uploadStreamPool[i];
+
+        if (!pool->head) continue;
+
+        uint64_t completed = 0;
+        vkGetSemaphoreCounterValueKHR(state.device, state.uploadSemaphore[i], &completed);
+
+        while (pool->head && pool->head->id <= completed) {
+          gpu_stream* stream = pool->head;
+
+          vkFreeCommandBuffers(state.device, pool->handle, 1, &stream->commands);
+
+          if (!stream->next) {
+            pool->tail = NULL;
+          }
+
+          pool->head = stream->next;
+
+          state.config.fnFree(stream);
+        }
+      }
+
+      // Get a command buffer to use
+
+      int queue = info->upload.async && state.queue[TRANSFER] ? TRANSFER : GRAPHICS;
+      gpu_stream_pool* pool = &thread.uploadStreamPool[queue];
+
+      if (!pool->handle) {
+        VkCommandPoolCreateInfo poolInfo = {
+          .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+          .flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
+          .queueFamilyIndex = state.queueFamilyIndex[queue]
+        };
+
+        VK(vkCreateCommandPool(state.device, &poolInfo, NULL, &pool->handle), "vkCreateCommandPool") {
+          gpu_texture_destroy(texture);
+          return false;
+        }
+      }
+
+      VkCommandBufferAllocateInfo commandBufferInfo = {
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+        .commandPool = pool->handle,
+        .commandBufferCount = 1
+      };
+
+      gpu_stream* stream = state.config.fnAlloc(sizeof(gpu_stream));
+
+      if (!stream) {
+        gpu_texture_destroy(texture);
+        return false;
+      }
+
+      VK(vkAllocateCommandBuffers(state.device, &commandBufferInfo, &stream->commands), "vkAllocateCommandBuffers") {
+        state.config.fnFree(stream);
+        gpu_texture_destroy(texture);
+        return false;
+      }
+
+      VkCommandBufferBeginInfo beginfo = {
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
+      };
+
+      VK(vkBeginCommandBuffer(stream->commands, &beginfo), "vkBeginCommandBuffer") {
+        vkFreeCommandBuffers(state.device, pool->handle, 1, &stream->commands);
+        state.config.fnFree(stream);
+        gpu_texture_destroy(texture);
+        return false;
+      }
+
+      // Transition to TRANSFER_DST
+
+      VkImageLayout layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+
+      vkCmdPipelineBarrier2KHR(stream->commands, &(VkDependencyInfoKHR) {
+        .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR,
+        .imageMemoryBarrierCount = 1,
+        .pImageMemoryBarriers = &(VkImageMemoryBarrier2KHR) {
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2_KHR,
+          .image = image,
+          .subresourceRange = subresource,
+          .srcStageMask = VK_PIPELINE_STAGE_2_NONE_KHR,
+          .dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR,
+          .srcAccessMask = VK_ACCESS_2_NONE_KHR,
+          .dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR,
+          .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+          .newLayout = layout
+        }
+      });
+
+      // Allocate a buffer, copy the data to it, copy it to the texture
+
+      uint32_t totalSize = 0;
+
+      for (uint32_t i = 0; i < levels; i++) {
+        totalSize += layers * info->upload.layerSizes[i];
+      }
+
+      void* data;
+
+      gpu_buffer_info bufferInfo = {
+        .type = GPU_BUFFER_UPLOAD,
+        .size = totalSize,
+        .pointer = &data,
+        .label = "Texture Staging Buffer"
+      };
+
+      if (!gpu_buffer_init(&texture->stagingBuffer, &bufferInfo)) {
+        vkFreeCommandBuffers(state.device, pool->handle, 1, &stream->commands);
+        state.config.fnFree(stream);
+        gpu_texture_destroy(texture);
+        return false;
+      }
+
+      uint32_t offset = 0;
       VkBufferImageCopy copies[16];
-      for (uint32_t i = 0; i < levelCount; i++) {
+      for (uint32_t i = 0; i < levels; i++) {
         copies[i] = (VkBufferImageCopy) {
-          .bufferOffset = info->upload.levelOffsets[i],
+          .bufferOffset = offset,
           .imageSubresource.aspectMask = texture->aspect,
           .imageSubresource.mipLevel = i,
           .imageSubresource.baseArrayLayer = 0,
-          .imageSubresource.layerCount = texture->layers ? info->size[2] : 1,
+          .imageSubresource.layerCount = texture->layers ? layers : 1,
           .imageExtent.width = MAX(info->size[0] >> i, 1),
           .imageExtent.height = MAX(info->size[1] >> i, 1),
-          .imageExtent.depth = texture->layers ? 1 : MAX(info->size[2] >> i, 1)
+          .imageExtent.depth = texture->layers ? 1 : MAX(layers >> i, 1)
         };
-      }
 
-      vkCmdCopyBufferToImage(commands, buffer->handle, image, transition.newLayout, levelCount, copies);
-
-      // Generate mipmaps
-      if (info->upload.generateMipmaps) {
-        transition.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR;
-        transition.dstStageMask = VK_PIPELINE_STAGE_2_BLIT_BIT_KHR;
-        transition.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR;
-        transition.dstAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT_KHR;
-        transition.oldLayout = transition.newLayout;
-        transition.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-        transition.subresourceRange.baseMipLevel = 0;
-        transition.subresourceRange.levelCount = levelCount;
-        vkCmdPipelineBarrier2KHR(commands, &barrier);
-
-        for (uint32_t i = levelCount; i < info->mipmaps; i++) {
-          transition.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR;
-          transition.dstStageMask = VK_PIPELINE_STAGE_2_BLIT_BIT_KHR;
-          transition.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR;
-          transition.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR;
-          transition.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-          transition.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-          transition.subresourceRange.baseMipLevel = i;
-          transition.subresourceRange.levelCount = 1;
-          vkCmdPipelineBarrier2KHR(commands, &barrier);
-
-          VkImageBlit region = {
-            .srcSubresource = {
-              .aspectMask = texture->aspect,
-              .mipLevel = i - 1,
-              .layerCount = texture->layers ? info->size[2] : 1
-            },
-            .dstSubresource = {
-              .aspectMask = texture->aspect,
-              .mipLevel = i,
-              .layerCount = texture->layers ? info->size[2] : 1
-            },
-            .srcOffsets[1] = { MAX(info->size[0] >> (i - 1), 1), MAX(info->size[1] >> (i - 1), 1), 1 },
-            .dstOffsets[1] = { MAX(info->size[0] >> i, 1), MAX(info->size[1] >> i, 1), 1 }
-          };
-
-          vkCmdBlitImage(commands, image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region, VK_FILTER_LINEAR);
-
-          transition.srcStageMask = VK_PIPELINE_STAGE_2_BLIT_BIT_KHR;
-          transition.dstStageMask = VK_PIPELINE_STAGE_2_BLIT_BIT_KHR;
-          transition.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR;
-          transition.dstAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT_KHR;
-          transition.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-          transition.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-          transition.subresourceRange.baseMipLevel = i;
-          transition.subresourceRange.levelCount = 1;
-          vkCmdPipelineBarrier2KHR(commands, &barrier);
+        for (uint32_t j = 0; j < layers; j++) {
+          memcpy((char*) data + offset, info->upload.levelData[i * layers + j], info->upload.layerSizes[i]);
+          offset += info->upload.layerSizes[i];
         }
       }
-    }
 
-    // Transition to natural layout
-    transition.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR | VK_PIPELINE_STAGE_2_BLIT_BIT_KHR;
-    transition.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR;
-    transition.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR;
-    transition.dstAccessMask = VK_ACCESS_2_MEMORY_READ_BIT_KHR | VK_ACCESS_2_MEMORY_WRITE_BIT_KHR;
-    transition.oldLayout = transition.newLayout;
-    transition.newLayout = texture->layout;
-    transition.subresourceRange.baseMipLevel = 0;
-    transition.subresourceRange.levelCount = info->mipmaps;
-    vkCmdPipelineBarrier2KHR(commands, &barrier);
+      vkCmdCopyBufferToImage(stream->commands, texture->stagingBuffer.handle, image, layout, levels, copies);
+
+      // Transition back to natural layout, do queue family ownership transfer if needed
+
+      vkCmdPipelineBarrier2KHR(stream->commands, &(VkDependencyInfoKHR) {
+        .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR,
+        .imageMemoryBarrierCount = 1,
+        .pImageMemoryBarriers = &(VkImageMemoryBarrier2KHR) {
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2_KHR,
+          .image = image,
+          .subresourceRange = subresource,
+          .srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR,
+          .dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR,
+          .srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR,
+          .dstAccessMask = VK_ACCESS_2_MEMORY_READ_BIT_KHR | VK_ACCESS_2_MEMORY_WRITE_BIT_KHR,
+          .srcQueueFamilyIndex = state.queueFamilyIndex[queue],
+          .dstQueueFamilyIndex = state.queueFamilyIndex[GRAPHICS],
+          .oldLayout = layout,
+          .newLayout = texture->layout
+        }
+      });
+
+      // Submit to the queue
+
+      VK(vkEndCommandBuffer(stream->commands), "vkEndCommandBuffer") {
+        vkFreeCommandBuffers(state.device, pool->handle, 1, &stream->commands);
+        state.config.fnFree(stream);
+        gpu_texture_destroy(texture);
+        return false;
+      }
+
+      mtx_lock(&state.queueLock[queue]);
+
+      stream->id = ++state.uploadId[queue];
+
+      VkSubmitInfo submit = {
+        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .pNext = &(VkTimelineSemaphoreSubmitInfo) {
+          .sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO,
+          .signalSemaphoreValueCount = 1,
+          .pSignalSemaphoreValues = (uint64_t[1]) { stream->id }
+        },
+        .signalSemaphoreCount = 1,
+        .pSignalSemaphores = &state.uploadSemaphore[queue],
+        .commandBufferCount = 1,
+        .pCommandBuffers = &stream->commands
+      };
+
+      VK(vkQueueSubmit(state.queue[queue], 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
+        mtx_unlock(&state.queueLock[queue]);
+        vkFreeCommandBuffers(state.device, pool->handle, 1, &stream->commands);
+        state.config.fnFree(stream);
+        gpu_texture_destroy(texture);
+        return false;
+      }
+
+      mtx_unlock(&state.queueLock[queue]);
+
+      // Subbookkeeping
+
+      stream->next = NULL;
+
+      if (pool->tail) {
+        pool->tail->next = stream;
+      } else {
+        pool->head = stream;
+      }
+
+      pool->tail = stream;
+
+      if (queue == TRANSFER) {
+        texture->uploadId = stream->id;
+        texture->uploadType = UPLOAD_TRANSFER;
+      } else {
+        texture->uploadType = UPLOAD_GRAPHICS;
+        gpu_buffer_destroy(&texture->stagingBuffer);
+        memset(&texture->stagingBuffer, 0, sizeof(gpu_buffer));
+      }
+    }
   }
 
   return true;
@@ -942,11 +1162,79 @@ bool gpu_texture_init_view(gpu_texture* texture, gpu_texture_view_info* info) {
 }
 
 void gpu_texture_destroy(gpu_texture* texture) {
+  if (texture->uploadId != ~0u && texture->uploadType == UPLOAD_TRANSFER) {
+    VkSemaphoreWaitInfo info = {
+      .sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO,
+      .semaphoreCount = 1,
+      .pSemaphores = &state.uploadSemaphore[TRANSFER],
+      .pValues = (uint64_t[1]) { texture->uploadId }
+    };
+
+    vkWaitSemaphoresKHR(state.device, &info, UINT64_MAX);
+  }
+
   condemn(texture->view, VK_OBJECT_TYPE_IMAGE_VIEW);
+  gpu_buffer_destroy(&texture->stagingBuffer);
   if (texture->imported) return;
   if (!texture->memory) return;
   condemn(texture->handle, VK_OBJECT_TYPE_IMAGE);
   release(texture->memory, texture->offset);
+}
+
+bool gpu_texture_is_uploaded(gpu_texture* texture) {
+  if (texture->uploadId == ~0u || texture->uploadType == UPLOAD_NONE || texture->uploadType == UPLOAD_HOST) {
+    return true;
+  }
+
+  uint64_t counter;
+  VkSemaphore semaphore = state.uploadSemaphore[texture->uploadType == UPLOAD_TRANSFER ? TRANSFER : GRAPHICS];
+  VK(vkGetSemaphoreCounterValueKHR(state.device, semaphore, &counter), "vkGetSemaphoreCounterValue") {
+    return false;
+  }
+
+  if (counter >= texture->uploadId) {
+    texture->uploadId = ~0u;
+    return true;
+  }
+
+  return false;
+}
+
+void gpu_texture_acquire(gpu_texture* texture, gpu_stream* stream) {
+  if (texture->uploadType == UPLOAD_HOST || texture->uploadType == UPLOAD_GRAPHICS) {
+    return;
+  }
+
+  VkImageMemoryBarrier2KHR barrier = {
+    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2_KHR,
+    .image = texture->handle,
+    .subresourceRange.aspectMask = texture->aspect,
+    .subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS,
+    .subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS,
+    .srcStageMask = VK_PIPELINE_STAGE_2_NONE_KHR,
+    .dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR,
+    .srcAccessMask = VK_ACCESS_2_NONE_KHR,
+    .dstAccessMask = VK_ACCESS_2_MEMORY_READ_BIT_KHR | VK_ACCESS_2_MEMORY_WRITE_BIT_KHR
+  };
+
+  if (texture->uploadType == UPLOAD_TRANSFER) {
+    barrier.srcQueueFamilyIndex = state.queueFamilyIndex[TRANSFER];
+    barrier.dstQueueFamilyIndex = state.queueFamilyIndex[GRAPHICS];
+    barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier.newLayout = texture->layout;
+    vkDestroyBuffer(state.device, texture->stagingBuffer.handle, NULL);
+    release(texture->stagingBuffer.memory, texture->stagingBuffer.offset);
+    memset(&texture->stagingBuffer, 0, sizeof(gpu_buffer));
+  } else if (texture->uploadType == UPLOAD_NONE) {
+    barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barrier.newLayout = texture->layout;
+  }
+
+  vkCmdPipelineBarrier2KHR(stream->commands, &(VkDependencyInfoKHR) {
+    .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR,
+    .imageMemoryBarrierCount = 1,
+    .pImageMemoryBarriers = &barrier
+  });
 }
 
 // Surface
@@ -1250,7 +1538,10 @@ bool gpu_surface_present(void) {
     .pSignalSemaphores = &presentSemaphore
   };
 
+  mtx_lock(&state.queueLock[GRAPHICS]);
+
   VK(vkQueueSubmit(state.queue[GRAPHICS], 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
+    mtx_unlock(&state.queueLock[GRAPHICS]);
     return false;
   }
 
@@ -1264,6 +1555,8 @@ bool gpu_surface_present(void) {
   };
 
   VkResult result = vkQueuePresentKHR(state.queue[GRAPHICS], &present);
+
+  mtx_unlock(&state.queueLock[GRAPHICS]);
 
   if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
     gpu_surface_resize(~0u, ~0u);
@@ -3279,13 +3572,11 @@ bool gpu_init(gpu_config* config) {
 
     ASSERT(state.queueFamilyIndex[GRAPHICS] != ~0u, "No graphics queue family available") goto fail;
 
-    if (state.queueFamilyIndex[TRANSFER] == ~0u) {
-      state.queueFamilyIndex[TRANSFER] = state.queueFamilyIndex[GRAPHICS];
+    for (uint32_t i = 0; i < COUNTOF(state.queue); i++) {
+      mtx_init(&state.queueLock[i], mtx_plain);
     }
 
     // Device
-
-    uint32_t queueCount = state.queueFamilyIndex[TRANSFER] == state.queueFamilyIndex[GRAPHICS] ? 1 : 2;
 
     VkDeviceQueueCreateInfo queueInfo[2] = {
       {
@@ -3305,7 +3596,7 @@ bool gpu_init(gpu_config* config) {
     VkDeviceCreateInfo deviceInfo = {
       .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
       .pNext = &enabled,
-      .queueCreateInfoCount = queueCount,
+      .queueCreateInfoCount = state.queueFamilyIndex[TRANSFER] == ~0u ? 1 : 2,
       .pQueueCreateInfos = queueInfo,
       .enabledExtensionCount = enabledExtensionCount,
       .ppEnabledExtensionNames = enabledExtensions
@@ -3319,10 +3610,8 @@ bool gpu_init(gpu_config* config) {
 
     vkGetDeviceQueue(state.device, state.queueFamilyIndex[GRAPHICS], 0, &state.queue[GRAPHICS]);
 
-    if (queueCount > 1) {
+    if (state.queueFamilyIndex[TRANSFER] != ~0u) {
       vkGetDeviceQueue(state.device, state.queueFamilyIndex[TRANSFER], 0, &state.queue[TRANSFER]);
-    } else {
-      state.queue[TRANSFER] = state.queue[GRAPHICS];
     }
 
     GPU_FOREACH_DEVICE(GPU_LOAD_DEVICE);
@@ -3483,7 +3772,7 @@ bool gpu_init(gpu_config* config) {
     mtx_init(&state.allocatorLock, mtx_plain);
   }
 
-  // Semaphore
+  // Semaphores
 
   VkSemaphoreCreateInfo timelineSemaphoreInfo = {
     .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
@@ -3494,6 +3783,10 @@ bool gpu_init(gpu_config* config) {
   };
 
   VK(vkCreateSemaphore(state.device, &timelineSemaphoreInfo, NULL, &state.semaphore), "vkCreateSemaphore") goto fail;
+
+  for (uint32_t i = 0; i < COUNTOF(state.uploadSemaphore); i++) {
+    VK(vkCreateSemaphore(state.device, &timelineSemaphoreInfo, NULL, &state.uploadSemaphore[i]), "vkCreateSemaphore") goto fail;
+  }
 
   // Pipeline cache
 
@@ -3526,6 +3819,15 @@ void gpu_destroy(void) {
   if (state.device) vkDeviceWaitIdle(state.device);
   expunge(UINT64_MAX);
   for (gpu_thread_state* t = state.threads, *next; t; t = next) {
+    for (uint32_t i = 0; i < COUNTOF(t->uploadStreamPool); i++) {
+      gpu_stream_pool* pool = &t->uploadStreamPool[i];
+      vkDestroyCommandPool(state.device, pool->handle, NULL);
+      while (pool->head) {
+        gpu_stream* next = pool->head->next;
+        state.config.fnFree(pool->head);
+        pool->head = next;
+      }
+    }
     for (gpu_stream_pool* pool = t->streamPools, *next; pool; pool = next) {
       vkDestroyCommandPool(state.device, pool->handle, NULL);
       for (gpu_stream* stream = pool->head, *next; stream; stream = next) {
@@ -3544,8 +3846,14 @@ void gpu_destroy(void) {
   }
   mtx_destroy(&state.morgue.lock);
   mtx_destroy(&state.allocatorLock);
+  for (uint32_t i = 0; i < COUNTOF(state.queueLock); i++) {
+    mtx_destroy(&state.queueLock[i]);
+  }
   if (state.pipelineCache) vkDestroyPipelineCache(state.device, state.pipelineCache, NULL);
-  if (state.semaphore) vkDestroySemaphore(state.device, state.semaphore, NULL);
+  vkDestroySemaphore(state.device, state.semaphore, NULL);
+  for (uint32_t i = 0; i < COUNTOF(state.uploadSemaphore); i++) {
+    vkDestroySemaphore(state.device, state.uploadSemaphore[i], NULL);
+  }
   for (uint32_t i = 0; i < COUNTOF(state.memory); i++) {
     if (state.memory[i].handle) vkFreeMemory(state.device, state.memory[i].handle, NULL);
   }
@@ -3646,10 +3954,15 @@ bool gpu_submit(gpu_stream** streams, uint32_t count, uint32_t tick) {
     .pCommandBuffers = commandBuffers
   };
 
+  mtx_lock(&state.queueLock[GRAPHICS]);
+
   VK(vkQueueSubmit(state.queue[GRAPHICS], 1, &submit, VK_NULL_HANDLE), "vkQueueSubmit") {
+    mtx_unlock(&state.queueLock[GRAPHICS]);
     if (commandBuffers != stack) state.config.fnFree(commandBuffers);
     return false;
   }
+
+  mtx_unlock(&state.queueLock[GRAPHICS]);
 
   expunge(getFinishedTick());
 
@@ -3709,7 +4022,7 @@ static gpu_memory* allocate(gpu_memory_type type, VkMemoryRequirements info, VkD
   static const uint32_t blockSizes[] = {
     [GPU_MEMORY_BUFFER_STATIC] = 1 << 26,
     [GPU_MEMORY_BUFFER_STREAM] = 0,
-    [GPU_MEMORY_BUFFER_UPLOAD] = 0,
+    [GPU_MEMORY_BUFFER_UPLOAD] = 1 << 24,
     [GPU_MEMORY_BUFFER_DOWNLOAD] = 0,
     [GPU_MEMORY_BUFFER_TREE] = 1 << 24,
     [GPU_MEMORY_TEXTURE_COLOR] = 1 << 26,

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -80,6 +80,8 @@ struct Buffer {
 struct Texture {
   atomic_uint ref;
   bool xrAcquired;
+  atomic_bool acquired;
+  uint8_t uploadedLevels;
   Sync* sync;
   gpu_texture* gpu;
   gpu_texture* sampleView;
@@ -191,6 +193,8 @@ struct Material {
   gpu_bundle* bundle;
   MaterialBlock* block;
   bool hasWritableTexture;
+  bool acquired;
+  bool weak;
 };
 
 typedef struct {
@@ -285,6 +289,7 @@ typedef struct {
 
 struct Model {
   atomic_uint ref;
+  bool stream;
   Model* parent;
   ModelMetadata meta;
   Buffer* rawVertexBuffer;
@@ -644,8 +649,8 @@ static void mipmapTexture(gpu_stream* stream, Texture* texture, uint32_t base, u
 static ShaderResource* findShaderResource(Shader* shader, const char* name, size_t length);
 static Access* getNextAccess(Pass* pass, int type, bool texture, bool raytracer);
 static void trackBuffer(Pass* pass, Buffer* buffer, gpu_phase phase, gpu_cache cache);
-static void trackTexture(Pass* pass, Texture* texture, gpu_phase phase, gpu_cache cache);
-static void trackMaterial(Pass* pass, Material* material);
+static bool trackTexture(Pass* pass, Texture* texture, gpu_phase phase, gpu_cache cache);
+static bool trackMaterial(Pass* pass, Material* material);
 static void trackRaytracer(Pass* pass, Raytracer* raytracer, gpu_phase phase, gpu_cache cache);
 static bool syncResource(Access* access, gpu_barrier* barrier);
 static gpu_barrier syncStream(Sync* sync, gpu_phase phase, gpu_cache cache);
@@ -957,6 +962,14 @@ void lovrGraphicsDestroy(void) {
 
 bool lovrGraphicsIsInitialized(void) {
   return state.initialized;
+}
+
+void lovrGraphicsInitWorker(void) {
+  initAllocator(&thread.stack);
+}
+
+void lovrGraphicsDestroyWorker(void) {
+  lovrFree(&thread.stack.memory);
 }
 
 void lovrGraphicsGetDevice(GraphicsDevice* device) {
@@ -2343,6 +2356,49 @@ bool lovrBufferClear(Buffer* buffer, uint32_t offset, uint32_t extent, uint32_t 
 
 // Texture
 
+static bool lovrTextureAcquire(Texture* t) {
+  Texture* texture = t->root;
+
+  if (atomic_load_explicit(&texture->acquired, memory_order_acquire)) {
+    return true;
+  }
+
+  if (texture->info.stream && !gpu_texture_is_uploaded(texture->gpu)) {
+    return lovrSetError("Attempt to use a Texture before it's finished streaming");
+  }
+
+  mtx_lock(&state.lock);
+
+  if (atomic_load_explicit(&texture->acquired, memory_order_relaxed)) {
+    mtx_unlock(&state.lock);
+    return true;
+  }
+
+  gpu_texture_acquire(texture->gpu, state.stream);
+
+  if (texture->uploadedLevels > 0 && texture->uploadedLevels < texture->info.mipmaps) {
+    uint32_t base = texture->uploadedLevels - 1;
+    uint32_t count = texture->info.mipmaps - texture->uploadedLevels;
+    mipmapTexture(state.stream, texture, base, count);
+
+    if (texture->info.usage == TEXTURE_SAMPLE) {
+      state.barrier.prev |= GPU_PHASE_BLIT;
+      state.barrier.next |= GPU_PHASE_SHADER_VERTEX | GPU_PHASE_SHADER_FRAGMENT | GPU_PHASE_SHADER_COMPUTE;
+      state.barrier.flush |= GPU_CACHE_TRANSFER_WRITE;
+      state.barrier.clear |= GPU_CACHE_TEXTURE;
+    } else {
+      texture->sync->writePhase = GPU_PHASE_BLIT;
+      texture->sync->pendingWrite = GPU_CACHE_TRANSFER_WRITE;
+      texture->sync->lastStreamWrite = state.tick;
+    }
+  }
+
+  atomic_store_explicit(&texture->acquired, true, memory_order_release);
+  mtx_unlock(&state.lock);
+
+  return true;
+}
+
 bool lovrGraphicsGetWindowTexture(Texture** texture) {
   mtx_lock(&state.lock);
 
@@ -2360,6 +2416,7 @@ bool lovrGraphicsGetWindowTexture(Texture** texture) {
     state.window->sync = lovrCalloc(sizeof(Sync));
     state.window->sampleView = NULL;
     state.window->renderView = NULL;
+    state.window->root = state.window;
     state.window->info = (TextureInfo) {
       .type = TEXTURE_2D,
       .width = width,
@@ -2494,55 +2551,35 @@ Texture* lovrTextureCreate(const TextureInfo* info) {
   texture->info.srgb = srgb;
   texture->info.label = lovrStrdup(info->label);
 
-  uint32_t levelCount = 0;
-  uint32_t levelOffsets[16];
-  uint32_t levelSizes[16];
-  BufferView view = { 0 };
+  size_t stack = stackPush(&thread.stack);
 
-  mtx_lock(&state.lock);
+  void** levelData = NULL;
+  uint32_t layerSizes[16];
 
   if (info->imageCount > 0) {
-    levelCount = lovrImageGetLevelCount(info->images[0]);
+    texture->uploadedLevels = lovrImageGetLevelCount(info->images[0]);
+    levelData = allocate(&thread.stack, texture->uploadedLevels * info->layers * sizeof(void*));
 
-    if (info->type == TEXTURE_3D && levelCount > 1) {
+    if (info->type == TEXTURE_3D && texture->uploadedLevels > 1) {
       lovrSetError("Images used to initialize 3D textures can not have mipmaps");
       lovrTextureDestroy(texture);
+      stackPop(&thread.stack, stack);
       return NULL;
     }
 
-    uint32_t total = 0;
-    for (uint32_t level = 0; level < levelCount; level++) {
-      levelOffsets[level] = total;
-      uint32_t width = MAX(info->width >> level, 1);
-      uint32_t height = MAX(info->height >> level, 1);
-      levelSizes[level] = measureTexture(info->format, width, height, info->layers);
-      total += levelSizes[level];
-    }
+    for (uint32_t level = 0; level < texture->uploadedLevels; level++) {
+      void** layers = &levelData[level * info->layers];
+      layerSizes[level] = lovrImageGetLayerSize(info->images[0], level);
 
-    view = getBuffer(GPU_BUFFER_UPLOAD, total, 64);
-    char* data = view.pointer;
-
-    if (!view.buffer) {
-      lovrTextureDestroy(texture);
-      return NULL;
-    }
-
-    for (uint32_t level = 0; level < levelCount; level++) {
       for (uint32_t layer = 0; layer < info->layers; layer++) {
         Image* image = info->imageCount == 1 ? info->images[0] : info->images[layer];
         uint32_t slice = info->imageCount == 1 ? layer : 0;
-        size_t size = lovrImageGetLayerSize(image, level);
-        if (size != levelSizes[level] / info->layers) lovrUnreachable();
-        void* pixels = lovrImageGetLayerData(image, level, slice);
-        memcpy(data, pixels, size);
-        data += size;
+        layers[layer] = lovrImageGetLayerData(image, level, slice);
       }
-      levelOffsets[level] += view.offset;
     }
   }
 
-  // Render targets with mipmaps get transfer usage for automipmapping
-  bool transfer = (info->usage & TEXTURE_TRANSFER) || ((info->usage & TEXTURE_RENDER) && texture->info.mipmaps > 1);
+  bool generateMipmaps = texture->uploadedLevels > 0 && texture->uploadedLevels < texture->info.mipmaps;
 
   if (!gpu_texture_init(texture->gpu, &(gpu_texture_info) {
     .type = (gpu_texture_type) info->type,
@@ -2553,27 +2590,27 @@ Texture* lovrTextureCreate(const TextureInfo* info) {
     .usage =
       ((info->usage & TEXTURE_SAMPLE) ? GPU_TEXTURE_SAMPLE : 0) |
       ((info->usage & TEXTURE_RENDER) ? GPU_TEXTURE_RENDER : 0) |
+      ((info->usage & TEXTURE_RENDER) && mipmaps > 1 ? GPU_TEXTURE_COPY_SRC | GPU_TEXTURE_COPY_DST : 0) |
       ((info->usage & TEXTURE_STORAGE) ? GPU_TEXTURE_STORAGE : 0) |
-      (transfer ? GPU_TEXTURE_COPY_SRC | GPU_TEXTURE_COPY_DST : 0) |
+      ((info->usage & TEXTURE_TRANSFER) || generateMipmaps ? GPU_TEXTURE_COPY_SRC | GPU_TEXTURE_COPY_DST : 0) |
       ((info->usage & TEXTURE_FOVEATION) ? GPU_TEXTURE_FOVEATION : 0),
     .srgb = srgb,
     .handle = info->handle,
     .label = info->label,
     .upload = {
-      .stream = state.stream,
-      .buffer = view.buffer,
-      .levelCount = levelCount,
-      .levelOffsets = levelOffsets,
-      .generateMipmaps = levelCount > 0 && levelCount < mipmaps
+      .levelData = levelData,
+      .levelCount = texture->uploadedLevels,
+      .layerSizes = layerSizes,
+      .async = info->stream
     }
   })) {
-    mtx_unlock(&state.lock);
     lovrSetError("Failed to create texture: %s", gpu_get_error());
+    stackPop(&thread.stack, stack);
     lovrTextureDestroy(texture);
     return NULL;
   }
 
-  mtx_unlock(&state.lock);
+  stackPop(&thread.stack, stack);
 
   // Depth-stencil textures use a different depth-only view for sampling, otherwise default view can be used
   if (info->usage & TEXTURE_SAMPLE) {
@@ -2639,19 +2676,8 @@ Texture* lovrTextureCreate(const TextureInfo* info) {
     texture->storageView = texture->gpu;
   }
 
-  // Sample-only textures are exempt from sync tracking to reduce overhead.  Instead, they are
-  // manually synchronized with a single barrier after the upload stream.
-  if (info->usage == TEXTURE_SAMPLE) {
-    mtx_lock(&state.lock);
-    state.barrier.prev |= GPU_PHASE_COPY | GPU_PHASE_BLIT;
-    state.barrier.next |= GPU_PHASE_SHADER_VERTEX | GPU_PHASE_SHADER_FRAGMENT | GPU_PHASE_SHADER_COMPUTE;
-    state.barrier.flush |= GPU_CACHE_TRANSFER_WRITE;
-    state.barrier.clear |= GPU_CACHE_TEXTURE;
-    mtx_unlock(&state.lock);
-  } else if (levelCount > 0) {
-    texture->sync->writePhase = GPU_PHASE_COPY | GPU_PHASE_BLIT;
-    texture->sync->pendingWrite = GPU_CACHE_TRANSFER_WRITE;
-    texture->sync->lastStreamWrite = state.tick;
+  if (!info->stream) {
+    lovrTextureAcquire(texture);
   }
 
   for (uint32_t i = 0; i < mipmaps; i++) {
@@ -2826,7 +2852,13 @@ const TextureInfo* lovrTextureGetInfo(Texture* texture) {
   return &texture->info;
 }
 
+bool lovrTextureIsReady(Texture* texture) {
+  return !texture->info.stream || atomic_load(&texture->root->acquired) || gpu_texture_is_uploaded(texture->root->gpu);
+}
+
 bool lovrTextureSetPixels(Texture* texture, Image* image, uint32_t dstOffset[4], uint32_t srcOffset[4], uint32_t extent[3]) {
+  if (!lovrTextureAcquire(texture)) return false;
+
   TextureFormat format = texture->info.format;
   if (extent[0] == ~0u) extent[0] = MIN(texture->info.width - dstOffset[0], lovrImageGetWidth(image, srcOffset[3]) - srcOffset[0]);
   if (extent[1] == ~0u) extent[1] = MIN(texture->info.height - dstOffset[1], lovrImageGetHeight(image, srcOffset[3]) - srcOffset[1]);
@@ -2882,6 +2914,7 @@ bool lovrTextureCopy(Texture* src, Texture* dst, uint32_t srcOffset[4], uint32_t
   lovrCheck(src->info.usage & TEXTURE_TRANSFER, "Texture must be created with the 'transfer' usage to copy %s it", "from");
   lovrCheck(dst->info.usage & TEXTURE_TRANSFER, "Texture must be created with the 'transfer' usage to copy %s it", "to");
   lovrCheck(src->info.samples == dst->info.samples, "Texture sample counts must match to copy between them");
+  if (!lovrTextureAcquire(src) || !lovrTextureAcquire(dst)) return false;
   if (!checkTextureBounds(&src->info, srcOffset, extent)) return false;
   if (!checkTextureBounds(&dst->info, dstOffset, extent)) return false;
 
@@ -2920,6 +2953,7 @@ bool lovrTextureBlit(Texture* src, Texture* dst, uint32_t srcOffset[4], uint32_t
   lovrCheck(!depth || src->info.format == dst->info.format, "Blitting between depth textures requires them to have the same format");
   lovrCheck(((src->info.type == TEXTURE_3D) ^ (dst->info.type == TEXTURE_3D)) == false, "3D textures can only be blitted with other 3D textures");
   lovrCheck(src->info.type == TEXTURE_3D || srcExtent[2] == dstExtent[2], "When blitting between non-3D textures, blit layer counts must match");
+  if (!lovrTextureAcquire(src) || !lovrTextureAcquire(dst)) return false;
   if (!checkTextureBounds(&src->info, srcOffset, srcExtent)) return false;
   if (!checkTextureBounds(&dst->info, dstOffset, dstExtent)) return false;
 
@@ -2944,6 +2978,7 @@ bool lovrTextureClear(Texture* texture, float value[4], uint32_t layer, uint32_t
   lovrCheck(texture->info.usage & TEXTURE_TRANSFER, "Texture must be created with 'transfer' usage to clear it");
   lovrCheck(texture->info.type == TEXTURE_3D || layer + layerCount <= texture->info.layers, "Texture clear range exceeds texture layer count");
   lovrCheck(level + levelCount <= texture->info.mipmaps, "Texture clear range exceeds texture mipmap count");
+  if (!lovrTextureAcquire(texture)) return false;
 
   mtx_lock(&state.lock);
   gpu_barrier barrier = syncStream(texture->sync, GPU_PHASE_CLEAR, GPU_CACHE_TRANSFER_WRITE);
@@ -2960,6 +2995,7 @@ bool lovrTextureGenerateMipmaps(Texture* texture, uint32_t base, uint32_t count)
   lovrCheck(texture->info.samples == 1, "Can not mipmap a multisampled texture");
   lovrCheck(supports & GPU_FEATURE_BLIT, "This GPU does not support mipmapping this texture format/encoding");
   lovrCheck(base + count < texture->info.mipmaps, "Trying to generate too many mipmaps");
+  if (!lovrTextureAcquire(texture)) return false;
 
   mtx_lock(&state.lock);
   gpu_barrier barrier = syncStream(texture->sync, GPU_PHASE_BLIT, GPU_CACHE_TRANSFER_READ | GPU_CACHE_TRANSFER_WRITE);
@@ -2984,7 +3020,8 @@ Material* lovrTextureToMaterial(Texture* texture) {
     texture->material = lovrMaterialCreate(&(MaterialInfo) {
       .data.color = { 1.f, 1.f, 1.f, 1.f },
       .data.uvScale = { 1.f, 1.f },
-      .texture = texture
+      .texture = texture,
+      .weak = true
     });
 
     if (!texture->material) {
@@ -2994,7 +3031,6 @@ Material* lovrTextureToMaterial(Texture* texture) {
     // Since the Material refcounts the Texture, this creates a cycle.  Release the texture to make
     // sure this is a weak relationship (the automaterial does not keep the texture refcounted).
     lovrRelease(texture, lovrTextureDestroy);
-    texture->material->info.texture = NULL;
   }
 
   return texture->material;
@@ -3412,7 +3448,6 @@ Shader* lovrGraphicsGetDefaultShader(DefaultShader type) {
 }
 
 Shader* lovrShaderCreate(const ShaderInfo* info) {
-  initAllocator(&thread.stack);
   size_t stack = stackPush(&thread.stack);
 
   Shader* shader = lovrCalloc(sizeof(Shader) + gpu_sizeof_shader());
@@ -4058,10 +4093,13 @@ Material* lovrMaterialCreate(const MaterialInfo* info) {
     { 0, GPU_SLOT_UNIFORM_BUFFER, .buffer = buffer }
   };
 
+  material->acquired = true;
+
   for (uint32_t i = 0; i < COUNTOF(textures); i++) {
     Texture* texture = textures[i] ? textures[i] : state.defaultTexture;
     bindings[i + 1] = (gpu_binding) { i + 1, GPU_SLOT_SAMPLED_TEXTURE, .texture.object = texture->sampleView };
     material->hasWritableTexture |= texture->info.usage != TEXTURE_SAMPLE;
+    material->acquired &= atomic_load(&texture->root->acquired);
     lovrRetain(textures[i]);
   }
 
@@ -4086,7 +4124,7 @@ void lovrMaterialDestroy(void* ref) {
   material->block->tail = material->index;
   if (material->block->head == ~0u) material->block->head = material->block->tail;
   mtx_unlock(&state.lock);
-  lovrRelease(material->info.texture, lovrTextureDestroy);
+  if (!material->info.weak) lovrRelease(material->info.texture, lovrTextureDestroy);
   lovrRelease(material->info.glowTexture, lovrTextureDestroy);
   lovrRelease(material->info.metalnessTexture, lovrTextureDestroy);
   lovrRelease(material->info.roughnessTexture, lovrTextureDestroy);
@@ -5140,6 +5178,7 @@ void lovrMeshSetMaterial(Mesh* mesh, Material* material) {
 Model* lovrModelCreate(const ModelInfo* info) {
   Model* model = lovrCalloc(sizeof(Model));
   model->ref = 1;
+  model->stream = info->stream;
   model->meta = info->data->meta;
   model->treeFlags = info->raytracerFlags;
   lovrRetain(model->meta.blob);
@@ -5186,6 +5225,7 @@ Model* lovrModelCreate(const ModelInfo* info) {
               .mipmaps = info->mipmaps || lovrImageGetLevelCount(image) > 1 ? ~0u : 1,
               .samples = 1,
               .srgb = texture == &material.texture || texture == &material.glowTexture,
+              .stream = info->stream,
               .images = &image,
               .imageCount = 1
             });
@@ -5317,6 +5357,7 @@ Model* lovrModelClone(Model* parent) {
   model->ref = 1;
   model->parent = parent;
   model->meta = parent->meta;
+  model->stream = parent->stream;
   lovrRetain(parent);
 
   ModelMetadata* meta = &model->meta;
@@ -5421,6 +5462,20 @@ void lovrModelDestroy(void* ref) {
 
 ModelMetadata* lovrModelGetMetadata(Model* model) {
   return &model->meta;
+}
+
+bool lovrModelIsReady(Model* model) {
+  if (!model->stream) {
+    return true;
+  }
+
+  for (uint32_t i = 0; i < model->meta.imageCount; i++) {
+    if (!lovrTextureIsReady(model->textures[i])) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 void lovrModelResetNodeTransforms(Model* model) {
@@ -6205,6 +6260,7 @@ Readback* lovrReadbackCreateTexture(Texture* texture, uint32_t offset[4], uint32
   lovrCheck(extent[2] == 1, "Currently, only one layer can be read from a Texture");
   lovrCheck(texture->info.samples == 1, "Can't get pixels of a multisampled texture");
   lovrCheck(texture->info.usage & TEXTURE_TRANSFER, "Texture must be created with the 'transfer' usage to read from it");
+  if (!lovrTextureAcquire(texture)) return false;
   if (!checkTextureBounds(&texture->info, offset, extent)) return NULL;
   Image* image = lovrImageCreateRaw(extent[0], extent[1], texture->info.format, texture->info.srgb);
   lovrAssert(image, "Failed to create image: %s", lovrGetError());
@@ -6592,6 +6648,7 @@ bool lovrPassSetCanvas(Pass* pass, Canvas* canvas) {
 
   for (uint32_t i = 0; i < 4 && color[i].texture; i++) {
     const TextureInfo* info = &color[i].texture->info;
+    if (!lovrTextureAcquire(color[i].texture)) return false;
     lovrCheck(!isDepthFormat(info->format), "Unable to use a depth texture as a color texture in a canvas");
     lovrCheck(state.features.formats[info->format][info->srgb] & GPU_FEATURE_RENDER, "This GPU does not support rendering to the texture format/encoding used by canvas texture #%d", i + 1);
     lovrCheck(info->usage & TEXTURE_RENDER, "Texture must be created with the 'render' usage to render to it");
@@ -6601,6 +6658,7 @@ bool lovrPassSetCanvas(Pass* pass, Canvas* canvas) {
     lovrCheck(info->samples == 1 || info->samples == texture->samples, "Multisampled canvas textures must have the same sample count");
     if (color[i].resolve) {
       TextureInfo* resolve = &color[i].resolve->info;
+      if (!lovrTextureAcquire(color[i].resolve)) return false;
       lovrCheck(resolve->format == info->format, "Resolve texture format does not match format of its corresponding color texture");
       lovrCheck(resolve->usage & TEXTURE_RENDER, "Texture must be created with the 'render' usage to render to it");
       lovrCheck(resolve->width == texture->width, "Canvas texture sizes must match");
@@ -6613,6 +6671,7 @@ bool lovrPassSetCanvas(Pass* pass, Canvas* canvas) {
 
   if (depth->texture) {
     const TextureInfo* info = &depth->texture->info;
+    if (!lovrTextureAcquire(depth->texture)) return false;
     lovrCheck(isDepthFormat(info->format), "Canvas depth textures must have a depth format");
     lovrCheck(state.features.formats[info->format][0] & GPU_FEATURE_RENDER, "Canvas depth format is not supported by this GPU");
     lovrCheck(info->usage & TEXTURE_RENDER, "Texture must be created with the 'render' usage to render to it");
@@ -6623,6 +6682,7 @@ bool lovrPassSetCanvas(Pass* pass, Canvas* canvas) {
     lovrCheck(!(info->samples == 1 && samples > 1) || state.features.depthResolve, "This GPU does not support resolving depth textures");
     if (depth->resolve) {
       TextureInfo* resolve = &depth->resolve->info;
+      if (!lovrTextureAcquire(depth->resolve)) return false;
       lovrCheck(state.features.depthResolve, "This GPU does not support resolving depth textures");
       lovrCheck(resolve->format == info->format, "Depth resolve texture format does not match main depth texture format");
       lovrCheck(resolve->usage & TEXTURE_RENDER, "Depth resolve texture format does not match main depth texture format");
@@ -7372,7 +7432,7 @@ bool lovrPassSendTexture(Pass* pass, const char* name, size_t length, Texture* t
     view = texture->sampleView;
   }
 
-  trackTexture(pass, texture, resource->phase, resource->cache);
+  if (!trackTexture(pass, texture, resource->phase, resource->cache)) return false;
   pass->bindings[slot].texture.object = view;
   pass->bindings[slot].texture.sampler = texture->sampler ? texture->sampler->gpu : state.defaultSamplers[FILTER_LINEAR]->gpu;
   pass->flags |= DIRTY_BINDINGS;
@@ -7664,7 +7724,7 @@ bool lovrPassDraw(Pass* pass, DrawInfo* info) {
   draw->material = info->material;
   if (!draw->material) draw->material = pass->pipeline->material;
   if (!draw->material) draw->material = state.defaultMaterial;
-  trackMaterial(pass, draw->material);
+  if (!trackMaterial(pass, draw->material)) return false;
 
   draw->start = info->start;
   draw->count = info->count > 0 ? info->count : (info->index.buffer || info->index.count > 0 ? info->index.count : info->vertex.count);
@@ -8925,7 +8985,7 @@ bool lovrPassMeshIndirect(Pass* pass, Buffer* vertices, Buffer* indices, Buffer*
   draw->shader = shader;
   draw->material = pass->pipeline->material;
   if (!draw->material) draw->material = state.defaultMaterial;
-  trackMaterial(pass, draw->material);
+  if (!trackMaterial(pass, draw->material)) return false;
 
   draw->indirect.buffer = draws->gpu;
   draw->indirect.offset = draws->base + offset;
@@ -9309,8 +9369,7 @@ static gpu_texture* createTemporaryTexture(const TextureInfo* parent, TextureFor
     .size = { parent->width, parent->height, parent->layers },
     .mipmaps = 1,
     .samples = samples,
-    .usage = GPU_TEXTURE_RENDER,
-    .upload.stream = state.stream
+    .usage = GPU_TEXTURE_RENDER
   };
 
   gpu_texture* texture = lovrMalloc(gpu_sizeof_texture());
@@ -9319,6 +9378,8 @@ static gpu_texture* createTemporaryTexture(const TextureInfo* parent, TextureFor
     lovrFree(texture);
     return NULL;
   }
+
+  gpu_texture_acquire(texture, state.stream);
 
   return texture;
 }
@@ -9487,8 +9548,9 @@ static void trackBuffer(Pass* pass, Buffer* buffer, gpu_phase phase, gpu_cache c
   lovrRetain(buffer);
 }
 
-static void trackTexture(Pass* pass, Texture* texture, gpu_phase phase, gpu_cache cache) {
-  if (!texture) return;
+static bool trackTexture(Pass* pass, Texture* texture, gpu_phase phase, gpu_cache cache) {
+  if (!texture) return true;
+  if (!lovrTextureAcquire(texture)) return false;
 
   // Sample-only textures can skip sync, but still need to be refcounted
   if (texture->root->info.usage == TEXTURE_SAMPLE) {
@@ -9502,23 +9564,27 @@ static void trackTexture(Pass* pass, Texture* texture, gpu_phase phase, gpu_cach
   access->phase = phase;
   access->cache = cache;
   lovrRetain(texture);
+  return true;
 }
 
-static void trackMaterial(Pass* pass, Material* material) {
-  if (!material->hasWritableTexture) {
-    return;
+static bool trackMaterial(Pass* pass, Material* material) {
+  if (material->acquired && !material->hasWritableTexture) {
+    return true;
   }
 
   gpu_phase phase = GPU_PHASE_SHADER_VERTEX | GPU_PHASE_SHADER_FRAGMENT;
   gpu_cache cache = GPU_CACHE_TEXTURE;
 
-  trackTexture(pass, material->info.texture, phase, cache);
-  trackTexture(pass, material->info.glowTexture, phase, cache);
-  trackTexture(pass, material->info.metalnessTexture, phase, cache);
-  trackTexture(pass, material->info.roughnessTexture, phase, cache);
-  trackTexture(pass, material->info.clearcoatTexture, phase, cache);
-  trackTexture(pass, material->info.occlusionTexture, phase, cache);
-  trackTexture(pass, material->info.normalTexture, phase, cache);
+  if (!trackTexture(pass, material->info.texture, phase, cache)) return false;
+  if (!trackTexture(pass, material->info.glowTexture, phase, cache)) return false;
+  if (!trackTexture(pass, material->info.metalnessTexture, phase, cache)) return false;
+  if (!trackTexture(pass, material->info.roughnessTexture, phase, cache)) return false;
+  if (!trackTexture(pass, material->info.clearcoatTexture, phase, cache)) return false;
+  if (!trackTexture(pass, material->info.occlusionTexture, phase, cache)) return false;
+  if (!trackTexture(pass, material->info.normalTexture, phase, cache)) return false;
+
+  material->acquired = true;
+  return true;
 }
 
 static void trackRaytracer(Pass* pass, Raytracer* raytracer, gpu_phase phase, gpu_cache cache) {

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -2853,7 +2853,7 @@ const TextureInfo* lovrTextureGetInfo(Texture* texture) {
 }
 
 bool lovrTextureIsReady(Texture* texture) {
-  return !texture->info.stream || atomic_load(&texture->root->acquired) || gpu_texture_is_uploaded(texture->root->gpu);
+  return !texture->root->info.stream || atomic_load(&texture->root->acquired) || gpu_texture_is_uploaded(texture->root->gpu);
 }
 
 bool lovrTextureSetPixels(Texture* texture, Image* image, uint32_t dstOffset[4], uint32_t srcOffset[4], uint32_t extent[3]) {

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -105,6 +105,8 @@ enum {
 bool lovrGraphicsInit(GraphicsConfig* config);
 void lovrGraphicsDestroy(void);
 bool lovrGraphicsIsInitialized(void);
+void lovrGraphicsInitWorker(void);
+void lovrGraphicsDestroyWorker(void);
 
 void lovrGraphicsGetDevice(GraphicsDevice* device);
 void lovrGraphicsGetFeatures(GraphicsFeatures* features);
@@ -227,6 +229,7 @@ typedef struct {
   uint32_t usage;
   bool srgb;
   bool xr;
+  bool stream;
   uint32_t imageCount;
   struct Image** images;
   char* label;
@@ -252,6 +255,7 @@ Texture* lovrTextureCreate(const TextureInfo* info);
 Texture* lovrTextureCreateView(Texture* parent, const TextureViewInfo* info);
 void lovrTextureDestroy(void* ref);
 const TextureInfo* lovrTextureGetInfo(Texture* texture);
+bool lovrTextureIsReady(Texture* texture);
 bool lovrTextureSetPixels(Texture* texture, struct Image* image, uint32_t texOffset[4], uint32_t imgOffset[4], uint32_t extent[3]);
 bool lovrTextureCopy(Texture* src, Texture* dst, uint32_t srcOffset[4], uint32_t dstOffset[4], uint32_t extent[3]);
 bool lovrTextureBlit(Texture* src, Texture* dst, uint32_t srcOffset[4], uint32_t dstOffset[4], uint32_t srcExtent[3], uint32_t dstExtent[3], FilterMode filter);
@@ -386,6 +390,7 @@ typedef struct {
   Texture* clearcoatTexture;
   Texture* occlusionTexture;
   Texture* normalTexture;
+  bool weak;
 } MaterialInfo;
 
 Material* lovrMaterialCreate(const MaterialInfo* info);
@@ -494,6 +499,7 @@ typedef struct {
   struct ModelData* data;
   bool materials;
   bool mipmaps;
+  bool stream;
   uint32_t raytracerFlags;
 } ModelInfo;
 
@@ -506,6 +512,7 @@ Model* lovrModelCreate(const ModelInfo* info);
 Model* lovrModelClone(Model* model);
 void lovrModelDestroy(void* ref);
 struct ModelMetadata* lovrModelGetMetadata(Model* model);
+bool lovrModelIsReady(Model* model);
 void lovrModelResetNodeTransforms(Model* model);
 void lovrModelResetBlendShapes(Model* model);
 bool lovrModelAnimate(Model* model, uint32_t animationIndex, float time, float alpha);

--- a/src/modules/thread/thread.c
+++ b/src/modules/thread/thread.c
@@ -1,6 +1,7 @@
 #include "thread/thread.h"
 #include "data/blob.h"
 #include "event/event.h"
+#include "graphics/graphics.h"
 #include "core/job.h"
 #include "core/os.h"
 #include "util.h"
@@ -47,9 +48,15 @@ static struct {
 static void workerInit(uint32_t id) {
   lovrProfileSetThreadName("Worker");
   os_thread_set_name("Worker");
+#ifndef LOVR_DISABLE_GRAPHICS
+  lovrGraphicsInitWorker();
+#endif
 }
 
 static void workerQuit(uint32_t id) {
+#ifndef LOVR_DISABLE_GRAPHICS
+  lovrGraphicsDestroyWorker();
+#endif
   if (state.onWorkerQuit) {
     state.onWorkerQuit();
   }


### PR DESCRIPTION
- Add `stream` flag to `lovr.graphics.newTexture/newModel`.  This will load the texture(s) asynchronously on a separate GPU queue when possible, avoiding interrupting the rendering work happening on the main queue.
- Add `Texture/Model:isReady` to check if the asynchronous transfer is complete and the texture is ready to use.  It is an error to use a Texture before it's ready.
  - You can use `Model:isReady` to see if all of its textures are ready, or you can check individual textures and draw the ready ones with `Pass:drawPart` to do a progressive per-mesh load.
- Vulkan details:
  - core/gpu texture creation takes a CPU pointer instead of GPU buffer
  - Texture upload uses `VK_EXT_host_image_copy` when available/optimal (for all textures).
  - Otherwise, falls back to separate transfer queue when available (and the texture is streaming).
  - Otherwise, falls back to doing the transfer on the graphics queue (original behavior).

Main "reason" to do it is that WebGPU really wants to take a CPU pointer for texture data.

Still unclear if this is worth it or a good idea, but it sure is cool!