### PR TITLE
Rework GPU Timing Stats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ dev
 - Add support for atomic floats in shaders.
 - Add `ConvexShape:setScale` and `MeshShape:setScale`.
 - Add `t.graphics.lowpower`.
+- Add `lovr.graphics.getTiming`.
 
 ### Change
 
@@ -40,6 +41,7 @@ dev
 
 - Deprecate `lovr.headset.getTime` (use `lovr.timer.getDisplayTime`).
 - Deprecate `lovr.headset.getDeltaTime` (use `lovr.timer.getDelta`).
+- Deprecate `gpuTime` and `submitTime` fields of `Pass:getStats` (use `lovr.graphics.getTiming`).
 
 ### Remove
 

--- a/etc/shaders/tallymerge.comp
+++ b/etc/shaders/tallymerge.comp
@@ -7,6 +7,7 @@ layout(push_constant) uniform PushConstants {
   uint views;
 };
 
+// input is u64, output is u32
 layout(set = 0, binding = 0) buffer readonly restrict Src { uint src[]; };
 layout(set = 0, binding = 1) buffer writeonly restrict Dst { uint dst[]; };
 
@@ -18,7 +19,7 @@ void main() {
   uint total = 0;
 
   for (uint i = 0; i < views; i++) {
-    total += src[base + i];
+    total += src[2 * (base + i) + 0];
   }
 
   dst[index] = total;

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -113,7 +113,8 @@ typedef struct {
 #define luax_checkfloat(L, i) (float) luaL_checknumber(L, i)
 #define luax_optfloat(L, i, x) (float) luaL_optnumber(L, i, x)
 #define luax_tofloat(L, i) (float) lua_tonumber(L, i)
-#define luax_assert(L, c) if (!(c)) { lua_pushstring(L, lovrGetError()); lua_error(L); }
+#define luax_throw(L) lua_pushstring(L, lovrGetError()), lua_error(L)
+#define luax_assert(L, c) if (!(c)) { luax_throw(L); }
 #define luax_pushnilerror(L) lua_pushnil(L), lua_pushstring(L, lovrGetError()), 2
 
 void luax_preload(lua_State* L);

--- a/src/api/l_graphics.c
+++ b/src/api/l_graphics.c
@@ -461,6 +461,60 @@ static int l_lovrGraphicsSetTimingEnabled(lua_State* L) {
   return 0;
 }
 
+static bool luax_pollreadback(void** context) {
+  return lovrReadbackPoll(*context);
+}
+
+static bool luax_waitreadback(void** context) {
+  return lovrReadbackWait(*context);
+}
+
+static int luax_pushtiming(lua_State* L, bool success, void* readback) {
+  if (success) {
+    Pass** passes;
+    Timing* timing;
+    uint32_t count;
+
+    if (!lovrReadbackGetTimestamps(readback, &passes, &timing, &count)) {
+      lovrRelease(readback, lovrReadbackDestroy);
+      return luax_throw(L);
+    }
+
+    lua_createtable(L, 0, (int) count);
+    for (uint32_t i = 0; i < count; i++) {
+      luax_pushtype(L, Pass, passes[i]);
+
+      lua_createtable(L, 0, 4);
+      lua_pushnumber(L, timing[i].duration), lua_setfield(L, -2, "duration");
+      lua_pushnumber(L, timing[i].submit), lua_setfield(L, -2, "submit");
+
+      if (timing[i].start != 0.) {
+        lua_pushnumber(L, timing[i].start), lua_setfield(L, -2, "start");
+        lua_pushnumber(L, timing[i].finish), lua_setfield(L, -2, "finish");
+      }
+
+      lua_settable(L, -3);
+    }
+
+    lovrRelease(readback, lovrReadbackDestroy);
+    return 1;
+  } else {
+    lovrRelease(readback, lovrReadbackDestroy);
+    return 0;
+  }
+}
+
+static int l_lovrGraphicsGetTiming(lua_State* L) {
+  Readback* readback = lovrGraphicsGetTiming();
+  if (!readback) {
+    lua_pushnil(L);
+    return 1;
+  } else {
+    lovrRetain(readback);
+    return luax_yieldpoll(L, luax_pollreadback, luax_waitreadback, luax_pushtiming, readback);
+  }
+}
+
 static int l_lovrGraphicsSubmit(lua_State* L) {
   bool table = lua_istable(L, 1);
   int length = table ? luax_len(L, 1) : lua_gettop(L);
@@ -1757,6 +1811,7 @@ static const luaL_Reg lovrGraphics[] = {
   { "isInitialized", l_lovrGraphicsIsInitialized },
   { "isTimingEnabled", l_lovrGraphicsIsTimingEnabled },
   { "setTimingEnabled", l_lovrGraphicsSetTimingEnabled },
+  { "getTiming", l_lovrGraphicsGetTiming },
   { "submit", l_lovrGraphicsSubmit },
   { "present", l_lovrGraphicsPresent },
   { "wait", l_lovrGraphicsWait },

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -768,12 +768,14 @@ void gpu_xr_release(gpu_stream* stream, gpu_texture* texture);
 // Entry
 
 typedef struct {
+  bool discrete;
   uint32_t deviceId;
   uint32_t vendorId;
   char deviceName[256];
   const char* renderer;
   uint32_t subgroupSize;
-  bool discrete;
+  double timestampOffset;
+  double timestampScale;
 } gpu_device_info;
 
 enum {
@@ -838,7 +840,6 @@ typedef struct {
   uint32_t pushConstantSize;
   uint32_t indirectDrawCount;
   uint32_t instances;
-  float timestampPeriod;
   float anisotropy;
   float pointSize;
 } gpu_limits;

--- a/src/core/gpu_vk.c
+++ b/src/core/gpu_vk.c
@@ -243,6 +243,7 @@ typedef struct {
   bool formatFlags2;
   bool hostImageCopy;
   bool atomicFloat;
+  bool calibratedTimestamps;
 } gpu_extensions;
 
 // State
@@ -446,7 +447,8 @@ static void error(const char* message);
   X(vkDestroyAccelerationStructureKHR)\
   X(vkCmdBuildAccelerationStructuresKHR)\
   X(vkCopyMemoryToImageEXT)\
-  X(vkTransitionImageLayoutEXT)
+  X(vkTransitionImageLayoutEXT)\
+  X(vkGetCalibratedTimestampsKHR)
 
 // Used to load/declare Vulkan functions without lots of clutter
 #define GPU_LOAD_ANONYMOUS(fn) fn = (PFN_##fn) vkGetInstanceProcAddr(NULL, #fn);
@@ -2761,7 +2763,7 @@ void gpu_copy_texture_buffer(gpu_stream* stream, gpu_texture* src, gpu_buffer* d
 }
 
 void gpu_copy_tally_buffer(gpu_stream* stream, gpu_tally* src, gpu_buffer* dst, uint32_t srcIndex, uint32_t dstOffset, uint32_t count) {
-  vkCmdCopyQueryPoolResults(stream->commands, src->handle, srcIndex, count, dst->handle, dstOffset, 4, VK_QUERY_RESULT_WAIT_BIT);
+  vkCmdCopyQueryPoolResults(stream->commands, src->handle, srcIndex, count, dst->handle, dstOffset, 8, VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
 }
 
 void gpu_clear_buffer(gpu_stream* stream, gpu_buffer* buffer, uint32_t offset, uint32_t extent, uint32_t value) {
@@ -3099,6 +3101,9 @@ bool gpu_init(gpu_config* config) {
     struct { const char* name; bool shouldEnable; bool* flag; } extensions[] = {
       { "VK_KHR_acceleration_structure", true, &state.extensions.accelerationStructure },
       { "VK_KHR_buffer_device_address", true, &state.extensions.bufferDeviceAddress },
+#ifndef __APPLE__
+      { "VK_KHR_calibrated_timestamps", true, &state.extensions.calibratedTimestamps },
+#endif
       { "VK_KHR_create_renderpass2", true, &state.extensions.renderPass2 },
       { "VK_KHR_deferred_host_operations", true, &state.extensions.deferredHostOperations },
       { "VK_KHR_swapchain", true, &state.extensions.swapchain },
@@ -3153,12 +3158,12 @@ bool gpu_init(gpu_config* config) {
 
     if (config->device) {
       VkPhysicalDeviceProperties* properties = &properties2.properties;
+      config->device->discrete = properties->deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
       config->device->deviceId = properties->deviceID;
       config->device->vendorId = properties->vendorID;
       memcpy(config->device->deviceName, properties->deviceName, MIN(sizeof(config->device->deviceName), sizeof(properties->deviceName)));
       config->device->renderer = "Vulkan";
       config->device->subgroupSize = subgroupProperties.subgroupSize;
-      config->device->discrete = properties->deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
     }
 
     // Limits
@@ -3199,10 +3204,11 @@ bool gpu_init(gpu_config* config) {
       config->limits->pushConstantSize = limits->maxPushConstantsSize;
       config->limits->indirectDrawCount = limits->maxDrawIndirectCount;
       config->limits->instances = multiviewProperties.maxMultiviewInstanceIndex;
-      config->limits->timestampPeriod = limits->timestampPeriod;
       config->limits->anisotropy = limits->maxSamplerAnisotropy;
       config->limits->pointSize = limits->pointSizeRange[1];
     }
+
+    config->device->timestampScale = (double) properties2.properties.limits.timestampPeriod * 1e-9;
 
     // Features
 
@@ -3600,6 +3606,32 @@ bool gpu_init(gpu_config* config) {
   }
 
   VK(vkCreatePipelineCache(state.device, &cacheInfo, NULL, &state.pipelineCache), "vkCreatePipelineCache") goto fail;
+
+  // Calibrated timestamps
+
+  if (state.extensions.calibratedTimestamps) {
+    VkCalibratedTimestampInfoKHR domains[2] = {
+      {
+        .sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR,
+        .timeDomain = VK_TIME_DOMAIN_DEVICE_KHR
+      },
+      {
+        .sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR,
+#ifdef _WIN32
+        .timeDomain = VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR
+#else
+        .timeDomain = VK_TIME_DOMAIN_CLOCK_MONOTONIC_KHR
+#endif
+      }
+    };
+
+    uint64_t timestamps[2];
+    uint64_t deviation;
+
+    if (vkGetCalibratedTimestampsKHR(state.device, COUNTOF(domains), domains, timestamps, &deviation) == VK_SUCCESS) {
+      config->device->timestampOffset = timestamps[1] * 1e-9 - timestamps[0] * config->device->timestampScale;
+    }
+  }
 
   mtx_init(&state.morgue.lock, mtx_plain);
 

--- a/src/core/gpu_web.c
+++ b/src/core/gpu_web.c
@@ -1462,6 +1462,10 @@ bool gpu_init(gpu_config* config) {
   state.device = wgpu_adapter_request_device_sync_simple(state.adapter);
   state.queue = wgpu_device_get_queue(state.device);
 
+  if (config->device) {
+    config->device->timestampScale = 1e-9;
+  }
+
   if (config->features) {
     config->features->textureBC = wgpu_device_supports_feature(state.device, WGPU_FEATURE_TEXTURE_COMPRESSION_BC);
     config->features->textureASTC = wgpu_device_supports_feature(state.device, WGPU_FEATURE_TEXTURE_COMPRESSION_ASTC);
@@ -1623,7 +1627,6 @@ bool gpu_init(gpu_config* config) {
     config->limits->pushConstantSize = supported.maxImmediateSize;
     config->limits->indirectDrawCount = 1;
     config->limits->instances = ~0u;
-    config->limits->timestampPeriod = 1.f;
     config->limits->anisotropy = 16.f;
     config->limits->pointSize = 1.f;
   }

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@ bool step(void* arg) {
     return false;
   } else {
     int status = lua_tointeger(T, -1);
+    lovrSetLogCallback(NULL, NULL);
     luax_close(T);
     os_destroy();
     exit(status);
@@ -66,6 +67,7 @@ int main(int argc, char** argv) {
       } else {
         luax_checkvariant(T, 2, &cookie);
         if (cookie.type == TYPE_OBJECT) memset(&cookie, 0, sizeof(cookie));
+        lovrSetLogCallback(NULL, NULL);
         luax_close(L);
         break;
       }

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -331,11 +331,6 @@ typedef enum {
   READBACK_TIMESTAMP
 } ReadbackType;
 
-typedef struct {
-  Pass* pass;
-  double cpuTime;
-} TimingInfo;
-
 struct Readback {
   atomic_uint ref;
   uint32_t tick;
@@ -350,7 +345,8 @@ struct Readback {
     };
     Image* image;
     struct {
-      TimingInfo* times;
+      Pass** passes;
+      Timing* timing;
       uint32_t count;
     };
   };
@@ -611,6 +607,7 @@ static struct {
   _Atomic(Shader*) defaultShaders[DEFAULT_SHADER_COUNT];
   gpu_vertex_format vertexFormats[VERTEX_FORMAT_COUNT];
   Readback* readbacks;
+  Readback* timingReadback;
   MaterialBlock* materials;
   BufferAllocator bufferAllocators[4];
   _Atomic(PipelineJob*) newPipelines;
@@ -898,9 +895,10 @@ void lovrGraphicsDestroy(void) {
 #endif
   while (state.readbacks) {
     Readback* next = state.readbacks->next;
-    lovrReadbackDestroy(state.readbacks);
+    lovrRelease(state.readbacks, lovrReadbackDestroy);
     state.readbacks = next;
   }
+  lovrRelease(state.timingReadback, lovrReadbackDestroy);
   if (state.timestamps) gpu_tally_destroy(state.timestamps);
   lovrFree(state.timestamps);
   if (state.window) lovrFree(state.window->sync);
@@ -1089,6 +1087,10 @@ bool lovrGraphicsIsTimingEnabled(void) {
 
 void lovrGraphicsSetTimingEnabled(bool enable) {
   state.timingEnabled = enable;
+}
+
+Readback* lovrGraphicsGetTiming(void) {
+  return state.timingReadback;
 }
 
 static bool recordComputePass(Pass* pass, gpu_stream* stream, gpu_timestamp_writes* timestamps) {
@@ -1690,7 +1692,7 @@ static bool recordRenderPass(Pass* pass, gpu_stream* stream, gpu_timestamp_write
     gpu_sync(stream, &barrier, 1);
 
     gpu_binding bindings[] = {
-      { 0, GPU_SLOT_STORAGE_BUFFER, .buffer = { tempBuffer->gpu, 0, count * pass->views * sizeof(uint32_t) } },
+      { 0, GPU_SLOT_STORAGE_BUFFER, .buffer = { tempBuffer->gpu, 0, count * pass->views * sizeof(uint64_t) } },
       { 1, GPU_SLOT_STORAGE_BUFFER, .buffer = { tally->buffer->gpu, tally->buffer->base + tally->bufferOffset, count * sizeof(uint32_t) } }
     };
 
@@ -1711,7 +1713,7 @@ static bool recordRenderPass(Pass* pass, gpu_stream* stream, gpu_timestamp_write
   return true;
 }
 
-static Readback* lovrReadbackCreateTimestamp(TimingInfo* passes, uint32_t count, BufferView view);
+static Readback* lovrReadbackCreateTimestamp(Pass** passes, uint32_t count);
 
 static void syncAttachment(Texture* texture, bool depth, bool resolve, bool load, bool temporary) {
   if (!texture) return;
@@ -1832,15 +1834,10 @@ bool lovrGraphicsSubmit(Pass** passes, uint32_t count) {
     }
   }
 
-  TimingInfo* times = NULL;
-
   if (state.timingEnabled && count > 0) {
-    times = lovrMalloc(count * sizeof(TimingInfo));
-
-    for (uint32_t i = 0; i < count; i++) {
-      times[i].pass = passes[i];
-      lovrRetain(passes[i]);
-    }
+    lovrRelease(state.timingReadback, lovrReadbackDestroy);
+    state.timingReadback = lovrReadbackCreateTimestamp(passes, count);
+    if (!state.timingReadback) goto fail;
 
     uint32_t timestampCount = 2 * count;
 
@@ -1875,7 +1872,7 @@ bool lovrGraphicsSubmit(Pass** passes, uint32_t count) {
     gpu_timestamp_writes renderTimestamps = { 0 };
 
     if (state.timingEnabled) {
-      times[i].cpuTime = os_get_time();
+      state.timingReadback->timing[i].submit = os_get_time();
 
       bool compute = pass->computeCount > 0;
       bool render = pass->canvas.color->texture || pass->canvas.depth.texture;
@@ -1903,7 +1900,7 @@ bool lovrGraphicsSubmit(Pass** passes, uint32_t count) {
     gpu_sync(stream, &renderBarriers[i], 1);
 
     if (state.timingEnabled) {
-      times[i].cpuTime = os_get_time() - times[i].cpuTime;
+      state.timingReadback->timing[i].submit = os_get_time() - state.timingReadback->timing[i].submit;
     }
 
     lovrAssertGoto(fail, gpu_stream_end(stream), "Failed to end GPU command buffer: %s", gpu_get_error());
@@ -1915,12 +1912,8 @@ bool lovrGraphicsSubmit(Pass** passes, uint32_t count) {
 
     // Timestamp Readback
     if (state.timingEnabled) {
-      BufferView view = getBuffer(GPU_BUFFER_DOWNLOAD, 2 * count * sizeof(uint32_t), 4);
-      if (!view.buffer) goto fail;
+      BufferView view = state.timingReadback->view;
       gpu_copy_tally_buffer(stream, state.timestamps, view.buffer, 0, view.offset, 2 * count);
-      Readback* readback = lovrReadbackCreateTimestamp(times, count, view);
-      if (!readback) goto fail;
-      lovrRelease(readback, lovrReadbackDestroy); // It gets freed when it completes
     }
 
     // OpenXR Swapchain Layout Transitions
@@ -6351,11 +6344,16 @@ Readback* lovrReadbackCreateTexture(Texture* texture, uint32_t offset[4], uint32
 
 // Note that this is currently only called from within lovrGraphicsSubmit, so we don't need to lock,
 // because it's already holding the lock
-static Readback* lovrReadbackCreateTimestamp(TimingInfo* times, uint32_t count, BufferView buffer) {
+static Readback* lovrReadbackCreateTimestamp(Pass** passes, uint32_t count) {
+  BufferView view = getBuffer(GPU_BUFFER_DOWNLOAD, count * 2 * sizeof(uint64_t), 8);
+  if (!view.buffer) return NULL;
   Readback* readback = lovrReadbackCreate(READBACK_TIMESTAMP);
-  readback->view = buffer;
-  readback->times = times;
+  readback->passes = lovrMalloc(count * sizeof(Pass*));
+  memcpy(readback->passes, passes, count * sizeof(Pass*));
+  for (uint32_t i = 0; i < count; i++) lovrRetain(passes[i]);
+  readback->timing = lovrMalloc(count * sizeof(Timing));
   readback->count = count;
+  readback->view = view;
   return readback;
 }
 
@@ -6371,9 +6369,10 @@ void lovrReadbackDestroy(void* ref) {
       break;
     case READBACK_TIMESTAMP:
       for (uint32_t i = 0; i < readback->count; i++) {
-        lovrRelease(readback->times[i].pass, lovrPassDestroy);
+        lovrRelease(readback->passes[i], lovrPassDestroy);
       }
-      lovrFree(readback->times);
+      lovrFree(readback->passes);
+      lovrFree(readback->timing);
       break;
     default: break;
   }
@@ -6392,11 +6391,26 @@ bool lovrReadbackPoll(Readback* readback) {
         memcpy(data, readback->view.pointer, size);
         break;
       case READBACK_TIMESTAMP:;
-        uint32_t* timestamps = readback->view.pointer;
+        uint64_t* timestamps = readback->view.pointer;
+        double offset = state.device.timestampOffset ? state.device.timestampOffset - lovrTimerGetEpoch() : 0.;
+
         for (uint32_t i = 0; i < readback->count; i++) {
-          Pass* pass = readback->times[i].pass;
-          pass->stats.submitTime = readback->times[i].cpuTime;
-          pass->stats.gpuTime = (timestamps[2 * i + 1] - timestamps[2 * i + 0]) * state.limits.timestampPeriod / 1e9;
+          uint64_t start = timestamps[2 * i + 0];
+          uint64_t finish = timestamps[2 * i + 1];
+
+          readback->timing[i].duration = (finish - start) * state.device.timestampScale;
+
+          if (offset) {
+            readback->timing[i].start = offset + start * state.device.timestampScale;
+            readback->timing[i].finish = offset + finish * state.device.timestampScale;
+          } else {
+            readback->timing[i].start = 0.;
+            readback->timing[i].finish = 0.;
+          }
+
+          // Deprecated
+          readback->passes[i]->stats.submitTime = readback->timing[i].submit;
+          readback->passes[i]->stats.gpuTime = readback->timing[i].duration;
         }
         break;
       default: break;
@@ -6446,6 +6460,14 @@ Blob* lovrReadbackGetBlob(Readback* readback) {
 
 Image* lovrReadbackGetImage(Readback* readback) {
   return lovrReadbackPoll(readback) ? readback->image : NULL;
+}
+
+bool lovrReadbackGetTimestamps(Readback* readback, Pass*** passes, Timing** timing, uint32_t* count) {
+  lovrCheck(readback->type == READBACK_TIMESTAMP, "Invalid Readback type");
+  *passes = readback->passes;
+  *timing = readback->timing;
+  *count = readback->count;
+  return true;
 }
 
 // Pass
@@ -9118,7 +9140,7 @@ bool lovrPassBeginTally(Pass* pass, uint32_t* index) {
     lovrAssert(gpu_tally_init(pass->tally.gpu, &tallyInfo), "Failed to create tally: %s", gpu_get_error());
 
     BufferInfo bufferInfo = {
-      .size = MAX_TALLIES * state.limits.renderSize[2] * sizeof(uint32_t)
+      .size = MAX_TALLIES * state.limits.renderSize[2] * sizeof(uint64_t)
     };
 
     pass->tally.tempBuffer = lovrBufferCreate(&bufferInfo, NULL);

--- a/src/modules/graphics/graphics.h
+++ b/src/modules/graphics/graphics.h
@@ -123,6 +123,7 @@ void lovrGraphicsSetBackgroundColor(float background[4]);
 
 bool lovrGraphicsIsTimingEnabled(void);
 void lovrGraphicsSetTimingEnabled(bool enable);
+Readback* lovrGraphicsGetTiming(void);
 bool lovrGraphicsSubmit(Pass** passes, uint32_t count);
 bool lovrGraphicsPresent(void);
 bool lovrGraphicsWait(void);
@@ -544,6 +545,13 @@ bool lovrRaytracerBuild(Raytracer* raytracer);
 
 // Readback
 
+typedef struct {
+  double duration;
+  double start;
+  double finish;
+  double submit;
+} Timing;
+
 Readback* lovrReadbackCreateBuffer(Buffer* buffer, uint32_t offset, uint32_t extent);
 Readback* lovrReadbackCreateTexture(Texture* texture, uint32_t offset[4], uint32_t extent[3]);
 void lovrReadbackDestroy(void* ref);
@@ -552,6 +560,7 @@ bool lovrReadbackWait(Readback* readback);
 void* lovrReadbackGetData(Readback* readback, DataField** format, uint32_t* count);
 struct Blob* lovrReadbackGetBlob(Readback* readback);
 struct Image* lovrReadbackGetImage(Readback* readback);
+bool lovrReadbackGetTimestamps(Readback* readback, Pass*** passes, Timing** timings, uint32_t* count);
 
 // Pass
 

--- a/src/modules/timer/timer.c
+++ b/src/modules/timer/timer.c
@@ -30,6 +30,10 @@ void lovrTimerDestroy(void) {
   lovrModuleReset(&ref);
 }
 
+double lovrTimerGetEpoch(void) {
+  return state.epoch;
+}
+
 double lovrTimerGetDelta(void) {
 #ifndef LOVR_DISABLE_HEADSET
   double dt = lovrHeadsetGetDeltaTime();

--- a/src/modules/timer/timer.h
+++ b/src/modules/timer/timer.h
@@ -6,6 +6,7 @@
 
 bool lovrTimerInit(void);
 void lovrTimerDestroy(void);
+double lovrTimerGetEpoch(void);
 double lovrTimerGetDelta(void);
 double lovrTimerGetTime(void);
 double lovrTimerGetDisplayTime(void);

--- a/src/util.c
+++ b/src/util.c
@@ -131,7 +131,11 @@ void lovrSetLogCallback(fn_log* callback, void* userdata) {
 void lovrLog(int level, const char* tag, const char* format, ...) {
   va_list args;
   va_start(args, format);
-  lovrLogCallback(lovrLogUserdata, level, tag, format, args);
+  if (lovrLogCallback) {
+    lovrLogCallback(lovrLogUserdata, level, tag, format, args);
+  } else {
+    vprintf(format, args);
+  }
   va_end(args);
 }
 


### PR DESCRIPTION
- Add a new async `lovr.graphics.getTiming` function that returns a table of timestamps for the last GPU submission, keyed by pass.
- The timestamps are formatted like this:

```lua
{
  [pass1] = {
    duration = t,
    start = t,
    finish = t,
    submit = t
  },
  [pass2] = {
    duration = t,
    start = t,
    finish = t,
    submit = t
  }
}
```

- The start/finish times are in the same units/epoch as `lovr.timer.getTime`, so you can correlate it with other CPU times.
- Not every GPU can correlate timestamps, so start/finish may be nil.  But nearly every desktop GPU supports it.
- Deprecate `gpuTime`/`submitTime` in `Pass:getStats`.
- Main goals are:
  - Make it easier to get stats for multiple passes
  - Use an async function to make it easier to correlate stats to a particular submit instead of updating the pass stats asynchronously
  - Use the start/finish times to see when a Pass actually ran (measure CPU-GPU latency, see if passes are overlapping on GPU)
  - Use 64 bit queries internally, because that's all WebGPU supports

Example:

```lua
lovr.graphics.setTimingEnabled(true)

function lovr.draw(pass)
  --

  lovr.graphics.submit(pass)

  lovr.task.start(function()
    for pass, t in pairs(lovr.graphics.getTiming()) do
      print(pass, t.duration, t.start, t.finish, t.submit)
    end
  end)

  return true
end
```