### PR TITLE
lovr.timer.getDisplayTime;

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Changelog
 dev
 ---
 
+### Add
+
+- Add `lovr.timer.getDisplayTime`.
+
 ### Change
 
 - Change `Pass:setScissor` to clamp negative x/y values to zero.
@@ -13,11 +17,17 @@ dev
 - Change `Image:encode` to support more formats (all uncompressed non-float color formats).
 - Change `lovr.data.newRasterizer` to take an `Image` to use for a BMFont atlas.
 - Change `lovr.graphics.newFont` to take an `Image` to use for a BMFont atlas.
+- Change `lovr.timer.getDelta/getAverageDelta/getFPS` to return values from the headset when VR is active.
 
 ### Fix
 
 - Fix `Pass:drawPart`.
 - Fix invisible window when it was bigger than the size of the monitor.
+
+### Deprecate
+
+- Deprecate `lovr.headset.getTime` (use `lovr.timer.getDisplayTime`).
+- Deprecate `lovr.headset.getDeltaTime` (use `lovr.timer.getDelta`).
 
 ### Remove
 

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -197,11 +197,9 @@ function lovr.run()
       end
     end
     local dt = 0
+    if lovr.headset then lovr.headset.update() end
     if lovr.timer then dt = lovr.timer.step() end
-    if lovr.headset then
-      dt = lovr.headset.update()
-      if not lovr.headset.isActive() then lovr.simulate(dt) end
-    end
+    if lovr.headset and not lovr.headset.isActive() then lovr.simulate(dt) end
     if lovr.task then
       for task in lovr.task.poll() do
         lovr.taskready(task)

--- a/src/api/l_headset.c
+++ b/src/api/l_headset.c
@@ -3,6 +3,7 @@
 #include "data/image.h"
 #include "data/modelData.h"
 #include "graphics/graphics.h"
+#include "timer/timer.h"
 #include "core/maf.h"
 #include "util.h"
 #include <stdlib.h>
