### PR TITLE
CJK character wrapping in lovrFontGetLines and lovrFontGetVertices

### DIFF
--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4625,6 +4625,50 @@ float lovrFontGetWidth(Font* font, ColoredString* strings, uint32_t count) {
   return MAX(maxWidth, x) / font->pixelDensity;
 }
 
+static int isCodepointCJK(uint32_t cp) {
+  // There are many classes of characters, many classes are consecutive, which are merged (godbolt suggested that
+  // the compiler might not do this).  Also merged small gaps containing characters unlikely to
+  // form Latin style words.
+  return cp >= 0x01100 && (
+      (cp <= 0x011FF) ||
+      (cp >= 0x02E80 && cp <= 0x0A4CF) ||  // Gap between these are Lisu characters with specific wrapping rules
+      (cp >= 0x0AC00 && cp <= 0x0D7AF) ||  // Gap contains a block of user definable codepoints
+      (cp >= 0x0F900 && cp <= 0x0FAFF) ||  // Gap contains Latin/Arabic ligatures, followed by (fullwidth) punctuation
+      (cp >= 0x0FF00 && cp <= 0x0FFEF) ||  // Gap is big
+      (cp >= 0x1F200 && cp <= 0x1F2FF) ||  // Gap contains emoji and ?
+      (cp >= 0x20000 && cp <= 0x2FFFF));
+}
+
+// Characters that must NOT begin a line (closing brackets, punctuation)
+static int isNoBreakBefore(uint32_t cp) {
+  // This is likely not exhaustive
+  switch (cp) {
+    case 0x3001: case 0x3002: // 、 。
+    case 0xFF0C: case 0xFF0E: // ，．
+    case 0xFF01: case 0xFF1F: // ！？
+    case 0xFF1A: case 0xFF1B: // ：；
+    case 0x2019: case 0x201D: // ' "
+    case 0x3009: case 0x300B: case 0x300D: case 0x300F: // 〉》」』
+    case 0x3011: case 0xFF09: case 0xFF3D: case 0xFF5D:  // 】）］｝
+    case 0x30FB: case 0x30FC: case 0x3005: // ・ ー 々
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+// Characters that must NOT end a line (opening brackets)
+static int isNoBreakAfter(uint32_t cp) {
+  switch (cp) {
+    case 0x2018: case 0x201C: // ' "
+    case 0x3008: case 0x300A: case 0x300C: case 0x300E: // 〈《「『
+    case 0x3010: case 0xFF08: case 0xFF3B: case 0xFF5B:  // 【（［｛
+      return 1;
+    default:
+      return 0;
+  }
+}
+
 void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float wrap, void (*callback)(void* context, const char* string, size_t length), void* context) {
   if (count == 0) return;
 
@@ -4679,10 +4723,13 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
     }
 
     // CJK symbols break words
-    int isCJK = (codepoint >= 0x2E00 && codepoint < 0xE000) || (codepoint >= 0xF900 && codepoint < 0x10000) || (codepoint >= 0x20000 && codepoint < 0x2EBF0);
+    int isCJK = isCodepointCJK(codepoint);
     if (isCJK || previousIsCJK) {
-      nextWordStartX = x;
-      wordStart = string;
+      int breakSuppressed = isNoBreakBefore(codepoint) || isNoBreakAfter(previous);
+      if (!breakSuppressed) {
+        nextWordStartX = x;
+        wordStart = string;
+      }
     }
     previousIsCJK = isCJK;
 
@@ -4790,11 +4837,14 @@ bool lovrFontGetVertices(Font* font, ColoredString* strings, uint32_t count, flo
       }
 
       // CJK symbols break words
-      int isCJK = (codepoint >= 0x2E00 && codepoint < 0xE000) || (codepoint >= 0xF900 && codepoint < 0x10000) || (codepoint >= 0x20000 && codepoint < 0x2EBF0);
+      int isCJK = isCodepointCJK(codepoint);
       if (isCJK || previousIsCJK) {
-        prevWordEndX = x;
-        wordStartX = x;
-        wordStart = str;
+        int breakSuppressed = isNoBreakBefore(codepoint) || isNoBreakAfter(previous);
+        if (!breakSuppressed) {
+          prevWordEndX = x;
+          wordStartX = x;
+          wordStart = vertexCount;
+        }
       }
       previousIsCJK = isCJK;
 

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4649,6 +4649,7 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
   size_t bytes;
   uint32_t codepoint;
   uint32_t previous = '\0';
+  int previousIsCJK = 0;
   const char* lineStart = string;
   const char* wordStart = string;
   const char* end = string + totalLength;
@@ -4676,6 +4677,14 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
       string += bytes;
       continue;
     }
