### PR TITLE
Added GPU selection

### DIFF
--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -379,6 +379,40 @@ static void luax_writeshadercache(void) {
   lovrFree(data);
 }
 
+
+static int callback_selectGPU(void* luaPtr, GraphicsDevice* gd, uint32_t count){
+    lua_State* L = (lua_State*) luaPtr;
+    
+    // main table
+    lua_createtable(L,count,0);
+
+    for (uint32_t i = 0; i < count; i++){
+        lua_newtable(L);
+
+        GraphicsDevice device = gd[i];
+
+        lua_pushinteger(L, device.deviceId), lua_setfield(L, -2, "id");
+        lua_pushinteger(L, device.vendorId), lua_setfield(L, -2, "vendor");
+        lua_pushstring(L, device.name), lua_setfield(L, -2, "name");
+        lua_pushstring(L, device.renderer), lua_setfield(L, -2, "renderer");
+        lua_pushboolean(L, device.discrete), lua_setfield(L, -2, "discrete");
+
+        lua_rawseti(L, -2, i + 1);
+    }
+
+    lua_getfield(L, LUA_REGISTRYINDEX, "__lovrconf_selectGPU");
+    lua_insert(L, -2);
+    lua_call(L,1,1);
+
+    int idx = luaL_optinteger(L, -1, 1) - 1;
+    lua_pop(L,1);
+
+    lua_pushnil(L);
+    lua_setfield(L, LUA_REGISTRYINDEX, "__lovrconf_selectGPU");
+
+    return idx;
+}
+
 static int l_lovrGraphicsInitialize(lua_State* L) {
   GraphicsConfig config = {
     .debug = false,
@@ -417,6 +451,16 @@ static int l_lovrGraphicsInitialize(lua_State* L) {
       lua_getfield(L, -1, "shadercache");
       shaderCache = lua_toboolean(L, -1);
       lua_pop(L, 1);
+    
+      lua_getfield(L, -1, "selectGPU");
+      if (lua_isfunction(L, -1)) {
+        lua_setfield(L, LUA_REGISTRYINDEX, "__lovrconf_selectGPU");
+        config.selectGPU = callback_selectGPU;
+        config.selectGPUUserData = L;
+      }
+      else {
+        lua_pop(L, 1);
+      }
     }
     lua_pop(L, 1);
 

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -833,6 +833,9 @@ typedef struct {
   void (*fnLog)(void* userdata, const char* message);
   void* (*fnAlloc)(size_t size);
   void (*fnFree)(void* data);
+  int (*fnSelectGPU)(gpu_device_info*, uint32_t count, void* f, void* ud);
+  void* selectGPUFunction;
+  void* selectGPUUserData;
   const char* engineName;
   uint32_t engineVersion[3];
   gpu_device_info* device;

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -3051,13 +3051,41 @@ bool gpu_init(gpu_config* config) {
   { // Device
     if (config->vk.getPhysicalDevice) {
       config->vk.getPhysicalDevice(state.instance, (uintptr_t) &state.adapter);
-    }
+    } else if (config->fnSelectGPU) {
+      uint32_t deviceCount = 0;
 
-    if (!state.adapter) {
+      vkEnumeratePhysicalDevices(state.instance, &deviceCount, NULL);
+      VkPhysicalDevice* devices = config->fnAlloc(deviceCount * sizeof(VkPhysicalDevice));
+      vkEnumeratePhysicalDevices(state.instance, &deviceCount, devices);
+
+      gpu_device_info* infos = config->fnAlloc(deviceCount * sizeof(gpu_device_info));
+
+      for (uint32_t i = 0; i < deviceCount; i++){
+        VkPhysicalDeviceProperties2 properties2 = { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2 };
+        vkGetPhysicalDeviceProperties2(devices[i], &properties2);
+
+        VkPhysicalDeviceProperties* properties = &properties2.properties;
+        infos[i].deviceId = properties->deviceID;
+        infos[i].vendorId = properties->vendorID;
+        memcpy(infos[i].deviceName, properties->deviceName, MIN(sizeof(config->device->deviceName), sizeof(properties->deviceName)));
+        infos[i].renderer = "Vulkan";
+        infos[i].discrete = properties->deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+      }
+        
+      int selected = config->fnSelectGPU(infos, deviceCount, config->selectGPUFunction, config->selectGPUUserData);
+
+      if (selected == -1) selected = 0;
+
+      VkPhysicalDevice selected_device = devices[selected];
+
+      config->fnFree(infos);
+      config->fnFree(devices);
+
+      state.adapter = selected_device;
+    } else {
       uint32_t deviceCount = 1;
       VK(vkEnumeratePhysicalDevices(state.instance, &deviceCount, &state.adapter), "vkEnumeratePhysicalDevices") goto fail;
     }
-
     if (!state.adapter) {
       error("No suitable graphics device available");
       goto fail;

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -659,6 +659,30 @@ static void onMessage(void* context, const char* message);
 
 // Entry
 
+static int selectGPUCallback(gpu_device_info* gd, uint32_t count, void* f, void* ud){
+    selectGPU fn = (selectGPU) f;
+    if (!fn) return -1;
+
+    // convert to GraphicsDevice info
+
+    GraphicsDevice* data = lovrMalloc(count * sizeof(GraphicsDevice));
+    
+    for (uint32_t i = 0; i < count; i++){
+        data[i].deviceId = gd[i].deviceId;
+        data[i].vendorId = gd[i].vendorId;
+        data[i].name = gd[i].deviceName;
+        data[i].renderer = gd[i].renderer;
+        data[i].discrete = gd[i].discrete;
+        data[i].subgroupSize = -1; // not implemented in gpu_vk yet
+    }
+
+    int idx = fn(ud,data,count);
+
+    lovrFree(data);
+
+    return idx;
+}
+
 bool lovrGraphicsInit(GraphicsConfig* config) {
   initAllocator(&thread.stack);
 
@@ -686,6 +710,12 @@ bool lovrGraphicsInit(GraphicsConfig* config) {
     .vk.createDevice = lovrHeadsetIsConnected() ? lovrHeadsetCreateVulkanDevice : NULL
 #endif
   };
+
+  if (config->selectGPU){
+    gpu.fnSelectGPU = selectGPUCallback;
+    gpu.selectGPUUserData = config->selectGPUUserData;
+    gpu.selectGPUFunction = config->selectGPU;
+  }
 
   if (!gpu_init(&gpu)) {
 #if _WIN32

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -23,16 +23,6 @@ typedef struct Readback Readback;
 typedef struct Pass Pass;
 
 typedef struct {
-  bool debug;
-  bool vsync;
-  bool stencil;
-  bool antialias;
-  bool hdr;
-  void* cacheData;
-  size_t cacheSize;
-} GraphicsConfig;
-
-typedef struct {
   uint32_t deviceId;
   uint32_t vendorId;
   const char* name;
@@ -40,6 +30,20 @@ typedef struct {
   uint32_t subgroupSize;
   bool discrete;
 } GraphicsDevice;
+
+typedef int (*selectGPU)(void* luaPtr, GraphicsDevice*, uint32_t count);
+
+typedef struct {
+  bool debug;
+  bool vsync;
+  bool stencil;
+  bool antialias;
+  bool hdr;
+  void* cacheData;
+  size_t cacheSize;
+  selectGPU selectGPU;
+  void* selectGPUUserData;
+} GraphicsConfig;
 
 typedef struct {
   bool textureBC;


### PR DESCRIPTION
in lovr.conf, t.graphics.selectGPU takes a function and lets you choose what GPU you want lovr to use

Only for Vulkan

usage example for selecting discrete GPU:
```lua
-- in lovr.conf
t.graphics.selectGPU = function(gpus)
    for Idx, Device in ipairs(gpus) do
        if Device.discrete then return Idx end
    end
    return 1
end
```

Has fields: `.vendor, .name, .id, .discrete, .renderer`
Defaults to GPU at index 1 if no function provided or no return