@@ -197,20 +198,8 @@ static int l_lovrHeadsetPollEvents(lua_State* L) {
 }
 
 static int l_lovrHeadsetUpdate(lua_State* L) {
-  double dt = 0.;
-  luax_assert(L, lovrHeadsetUpdate(&dt));
-  lua_pushnumber(L, dt);
-  return 1;
-}
-
-static int l_lovrHeadsetGetDeltaTime(lua_State* L) {
-  lua_pushnumber(L, lovrHeadsetGetDeltaTime());
-  return 1;
-}
-
-static int l_lovrHeadsetGetTime(lua_State* L) {
-  lua_pushnumber(L, lovrHeadsetGetDisplayTime());
-  return 1;
+  luax_assert(L, lovrHeadsetUpdate());
+  return 0;
 }
 
 static int l_lovrHeadsetGetDisplayWidth(lua_State* L) {
@@ -1013,6 +1002,20 @@ static int l_lovrHeadsetGetHands(lua_State* L) {
   return 1;
 }
 
+// Deprecated
+
+static int l_lovrHeadsetGetDeltaTime(lua_State* L) {
+  double dt = lovrHeadsetGetDeltaTime();
+  lua_pushnumber(L, dt == 0. ? lovrTimerGetDelta() : dt);
+  return 1;
+}
+
+static int l_lovrHeadsetGetTime(lua_State* L) {
+  double t = lovrHeadsetGetDisplayTime();
+  lua_pushnumber(L, t == 0. ? lovrTimerGetTime() : t);
+  return 1;
+}
+
 static const luaL_Reg lovrHeadset[] = {
   { "connect", l_lovrHeadsetConnect },
   { "getName", l_lovrHeadsetGetName },
@@ -1027,8 +1030,6 @@ static const luaL_Reg lovrHeadset[] = {
   { "isMounted", l_lovrHeadsetIsMounted },
   { "pollEvents", l_lovrHeadsetPollEvents },
   { "update", l_lovrHeadsetUpdate },
-  { "getDeltaTime", l_lovrHeadsetGetDeltaTime },
-  { "getTime", l_lovrHeadsetGetTime },
   { "getDisplayWidth", l_lovrHeadsetGetDisplayWidth },
   { "getDisplayHeight", l_lovrHeadsetGetDisplayHeight },
   { "getDisplayDimensions", l_lovrHeadsetGetDisplayDimensions },
@@ -1079,6 +1080,11 @@ static const luaL_Reg lovrHeadset[] = {
   { "setButton", l_lovrHeadsetSetButton },
   { "newLayer", l_lovrHeadsetNewLayer },
   { "getHands", l_lovrHeadsetGetHands },
+
+  // Deprecated
+  { "getDeltaTime", l_lovrHeadsetGetDeltaTime },
+  { "getTime", l_lovrHeadsetGetTime },
+
   { NULL, NULL }
 };
 

--- a/src/api/l_timer.c
+++ b/src/api/l_timer.c
@@ -21,6 +21,11 @@ static int l_lovrTimerGetTime(lua_State* L) {
   return 1;
 }
 
+static int l_lovrTimerGetDisplayTime(lua_State* L) {
+  lua_pushnumber(L, lovrTimerGetDisplayTime());
+  return 1;
+}
+
 static int l_lovrTimerStep(lua_State* L) {
   lua_pushnumber(L, lovrTimerStep());
   return 1;
@@ -53,6 +58,7 @@ static const luaL_Reg lovrTimer[] = {
   { "getAverageDelta", l_lovrTimerGetAverageDelta },
   { "getFPS", l_lovrTimerGetFPS },
   { "getTime", l_lovrTimerGetTime },
+  { "getDisplayTime", l_lovrTimerGetDisplayTime },
   { "step", l_lovrTimerStep },
   { "sleep", l_lovrTimerSleep },
   { NULL, NULL }

--- a/src/modules/headset/headset.c
+++ b/src/modules/headset/headset.c
@@ -2024,15 +2024,13 @@ bool lovrHeadsetPollEvents(void) {
   return true;
 }
 
-bool lovrHeadsetUpdate(double* dt) {
+bool lovrHeadsetUpdate(void) {
   if (!state.session) {
     memcpy(state.simulator.lastButtons, state.simulator.buttons, sizeof(state.simulator.buttons));
-    *dt = lovrTimerGetDelta();
     return true;
   }
 
   if (state.waited) {
-    *dt = lovrHeadsetGetDeltaTime();
     return true;
   }
 
@@ -2064,24 +2062,7 @@ bool lovrHeadsetUpdate(double* dt) {
     os_sleep(.001);
   }
 
-  *dt = lovrHeadsetGetDeltaTime();
   return true;
-}
-
-double lovrHeadsetGetDeltaTime(void) {
-  if (SESSION_RUNNING(state.sessionState)) {
-    return (state.frameState.predictedDisplayTime - state.lastDisplayTime) / 1e9;
-  } else {
-    return lovrTimerGetDelta();
-  }
-}
-
-double lovrHeadsetGetDisplayTime(void) {
-  if (SESSION_RUNNING(state.sessionState)) {
-    return (state.frameState.predictedDisplayTime - state.epoch) / 1e9;
-  } else {
-    return lovrTimerGetTime();
-  }
 }
 
 void lovrHeadsetGetDisplayDimensions(uint32_t* width, uint32_t* height) {
@@ -3977,12 +3958,16 @@ uint32_t lovrHeadsetCreateVulkanDevice(void* instance, void* deviceCreateInfo, v
   return result;
 }
 
-uintptr_t lovrHeadsetGetInstanceHandle(void) {
-  return (uintptr_t) state.instance;
+double lovrHeadsetGetDisplayTime(void) {
+  return SESSION_RUNNING(state.sessionState) ? (state.frameState.predictedDisplayTime - state.epoch) / 1e9 : 0.;
 }
 
-uintptr_t lovrHeadsetGetSessionHandle(void) {
-  return (uintptr_t) state.session;
+double lovrHeadsetGetDisplayPeriod(void) {
+  return SESSION_RUNNING(state.sessionState) ? state.frameState.predictedDisplayPeriod : 0.;
+}
+
+double lovrHeadsetGetDeltaTime(void) {
+  return SESSION_RUNNING(state.sessionState) ? (state.frameState.predictedDisplayTime - state.lastDisplayTime) / 1e9 : 0.;
 }
 
 // Helpers

--- a/src/modules/headset/headset.h
+++ b/src/modules/headset/headset.h
@@ -191,9 +191,7 @@ bool lovrHeadsetIsVisible(void);
 bool lovrHeadsetIsFocused(void);
 bool lovrHeadsetIsMounted(void);
 bool lovrHeadsetPollEvents(void);
-bool lovrHeadsetUpdate(double* dt);
-double lovrHeadsetGetDeltaTime(void);
-double lovrHeadsetGetDisplayTime(void);
+bool lovrHeadsetUpdate(void);
 void lovrHeadsetGetDisplayDimensions(uint32_t* width, uint32_t* height);
 float* lovrHeadsetGetRefreshRates(uint32_t* count);
 float lovrHeadsetGetRefreshRate(void);
@@ -261,7 +259,9 @@ struct Pass* lovrLayerGetPass(Layer* layer);
 
 // Private
 
-bool lovrHeadsetIsSupported(void);
 void lovrHeadsetGetVulkanPhysicalDevice(void* instance, uintptr_t physicalDevice);
 uint32_t lovrHeadsetCreateVulkanInstance(void* instanceCreateInfo, void* allocator, uintptr_t instance, void* getInstanceProcAddr);
 uint32_t lovrHeadsetCreateVulkanDevice(void* instance, void* deviceCreateInfo, void* allocatoor, uintptr_t device, void* getInstanceProcAddr);
+double lovrHeadsetGetDisplayTime(void);
+double lovrHeadsetGetDisplayPeriod(void);
+double lovrHeadsetGetDeltaTime(void);

--- a/src/modules/timer/timer.c
+++ b/src/modules/timer/timer.c
@@ -1,4 +1,5 @@
 #include "timer/timer.h"
+#include "headset/headset.h"
 #include "core/os.h"
 #include "util.h"
 #include <stdatomic.h>
@@ -30,11 +31,23 @@ void lovrTimerDestroy(void) {
 }
 
 double lovrTimerGetDelta(void) {
+#ifndef LOVR_DISABLE_HEADSET
+  double dt = lovrHeadsetGetDeltaTime();
+  if (dt != 0.) return dt;
+#endif
   return state.dt;
 }
 
 double lovrTimerGetTime(void) {
   return os_get_time() - state.epoch;
+}
+
+double lovrTimerGetDisplayTime(void) {
+#ifndef LOVR_DISABLE_HEADSET
+  double t = lovrHeadsetGetDisplayTime();
+  if (t != 0.) return t;
+#endif
+  return lovrTimerGetTime();
 }
 
 double lovrTimerStep(void) {
@@ -47,15 +60,19 @@ double lovrTimerStep(void) {
   if (++state.tickIndex == TICK_SAMPLES) {
     state.tickIndex = 0;
   }
-  return state.dt;
+  return lovrTimerGetDelta();
 }
 
 double lovrTimerGetAverageDelta(void) {
+#ifndef LOVR_DISABLE_HEADSET
+  double dt = lovrHeadsetGetDisplayPeriod();
+  if (dt != 0.) return dt;
+#endif
   return state.tickSum / TICK_SAMPLES;
 }
 
 int lovrTimerGetFPS(void) {
-  return (int) (1 / (state.tickSum / TICK_SAMPLES) + .5);
+  return (int) (1. / lovrTimerGetAverageDelta() + .5);
 }
 
 void lovrTimerSleep(double seconds) {

--- a/src/modules/timer/timer.h
+++ b/src/modules/timer/timer.h
@@ -8,6 +8,7 @@ bool lovrTimerInit(void);
 void lovrTimerDestroy(void);
 double lovrTimerGetDelta(void);
 double lovrTimerGetTime(void);
+double lovrTimerGetDisplayTime(void);
 double lovrTimerStep(void);
 double lovrTimerGetAverageDelta(void);
 int lovrTimerGetFPS(void);


### PR DESCRIPTION
This is an attempt to unify the `lovr.headset` timing functions and the `lovr.timer` module.

- Add `lovr.timer.getDisplayTime`.  It's equivalent to the common idiom `lovr.headset and lovr.headset.getTime() or lovr.timer.getTime()`.
- Deprecate `lovr.headset.getTime` and `lovr.headset.getDeltaTime`.  Use `lovr.timer.getDisplayTime` or `lovr.timer.getDelta`, respectively.
- Also change `lovr.timer.getAverageDelta` and `lovr.timer.getFPS` to use headset-related values (`predictedDisplayPeriod` from OpenXR).

Biggest risks:

- VR is active but you want the lovr.timer dt for some reason.  I can't think of a reason why you'd want this.  It's easier if there's just one `dt`.
- We add non-VR display times (like for the window swapchain).  Then, which one should `lovr.timer.getDisplayTime` return?  Do we go back to `lovr.headset.getDisplayTime` and `lovr.graphics.getDisplayTime`?  Does `lovr.timer.getDisplayTime` take an optional `Display` parameter that can be `headset` or `window` and defaults to something sensible?

Fixes #960 