### PR TITLE
Whitespace removal in Font:getLines

### DIFF
--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4655,7 +4655,7 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
       continue;
     } else if (codepoint == '\n') {
       size_t length = string - lineStart;
-      while (string[length] == ' ' || string[length] == '\t') length--;
+      while (length > 0 && (lineStart[length - 1] == ' ' || lineStart[length - 1] == '\t')) length--;
       callback(context, lineStart, length);
       nextWordStartX = 0.f;
       x = 0.f;
@@ -4692,7 +4692,9 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
   }
 
   if (end - lineStart > 0) {
-    callback(context, lineStart, end - lineStart);
+    size_t length = end - lineStart;
+    while (length > 0 && (lineStart[length - 1] == ' ' || lineStart[length - 1] == '\t')) length--;
+    callback(context, lineStart, length);
   }
 
   stackPop(&thread.stack, stack);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4686,7 +4686,7 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
     // Wrap
     if (wrap >= 0.f && wordStart != lineStart && x + advance > wrap) {
       size_t length = wordStart - lineStart;
-      while (string[length] == ' ' || string[length] == '\t') length--;
+      while (length > 0 && (lineStart[length - 1] == ' ' || lineStart[length - 1] == '\t')) length--;
       callback(context, lineStart, length);
       lineStart = wordStart;
       x -= nextWordStartX;

--- a/test/lovr/graphics.lua
+++ b/test/lovr/graphics.lua
@@ -470,6 +470,9 @@ group('graphics', function()
       local font = lovr.graphics.getDefaultFont()
       local lines = font:getLines({ 0xff0000, 'hello ', 0x0000ff, 'world' }, 0)
       expect(lines).to.equal({ 'hello ', 'world' })
+      
+      local linesWhitespace = font:getLines('123   \n      ', 1e32)
+      expect(linesWhitespace).to.equal({ '123', '' })      
     end)
   end)
 

--- a/test/lovr/graphics.lua
+++ b/test/lovr/graphics.lua
@@ -479,7 +479,7 @@ group('graphics', function()
     test(':getLines', function()
       local font = lovr.graphics.getDefaultFont()
       local lines = font:getLines({ 0xff0000, 'hello ', 0x0000ff, 'world' }, 0)
-      expect(lines).to.equal({ 'hello ', 'world' })
+      expect(lines).to.equal({ 'hello', 'world' })
       
       local linesWhitespace = font:getLines('123   \n      ', 1e32)
       expect(linesWhitespace).to.equal({ '123', '' })      


### PR DESCRIPTION
This fixes #997 and adds a test.  It might be worth considering whether removing the whitespace at the end of the line is needed, in which case deleting the relevant lines is an alternative.

[EDIT: 6th Aug - I think I understand this better now, the `lovrFontGetVertices` function ignores spaces as they have no vertices and performs alignment ignoring the spaces.  So to match this behaviour `lovrFontGetLines` should remove all whitespace from the end of a line.  I initially missed the bugged while loop that did this for breaking after wrapping at a space, so added an extra commit fixing it and changed the test that was looking for a space when breaking "hello world".]