+
+    // CJK symbols break words
+    int isCJK = (codepoint >= 0x2E00 && codepoint < 0xE000) || (codepoint >= 0xF900 && codepoint < 0x10000) || (codepoint >= 0x20000 && codepoint < 0x2EBF0);
+    if (isCJK || previousIsCJK) {
+      nextWordStartX = x;
+      wordStart = string;
+    }
+    previousIsCJK = isCJK;
 
     float advance = lovrRasterizerGetAdvance(font->info.rasterizer, codepoint);
 
@@ -4719,6 +4728,7 @@ bool lovrFontGetVertices(Font* font, ColoredString* strings, uint32_t count, flo
   uint32_t lineStart = 0;
   uint32_t wordStart = 0;
   uint32_t previous = '\0';
+  int previousIsCJK = 0;
   uint32_t codepoint;
   *glyphCount = 0;
   *lineCount = 1;
@@ -4778,6 +4788,15 @@ bool lovrFontGetVertices(Font* font, ColoredString* strings, uint32_t count, flo
       if (resized) {
         return lovrFontGetVertices(font, strings, count, wrap, halign, valign, vertices, glyphCount, lineCount, material, flip);
       }
+
+      // CJK symbols break words
+      int isCJK = (codepoint >= 0x2E00 && codepoint < 0xE000) || (codepoint >= 0xF900 && codepoint < 0x10000) || (codepoint >= 0x20000 && codepoint < 0x2EBF0);
+      if (isCJK || previousIsCJK) {
+        prevWordEndX = x;
+        wordStartX = x;
+        wordStart = str;
+      }
+      previousIsCJK = isCJK;
 
       // Keming
       if (previous) x += lovrRasterizerGetKerning(font->info.rasterizer, previous, codepoint);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4655,7 +4655,7 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
       continue;
     } else if (codepoint == '\n') {
       size_t length = string - lineStart;
-      while (string[length] == ' ' || string[length] == '\t') length--;
+      while (length > 0 && (lineStart[length - 1] == ' ' || lineStart[length - 1] == '\t')) length--;
       callback(context, lineStart, length);
       nextWordStartX = 0.f;
       x = 0.f;
@@ -4692,7 +4692,9 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
   }
 
   if (end - lineStart > 0) {
-    callback(context, lineStart, end - lineStart);
+    size_t length = end - lineStart;
+    while (length > 0 && (lineStart[length - 1] == ' ' || lineStart[length - 1] == '\t')) length--;
+    callback(context, lineStart, length);
   }
 
   stackPop(&thread.stack, stack);

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4780,6 +4780,7 @@ bool lovrFontGetVertices(Font* font, ColoredString* strings, uint32_t count, flo
   uint32_t wordStart = 0;
   uint32_t previous = '\0';
   int previousIsCJK = 0;
+  int suppressKerning = true;
   uint32_t codepoint;
   *glyphCount = 0;
   *lineCount = 1;
@@ -4805,11 +4806,11 @@ bool lovrFontGetVertices(Font* font, ColoredString* strings, uint32_t count, flo
 
     while ((bytes = utf8_decode(str, end, &codepoint)) > 0) {
       if (codepoint == ' ' || codepoint == '\t') {
-        if (previous) prevWordEndX = x;
+        if (!suppressKerning) prevWordEndX = x;
         wordStart = vertexCount;
         x += codepoint == '\t' ? space * 4.f : space;
         wordStartX = x;
-        previous = '\0';
+        suppressKerning = true;
         str += bytes;
         continue;
       } else if (codepoint == '\n') {
@@ -4821,7 +4822,7 @@ bool lovrFontGetVertices(Font* font, ColoredString* strings, uint32_t count, flo
         wordStartX = 0.f;
         prevWordEndX = 0.f;
         (*lineCount)++;
-        previous = '\0';
+        suppressKerning = true;
         str += bytes;
         continue;
       } else if (codepoint == '\r') {
@@ -4853,8 +4854,9 @@ bool lovrFontGetVertices(Font* font, ColoredString* strings, uint32_t count, flo
       previousIsCJK = isCJK;
 
       // Keming
-      if (previous) x += lovrRasterizerGetKerning(font->info.rasterizer, previous, codepoint);
+      if (!suppressKerning) x += lovrRasterizerGetKerning(font->info.rasterizer, previous, codepoint);
       previous = codepoint;
+      suppressKerning = false;
 
       // Wrap
       if (wrap > 0.f && x + glyph->advance > wrap && wordStart != lineStart) {
@@ -4870,6 +4872,7 @@ bool lovrFontGetVertices(Font* font, ColoredString* strings, uint32_t count, flo
         aline(vertices, lineStart, wordStart, prevWordEndX, halign);
         lineStart = wordStart;
         wordStartX = 0.f;
+        suppressKerning = true;
         (*lineCount)++;
         x -= dx;
         y -= dy;

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4693,6 +4693,7 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
   size_t bytes;
   uint32_t codepoint;
   uint32_t previous = '\0';
+  int suppressKerning = true;
   int previousIsCJK = 0;
   const char* lineStart = string;
   const char* wordStart = string;
@@ -4702,7 +4703,7 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
     if (codepoint == ' ' || codepoint == '\t') {
       x += codepoint == '\t' ? space * 4.f : space;
       nextWordStartX = x;
-      previous = '\0';
+      suppressKerning = true;
       string += bytes;
       wordStart = string;
       continue;
@@ -4712,7 +4713,7 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
       callback(context, lineStart, length);
       nextWordStartX = 0.f;
       x = 0.f;
-      previous = '\0';
+      suppressKerning = true;
       string += bytes;
       lineStart = string;
       wordStart = string;
@@ -4736,18 +4737,19 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
     float advance = lovrRasterizerGetAdvance(font->info.rasterizer, codepoint);
 
     // Keming
-    if (previous) x += lovrRasterizerGetKerning(font->info.rasterizer, previous, codepoint);
+    if (!suppressKerning) x += lovrRasterizerGetKerning(font->info.rasterizer, previous, codepoint);
     previous = codepoint;
+    suppressKerning = false;
 
     // Wrap
-    if (wrap >= 0.f && wordStart != lineStart && x + advance > wrap) {
+    if (wrap > 0.f && wordStart != lineStart && x + advance > wrap) {
       size_t length = wordStart - lineStart;
       while (length > 0 && (lineStart[length - 1] == ' ' || lineStart[length - 1] == '\t')) length--;
       callback(context, lineStart, length);
       lineStart = wordStart;
       x -= nextWordStartX;
       nextWordStartX = 0.f;
-      previous = '\0';
+      suppressKerning = true;
     }
 
     // Advance

--- a/src/modules/graphics/graphics.c
+++ b/src/modules/graphics/graphics.c
@@ -4686,7 +4686,7 @@ void lovrFontGetLines(Font* font, ColoredString* strings, uint32_t count, float 
     // Wrap
     if (wrap >= 0.f && wordStart != lineStart && x + advance > wrap) {
       size_t length = wordStart - lineStart;
-      while (string[length] == ' ' || string[length] == '\t') length--;
+      while (length > 0 && (lineStart[length - 1] == ' ' || lineStart[length - 1] == '\t')) length--;
       callback(context, lineStart, length);
       lineStart = wordStart;
       x -= nextWordStartX;

--- a/test/lovr/graphics.lua
+++ b/test/lovr/graphics.lua
@@ -480,6 +480,15 @@ group('graphics', function()
       local font = lovr.graphics.getDefaultFont()
       local lines = font:getLines({ 0xff0000, 'hello ', 0x0000ff, 'world' }, 0)
       expect(lines).to.equal({ 'hello ', 'world' })
+      
+      local wrap = 1.25 -- small enough to require a character per line
+      local cjkText = "【重要】これは「日本語固有の括弧」と（Latin characters）を組み合わせたテスト文章です。"
+      local cjkLines = font:getLines(cjkText, wrap)
+      local cjkLineLengths = {}
+      for idx, line in ipairs(cjkLines) do
+        cjkLineLengths[idx] = #line
+      end
+      expect(cjkLineLengths).to.equal({6, 6, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 6, 3, 3, 6, 13, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 6})
     end)
   end)
 

--- a/test/lovr/graphics.lua
+++ b/test/lovr/graphics.lua
@@ -478,7 +478,7 @@ group('graphics', function()
 
     test(':getLines', function()
       local font = lovr.graphics.getDefaultFont()
-      local lines = font:getLines({ 0xff0000, 'hello ', 0x0000ff, 'world' }, 0)
+      local lines = font:getLines({ 0xff0000, 'hello ', 0x0000ff, 'world' }, 0.1)
       expect(lines).to.equal({ 'hello', 'world' })
       
       local wrap = 1.25 -- small enough to require a character per line
@@ -488,7 +488,7 @@ group('graphics', function()
       for idx, line in ipairs(cjkLines) do
         cjkLineLengths[idx] = #line
       end
-      expect(cjkLineLengths).to.equal({6, 6, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 6, 3, 3, 6, 13, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 6})     
+      expect(cjkLineLengths).to.equal({6, 6, 3, 3, 3, 6, 3, 3, 3, 3, 3, 3, 6, 3, 8, 13, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 6})     
       
       local linesWhitespace = font:getLines('123   \n      ', 1e32)
       expect(linesWhitespace).to.equal({ '123', '' })

--- a/test/lovr/graphics.lua
+++ b/test/lovr/graphics.lua
@@ -470,6 +470,9 @@ group('graphics', function()
       local font = lovr.graphics.getDefaultFont()
       local lines = font:getLines({ 0xff0000, 'hello ', 0x0000ff, 'world' }, 0)
       expect(lines).to.equal({ 'hello ', 'world' })
+      
+      local linesWhitespace = font:getLines('123   \n      ', 1e32)
+      expect(linesWhitespace).to.equal({ '123', '' })      
     end)
   end)
 

--- a/test/lovr/graphics.lua
+++ b/test/lovr/graphics.lua
@@ -479,7 +479,7 @@ group('graphics', function()
     test(':getLines', function()
       local font = lovr.graphics.getDefaultFont()
       local lines = font:getLines({ 0xff0000, 'hello ', 0x0000ff, 'world' }, 0)
-      expect(lines).to.equal({ 'hello ', 'world' })
+      expect(lines).to.equal({ 'hello', 'world' })
       
       local linesWhitespace = font:getLines('123   \n      ', 1e32)
       expect(linesWhitespace).to.equal({ '123', '' })      


### PR DESCRIPTION
Resolves #989

## Summary
Adds CJK-aware line wrapping (break at character boundaries for CJK text, suppressed at certain punctuation) without requiring a full shaping library.

## Changes
- new logic adding word breaks around CJK characters
- this logic needs to know the previous codepoint, in the getLines code the variable `previous` was being set to 0 to avoid kerning across linebreaks.  This was interfering with the CJK logic so a new variable `suppressKerning` now does the job instead.
- `suppressKerning` logic also ported to `lovrFontGetVertices`, because it was not easy to see that they were logically the same.
- this also includes a fix for inconsistency between getLines and getVertices where it comes to the wrap parameter, one used `wrap > 0` and the other `wrap >= 0`; I changed both to `wrap > 0`.

