### PR TITLE
Fall back to handheld display form factor

### DIFF
--- a/src/modules/headset/headset.c
+++ b/src/modules/headset/headset.c
@@ -583,7 +583,14 @@ bool lovrHeadsetConnect(void) {
     .formFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY
   };
 
-  XRG(xrGetSystem(state.instance, &systemInfo, &state.system), "xrGetSystem", fail);
+  // Prefer a head-mounted display, but fall back to a handheld display when the
+  // runtime does not offer an HMD, so both form factors are supported.
+  result = xrGetSystem(state.instance, &systemInfo, &state.system);
+  if (result == XR_ERROR_FORM_FACTOR_UNSUPPORTED) {
+    systemInfo.formFactor = XR_FORM_FACTOR_HANDHELD_DISPLAY;
+    result = xrGetSystem(state.instance, &systemInfo, &state.system);
+  }
+  XRG(result, "xrGetSystem", fail);
 
   XrSystemEyeGazeInteractionPropertiesEXT eyeGazeProperties = { .type = XR_TYPE_SYSTEM_EYE_GAZE_INTERACTION_PROPERTIES_EXT };
   XrSystemHandTrackingPropertiesEXT handTrackingProperties = { .type = XR_TYPE_SYSTEM_HAND_TRACKING_PROPERTIES_EXT };


### PR DESCRIPTION
## Summary

`lovrHeadsetConnect` only requests `XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY` from `xrGetSystem`. Runtimes that expose only a handheld display (`XR_FORM_FACTOR_HANDHELD_DISPLAY`) therefore fail to connect with `XR_ERROR_FORM_FACTOR_UNSUPPORTED`.

This retries with the handheld form factor when the HMD form factor is unsupported, so both form factors work from the same build.

## Notes

- The view configuration selection already includes `XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO`, so handheld (single-view) runtimes are picked up automatically — no other changes are needed.
- HMD remains the preferred form factor; the handheld path is only taken when an HMD is not offered.