### PR TITLE
Fix OBJ material copying when there is no texture

### DIFF
--- a/src/modules/data/modelData_obj.c
+++ b/src/modules/data/modelData_obj.c
@@ -346,6 +346,9 @@ bool lovrModelDataInitObj(ModelData** result, Blob* source, ModelDataIO* io) {
 
   if (meta->imageCount > 0) {
     memcpy(model->images, images.data, meta->imageCount * sizeof(Image*));
+  }
+
+  if (meta->materialCount > 0) {
     memcpy(meta->materials, materials.data, meta->materialCount * sizeof(ModelMaterial));
   }
 


### PR DESCRIPTION
Ran into this when loading Kenney's low poly assets that have no textures but still specify material properties.